### PR TITLE
DefinitionSet support and two types of builds

### DIFF
--- a/build/rollup/build.js
+++ b/build/rollup/build.js
@@ -20,7 +20,7 @@ const defaultPlugins = [
   })
 ]
 
-// Regular bundle
+// Standalone bundle
 rollup.rollup({
   entry: 'index.js',
   moduleName: 'InflectionTables',
@@ -28,8 +28,25 @@ rollup.rollup({
 }).then(bundle => {
   bundle.write({
     format: 'es',
-    dest: 'dist/inflection-tables.js',
+    dest: 'dist/inflection-tables.standalone.js',
     sourceMap: true
+  })
+}).catch(reason => {
+  'use strict'
+  console.error(reason)
+})
+
+// Module bundle
+rollup.rollup({
+  entry: 'index.js',
+  external: ['alpheios-data-models'],
+  moduleName: 'InflectionTables',
+  plugins: defaultPlugins
+}).then(bundle => {
+  bundle.write({
+    format: 'es',
+    dest: 'dist/inflection-tables.module-external.js',
+    sourceMap: false
   })
 }).catch(reason => {
   'use strict'

--- a/dist/inflection-tables.module-external.js
+++ b/dist/inflection-tables.module-external.js
@@ -1,1415 +1,4 @@
-/* eslint-disable no-unused-vars */
-const LANG_UNIT_WORD = Symbol('word');
-const LANG_UNIT_CHAR = Symbol('char');
-const LANG_DIR_LTR = Symbol('ltr');
-const LANG_DIR_RTL = Symbol('rtl');
-const LANG_LATIN = Symbol('latin');
-const LANG_GREEK = Symbol('greek');
-const LANG_ARABIC = Symbol('arabic');
-const LANG_PERSIAN = Symbol('persian');
-const STR_LANG_CODE_LAT = 'lat';
-const STR_LANG_CODE_LA = 'la';
-const STR_LANG_CODE_GRC = 'grc';
-const STR_LANG_CODE_ARA = 'ara';
-const STR_LANG_CODE_AR = 'ar';
-const STR_LANG_CODE_FAR = 'far';
-const STR_LANG_CODE_PER = 'per';
-// parts of speech
-const POFS_ADJECTIVE = 'adjective';
-const POFS_ADVERB = 'adverb';
-const POFS_ADVERBIAL = 'adverbial';
-const POFS_ARTICLE = 'article';
-const POFS_CONJUNCTION = 'conjunction';
-const POFS_EXCLAMATION = 'exclamation';
-const POFS_INTERJECTION = 'interjection';
-const POFS_NOUN = 'noun';
-const POFS_NUMERAL = 'numeral';
-const POFS_PARTICLE = 'particle';
-const POFS_PREFIX = 'prefix';
-const POFS_PREPOSITION = 'preposition';
-const POFS_PRONOUN = 'pronoun';
-const POFS_SUFFIX = 'suffix';
-const POFS_SUPINE = 'supine';
-const POFS_VERB = 'verb';
-const POFS_VERB_PARTICIPLE = 'verb participle';
-// gender
-const GEND_MASCULINE = 'masculine';
-const GEND_FEMININE = 'feminine';
-const GEND_NEUTER = 'neuter';
-const GEND_COMMON = 'common';
-const GEND_ANIMATE = 'animate';
-const GEND_INANIMATE = 'inanimate';
-// Polish gender types
-const GEND_PERSONAL_MASCULINE = 'personal masculine';
-const GEND_ANIMATE_MASCULINE = 'animate masculine';
-const GEND_INANIMATE_MASCULINE = 'inanimate masculine';
-// comparative
-const COMP_POSITIVE = 'positive';
-const COMP_COMPARITIVE = 'comparative';
-const COMP_SUPERLATIVE = 'superlative';
-// case
-const CASE_ABESSIVE = 'abessive';
-const CASE_ABLATIVE = 'ablative';
-const CASE_ABSOLUTIVE = 'absolutive';
-const CASE_ACCUSATIVE = 'accusative';
-const CASE_ADDIRECTIVE = 'addirective';
-const CASE_ADELATIVE = 'adelative';
-const CASE_ADESSIVE = 'adessive';
-const CASE_ADVERBIAL = 'adverbial';
-const CASE_ALLATIVE = 'allative';
-const CASE_ANTESSIVE = 'antessive';
-const CASE_APUDESSIVE = 'apudessive';
-const CASE_AVERSIVE = 'aversive';
-const CASE_BENEFACTIVE = 'benefactive';
-const CASE_CARITIVE = 'caritive';
-const CASE_CAUSAL = 'causal';
-const CASE_CAUSAL_FINAL = 'causal-final';
-const CASE_COMITATIVE = 'comitative';
-const CASE_DATIVE = 'dative';
-const CASE_DELATIVE = 'delative';
-const CASE_DIRECT = 'direct';
-const CASE_DISTRIBUTIVE = 'distributive';
-const CASE_DISTRIBUTIVE_TEMPORAL = 'distributive-temporal';
-const CASE_ELATIVE = 'elative';
-const CASE_ERGATIVE = 'ergative';
-const CASE_ESSIVE = 'essive';
-const CASE_ESSIVE_FORMAL = 'essive-formal';
-const CASE_ESSIVE_MODAL = 'essive-modal';
-const CASE_EQUATIVE = 'equative';
-const CASE_EVITATIVE = 'evitative';
-const CASE_EXESSIVE = 'exessive';
-const CASE_FINAL = 'final';
-const CASE_FORMAL = 'formal';
-const CASE_GENITIVE = 'genitive';
-const CASE_ILLATIVE = 'illative';
-const CASE_INELATIVE = 'inelative';
-const CASE_INESSIVE = 'inessive';
-const CASE_INSTRUCTIVE = 'instructive';
-const CASE_INSTRUMENTAL = 'instrumental';
-const CASE_INSTRUMENTAL_COMITATIVE = 'instrumental-comitative';
-const CASE_INTRANSITIVE = 'intransitive';
-const CASE_LATIVE = 'lative';
-const CASE_LOCATIVE = 'locative';
-const CASE_MODAL = 'modal';
-const CASE_MULTIPLICATIVE = 'multiplicative';
-const CASE_NOMINATIVE = 'nominative';
-const CASE_PARTITIVE = 'partitive';
-const CASE_PEGATIVE = 'pegative';
-const CASE_PERLATIVE = 'perlative';
-const CASE_POSSESSIVE = 'possessive';
-const CASE_POSTELATIVE = 'postelative';
-const CASE_POSTDIRECTIVE = 'postdirective';
-const CASE_POSTESSIVE = 'postessive';
-const CASE_POSTPOSITIONAL = 'postpositional';
-const CASE_PREPOSITIONAL = 'prepositional';
-const CASE_PRIVATIVE = 'privative';
-const CASE_PROLATIVE = 'prolative';
-const CASE_PROSECUTIVE = 'prosecutive';
-const CASE_PROXIMATIVE = 'proximative';
-const CASE_SEPARATIVE = 'separative';
-const CASE_SOCIATIVE = 'sociative';
-const CASE_SUBDIRECTIVE = 'subdirective';
-const CASE_SUBESSIVE = 'subessive';
-const CASE_SUBELATIVE = 'subelative';
-const CASE_SUBLATIVE = 'sublative';
-const CASE_SUPERDIRECTIVE = 'superdirective';
-const CASE_SUPERESSIVE = 'superessive';
-const CASE_SUPERLATIVE = 'superlative';
-const CASE_SUPPRESSIVE = 'suppressive';
-const CASE_TEMPORAL = 'temporal';
-const CASE_TERMINATIVE = 'terminative';
-const CASE_TRANSLATIVE = 'translative';
-const CASE_VIALIS = 'vialis';
-const CASE_VOCATIVE = 'vocative';
-const MOOD_ADMIRATIVE = 'admirative';
-const MOOD_COHORTATIVE = 'cohortative';
-const MOOD_CONDITIONAL = 'conditional';
-const MOOD_DECLARATIVE = 'declarative';
-const MOOD_DUBITATIVE = 'dubitative';
-const MOOD_ENERGETIC = 'energetic';
-const MOOD_EVENTIVE = 'eventive';
-const MOOD_GENERIC = 'generic';
-const MOOD_GERUNDIVE = 'gerundive';
-const MOOD_HYPOTHETICAL = 'hypothetical';
-const MOOD_IMPERATIVE = 'imperative';
-const MOOD_INDICATIVE = 'indicative';
-const MOOD_INFERENTIAL = 'inferential';
-const MOOD_INFINITIVE = 'infinitive';
-const MOOD_INTERROGATIVE = 'interrogative';
-const MOOD_JUSSIVE = 'jussive';
-const MOOD_NEGATIVE = 'negative';
-const MOOD_OPTATIVE = 'optative';
-const MOOD_PARTICIPLE = 'participle';
-const MOOD_PRESUMPTIVE = 'presumptive';
-const MOOD_RENARRATIVE = 'renarrative';
-const MOOD_SUBJUNCTIVE = 'subjunctive';
-const MOOD_SUPINE = 'supine';
-const NUM_SINGULAR = 'singular';
-const NUM_PLURAL = 'plural';
-const NUM_DUAL = 'dual';
-const NUM_TRIAL = 'trial';
-const NUM_PAUCAL = 'paucal';
-const NUM_SINGULATIVE = 'singulative';
-const NUM_COLLECTIVE = 'collective';
-const NUM_DISTRIBUTIVE_PLURAL = 'distributive plural';
-const NRL_CARDINAL = 'cardinal';
-const NRL_ORDINAL = 'ordinal';
-const NRL_DISTRIBUTIVE = 'distributive';
-const NURL_NUMERAL_ADVERB = 'numeral adverb';
-const ORD_1ST = '1st';
-const ORD_2ND = '2nd';
-const ORD_3RD = '3rd';
-const ORD_4TH = '4th';
-const ORD_5TH = '5th';
-const ORD_6TH = '6th';
-const ORD_7TH = '7th';
-const ORD_8TH = '8th';
-const ORD_9TH = '9th';
-const TENSE_AORIST = 'aorist';
-const TENSE_FUTURE = 'future';
-const TENSE_FUTURE_PERFECT = 'future perfect';
-const TENSE_IMPERFECT = 'imperfect';
-const TENSE_PAST_ABSOLUTE = 'past absolute';
-const TENSE_PERFECT = 'perfect';
-const TENSE_PLUPERFECT = 'pluperfect';
-const TENSE_PRESENT = 'present';
-const VKIND_TO_BE = 'to be';
-const VKIND_COMPOUNDS_OF_TO_BE = 'compounds of to be';
-const VKIND_TAKING_ABLATIVE = 'taking ablative';
-const VKIND_TAKING_DATIVE = 'taking dative';
-const VKIND_TAKING_GENITIVE = 'taking genitive';
-const VKIND_TRANSITIVE = 'transitive';
-const VKIND_INTRANSITIVE = 'intransitive';
-const VKIND_IMPERSONAL = 'impersonal';
-const VKIND_DEPONENT = 'deponent';
-const VKIND_SEMIDEPONENT = 'semideponent';
-const VKIND_PERFECT_DEFINITE = 'perfect definite';
-const VOICE_ACTIVE = 'active';
-const VOICE_PASSIVE = 'passive';
-const VOICE_MEDIOPASSIVE = 'mediopassive';
-const VOICE_IMPERSONAL_PASSIVE = 'impersonal passive';
-const VOICE_MIDDLE = 'middle';
-const VOICE_ANTIPASSIVE = 'antipassive';
-const VOICE_REFLEXIVE = 'reflexive';
-const VOICE_RECIPROCAL = 'reciprocal';
-const VOICE_CAUSATIVE = 'causative';
-const VOICE_ADJUTATIVE = 'adjutative';
-const VOICE_APPLICATIVE = 'applicative';
-const VOICE_CIRCUMSTANTIAL = 'circumstantial';
-const VOICE_DEPONENT = 'deponent';
-const TYPE_IRREGULAR = 'irregular';
-const TYPE_REGULAR = 'regular';
-/* eslit-enable no-unused-vars */
-
-
-var constants = Object.freeze({
-	LANG_UNIT_WORD: LANG_UNIT_WORD,
-	LANG_UNIT_CHAR: LANG_UNIT_CHAR,
-	LANG_DIR_LTR: LANG_DIR_LTR,
-	LANG_DIR_RTL: LANG_DIR_RTL,
-	LANG_LATIN: LANG_LATIN,
-	LANG_GREEK: LANG_GREEK,
-	LANG_ARABIC: LANG_ARABIC,
-	LANG_PERSIAN: LANG_PERSIAN,
-	STR_LANG_CODE_LAT: STR_LANG_CODE_LAT,
-	STR_LANG_CODE_LA: STR_LANG_CODE_LA,
-	STR_LANG_CODE_GRC: STR_LANG_CODE_GRC,
-	STR_LANG_CODE_ARA: STR_LANG_CODE_ARA,
-	STR_LANG_CODE_AR: STR_LANG_CODE_AR,
-	STR_LANG_CODE_FAR: STR_LANG_CODE_FAR,
-	STR_LANG_CODE_PER: STR_LANG_CODE_PER,
-	POFS_ADJECTIVE: POFS_ADJECTIVE,
-	POFS_ADVERB: POFS_ADVERB,
-	POFS_ADVERBIAL: POFS_ADVERBIAL,
-	POFS_ARTICLE: POFS_ARTICLE,
-	POFS_CONJUNCTION: POFS_CONJUNCTION,
-	POFS_EXCLAMATION: POFS_EXCLAMATION,
-	POFS_INTERJECTION: POFS_INTERJECTION,
-	POFS_NOUN: POFS_NOUN,
-	POFS_NUMERAL: POFS_NUMERAL,
-	POFS_PARTICLE: POFS_PARTICLE,
-	POFS_PREFIX: POFS_PREFIX,
-	POFS_PREPOSITION: POFS_PREPOSITION,
-	POFS_PRONOUN: POFS_PRONOUN,
-	POFS_SUFFIX: POFS_SUFFIX,
-	POFS_SUPINE: POFS_SUPINE,
-	POFS_VERB: POFS_VERB,
-	POFS_VERB_PARTICIPLE: POFS_VERB_PARTICIPLE,
-	GEND_MASCULINE: GEND_MASCULINE,
-	GEND_FEMININE: GEND_FEMININE,
-	GEND_NEUTER: GEND_NEUTER,
-	GEND_COMMON: GEND_COMMON,
-	GEND_ANIMATE: GEND_ANIMATE,
-	GEND_INANIMATE: GEND_INANIMATE,
-	GEND_PERSONAL_MASCULINE: GEND_PERSONAL_MASCULINE,
-	GEND_ANIMATE_MASCULINE: GEND_ANIMATE_MASCULINE,
-	GEND_INANIMATE_MASCULINE: GEND_INANIMATE_MASCULINE,
-	COMP_POSITIVE: COMP_POSITIVE,
-	COMP_COMPARITIVE: COMP_COMPARITIVE,
-	COMP_SUPERLATIVE: COMP_SUPERLATIVE,
-	CASE_ABESSIVE: CASE_ABESSIVE,
-	CASE_ABLATIVE: CASE_ABLATIVE,
-	CASE_ABSOLUTIVE: CASE_ABSOLUTIVE,
-	CASE_ACCUSATIVE: CASE_ACCUSATIVE,
-	CASE_ADDIRECTIVE: CASE_ADDIRECTIVE,
-	CASE_ADELATIVE: CASE_ADELATIVE,
-	CASE_ADESSIVE: CASE_ADESSIVE,
-	CASE_ADVERBIAL: CASE_ADVERBIAL,
-	CASE_ALLATIVE: CASE_ALLATIVE,
-	CASE_ANTESSIVE: CASE_ANTESSIVE,
-	CASE_APUDESSIVE: CASE_APUDESSIVE,
-	CASE_AVERSIVE: CASE_AVERSIVE,
-	CASE_BENEFACTIVE: CASE_BENEFACTIVE,
-	CASE_CARITIVE: CASE_CARITIVE,
-	CASE_CAUSAL: CASE_CAUSAL,
-	CASE_CAUSAL_FINAL: CASE_CAUSAL_FINAL,
-	CASE_COMITATIVE: CASE_COMITATIVE,
-	CASE_DATIVE: CASE_DATIVE,
-	CASE_DELATIVE: CASE_DELATIVE,
-	CASE_DIRECT: CASE_DIRECT,
-	CASE_DISTRIBUTIVE: CASE_DISTRIBUTIVE,
-	CASE_DISTRIBUTIVE_TEMPORAL: CASE_DISTRIBUTIVE_TEMPORAL,
-	CASE_ELATIVE: CASE_ELATIVE,
-	CASE_ERGATIVE: CASE_ERGATIVE,
-	CASE_ESSIVE: CASE_ESSIVE,
-	CASE_ESSIVE_FORMAL: CASE_ESSIVE_FORMAL,
-	CASE_ESSIVE_MODAL: CASE_ESSIVE_MODAL,
-	CASE_EQUATIVE: CASE_EQUATIVE,
-	CASE_EVITATIVE: CASE_EVITATIVE,
-	CASE_EXESSIVE: CASE_EXESSIVE,
-	CASE_FINAL: CASE_FINAL,
-	CASE_FORMAL: CASE_FORMAL,
-	CASE_GENITIVE: CASE_GENITIVE,
-	CASE_ILLATIVE: CASE_ILLATIVE,
-	CASE_INELATIVE: CASE_INELATIVE,
-	CASE_INESSIVE: CASE_INESSIVE,
-	CASE_INSTRUCTIVE: CASE_INSTRUCTIVE,
-	CASE_INSTRUMENTAL: CASE_INSTRUMENTAL,
-	CASE_INSTRUMENTAL_COMITATIVE: CASE_INSTRUMENTAL_COMITATIVE,
-	CASE_INTRANSITIVE: CASE_INTRANSITIVE,
-	CASE_LATIVE: CASE_LATIVE,
-	CASE_LOCATIVE: CASE_LOCATIVE,
-	CASE_MODAL: CASE_MODAL,
-	CASE_MULTIPLICATIVE: CASE_MULTIPLICATIVE,
-	CASE_NOMINATIVE: CASE_NOMINATIVE,
-	CASE_PARTITIVE: CASE_PARTITIVE,
-	CASE_PEGATIVE: CASE_PEGATIVE,
-	CASE_PERLATIVE: CASE_PERLATIVE,
-	CASE_POSSESSIVE: CASE_POSSESSIVE,
-	CASE_POSTELATIVE: CASE_POSTELATIVE,
-	CASE_POSTDIRECTIVE: CASE_POSTDIRECTIVE,
-	CASE_POSTESSIVE: CASE_POSTESSIVE,
-	CASE_POSTPOSITIONAL: CASE_POSTPOSITIONAL,
-	CASE_PREPOSITIONAL: CASE_PREPOSITIONAL,
-	CASE_PRIVATIVE: CASE_PRIVATIVE,
-	CASE_PROLATIVE: CASE_PROLATIVE,
-	CASE_PROSECUTIVE: CASE_PROSECUTIVE,
-	CASE_PROXIMATIVE: CASE_PROXIMATIVE,
-	CASE_SEPARATIVE: CASE_SEPARATIVE,
-	CASE_SOCIATIVE: CASE_SOCIATIVE,
-	CASE_SUBDIRECTIVE: CASE_SUBDIRECTIVE,
-	CASE_SUBESSIVE: CASE_SUBESSIVE,
-	CASE_SUBELATIVE: CASE_SUBELATIVE,
-	CASE_SUBLATIVE: CASE_SUBLATIVE,
-	CASE_SUPERDIRECTIVE: CASE_SUPERDIRECTIVE,
-	CASE_SUPERESSIVE: CASE_SUPERESSIVE,
-	CASE_SUPERLATIVE: CASE_SUPERLATIVE,
-	CASE_SUPPRESSIVE: CASE_SUPPRESSIVE,
-	CASE_TEMPORAL: CASE_TEMPORAL,
-	CASE_TERMINATIVE: CASE_TERMINATIVE,
-	CASE_TRANSLATIVE: CASE_TRANSLATIVE,
-	CASE_VIALIS: CASE_VIALIS,
-	CASE_VOCATIVE: CASE_VOCATIVE,
-	MOOD_ADMIRATIVE: MOOD_ADMIRATIVE,
-	MOOD_COHORTATIVE: MOOD_COHORTATIVE,
-	MOOD_CONDITIONAL: MOOD_CONDITIONAL,
-	MOOD_DECLARATIVE: MOOD_DECLARATIVE,
-	MOOD_DUBITATIVE: MOOD_DUBITATIVE,
-	MOOD_ENERGETIC: MOOD_ENERGETIC,
-	MOOD_EVENTIVE: MOOD_EVENTIVE,
-	MOOD_GENERIC: MOOD_GENERIC,
-	MOOD_GERUNDIVE: MOOD_GERUNDIVE,
-	MOOD_HYPOTHETICAL: MOOD_HYPOTHETICAL,
-	MOOD_IMPERATIVE: MOOD_IMPERATIVE,
-	MOOD_INDICATIVE: MOOD_INDICATIVE,
-	MOOD_INFERENTIAL: MOOD_INFERENTIAL,
-	MOOD_INFINITIVE: MOOD_INFINITIVE,
-	MOOD_INTERROGATIVE: MOOD_INTERROGATIVE,
-	MOOD_JUSSIVE: MOOD_JUSSIVE,
-	MOOD_NEGATIVE: MOOD_NEGATIVE,
-	MOOD_OPTATIVE: MOOD_OPTATIVE,
-	MOOD_PARTICIPLE: MOOD_PARTICIPLE,
-	MOOD_PRESUMPTIVE: MOOD_PRESUMPTIVE,
-	MOOD_RENARRATIVE: MOOD_RENARRATIVE,
-	MOOD_SUBJUNCTIVE: MOOD_SUBJUNCTIVE,
-	MOOD_SUPINE: MOOD_SUPINE,
-	NUM_SINGULAR: NUM_SINGULAR,
-	NUM_PLURAL: NUM_PLURAL,
-	NUM_DUAL: NUM_DUAL,
-	NUM_TRIAL: NUM_TRIAL,
-	NUM_PAUCAL: NUM_PAUCAL,
-	NUM_SINGULATIVE: NUM_SINGULATIVE,
-	NUM_COLLECTIVE: NUM_COLLECTIVE,
-	NUM_DISTRIBUTIVE_PLURAL: NUM_DISTRIBUTIVE_PLURAL,
-	NRL_CARDINAL: NRL_CARDINAL,
-	NRL_ORDINAL: NRL_ORDINAL,
-	NRL_DISTRIBUTIVE: NRL_DISTRIBUTIVE,
-	NURL_NUMERAL_ADVERB: NURL_NUMERAL_ADVERB,
-	ORD_1ST: ORD_1ST,
-	ORD_2ND: ORD_2ND,
-	ORD_3RD: ORD_3RD,
-	ORD_4TH: ORD_4TH,
-	ORD_5TH: ORD_5TH,
-	ORD_6TH: ORD_6TH,
-	ORD_7TH: ORD_7TH,
-	ORD_8TH: ORD_8TH,
-	ORD_9TH: ORD_9TH,
-	TENSE_AORIST: TENSE_AORIST,
-	TENSE_FUTURE: TENSE_FUTURE,
-	TENSE_FUTURE_PERFECT: TENSE_FUTURE_PERFECT,
-	TENSE_IMPERFECT: TENSE_IMPERFECT,
-	TENSE_PAST_ABSOLUTE: TENSE_PAST_ABSOLUTE,
-	TENSE_PERFECT: TENSE_PERFECT,
-	TENSE_PLUPERFECT: TENSE_PLUPERFECT,
-	TENSE_PRESENT: TENSE_PRESENT,
-	VKIND_TO_BE: VKIND_TO_BE,
-	VKIND_COMPOUNDS_OF_TO_BE: VKIND_COMPOUNDS_OF_TO_BE,
-	VKIND_TAKING_ABLATIVE: VKIND_TAKING_ABLATIVE,
-	VKIND_TAKING_DATIVE: VKIND_TAKING_DATIVE,
-	VKIND_TAKING_GENITIVE: VKIND_TAKING_GENITIVE,
-	VKIND_TRANSITIVE: VKIND_TRANSITIVE,
-	VKIND_INTRANSITIVE: VKIND_INTRANSITIVE,
-	VKIND_IMPERSONAL: VKIND_IMPERSONAL,
-	VKIND_DEPONENT: VKIND_DEPONENT,
-	VKIND_SEMIDEPONENT: VKIND_SEMIDEPONENT,
-	VKIND_PERFECT_DEFINITE: VKIND_PERFECT_DEFINITE,
-	VOICE_ACTIVE: VOICE_ACTIVE,
-	VOICE_PASSIVE: VOICE_PASSIVE,
-	VOICE_MEDIOPASSIVE: VOICE_MEDIOPASSIVE,
-	VOICE_IMPERSONAL_PASSIVE: VOICE_IMPERSONAL_PASSIVE,
-	VOICE_MIDDLE: VOICE_MIDDLE,
-	VOICE_ANTIPASSIVE: VOICE_ANTIPASSIVE,
-	VOICE_REFLEXIVE: VOICE_REFLEXIVE,
-	VOICE_RECIPROCAL: VOICE_RECIPROCAL,
-	VOICE_CAUSATIVE: VOICE_CAUSATIVE,
-	VOICE_ADJUTATIVE: VOICE_ADJUTATIVE,
-	VOICE_APPLICATIVE: VOICE_APPLICATIVE,
-	VOICE_CIRCUMSTANTIAL: VOICE_CIRCUMSTANTIAL,
-	VOICE_DEPONENT: VOICE_DEPONENT,
-	TYPE_IRREGULAR: TYPE_IRREGULAR,
-	TYPE_REGULAR: TYPE_REGULAR
-});
-
-/**
- * Wrapper class for a (grammatical, usually) feature, such as part of speech or declension. Keeps both value and type information.
- */
-class Feature {
-    /**
-     * Initializes a Feature object
-     * @param {string | string[]} value - A single feature value or, if this feature could have multiple
-     * values, an array of values.
-     * @param {string} type - A type of the feature, allowed values are specified in 'types' object.
-     * @param {string} language - A language of a feature, allowed values are specified in 'languages' object.
-     */
-  constructor (value, type, language) {
-    if (!Feature.types.isAllowed(type)) {
-      throw new Error('Features of "' + type + '" type are not supported.')
-    }
-    if (!value) {
-      throw new Error('Feature should have a non-empty value.')
-    }
-    if (!type) {
-      throw new Error('Feature should have a non-empty type.')
-    }
-    if (!language) {
-      throw new Error('Feature constructor requires a language')
-    }
-    this.value = value;
-    this.type = type;
-    this.language = language;
-  };
-
-  isEqual (feature) {
-    if (Array.isArray(feature.value)) {
-      if (!Array.isArray(this.value) || this.value.length !== feature.value.length) {
-        return false
-      }
-      let equal = this.type === feature.type && this.language === feature.language;
-      equal = equal && this.value.every(function (element, index) {
-        return element === feature.value[index]
-      });
-      return equal
-    } else {
-      return this.value === feature.value && this.type === feature.type && this.language === feature.language
-    }
-  }
-}
-// Should have no spaces in values in order to be used in HTML templates
-Feature.types = {
-  word: 'word',
-  part: 'part of speech', // Part of speech
-  number: 'number',
-  grmCase: 'case',
-  declension: 'declension',
-  gender: 'gender',
-  type: 'type',
-  conjugation: 'conjugation',
-  comparison: 'comparison',
-  tense: 'tense',
-  voice: 'voice',
-  mood: 'mood',
-  person: 'person',
-  frequency: 'frequency', // How frequent this word is
-  meaning: 'meaning', // Meaning of a word
-  source: 'source', // Source of word definition
-  footnote: 'footnote', // A footnote for a word's ending
-  dialect: 'dialect', // a dialect iderntifier
-  note: 'note', // a general note
-  pronunciation: 'pronunciation',
-  area: 'area',
-  geo: 'geo', // geographical data
-  kind: 'kind', // verb kind informatin
-  derivtype: 'derivtype',
-  stemtype: 'stemtype',
-  morph: 'morph', // general morphological information
-  var: 'var', // variance?
-  isAllowed (value) {
-    let v = `${value}`;
-    return Object.values(this).includes(v)
-  }
-};
-
-class FeatureImporter {
-  constructor (defaults = []) {
-    this.hash = {};
-    for (let value of defaults) {
-      this.map(value, value);
-    }
-    return this
-  }
-
-    /**
-     * Sets mapping between external imported value and one or more library standard values. If an importedValue
-     * is already in a hash table, old libraryValue will be overwritten with the new one.
-     * @param {string} importedValue - External value
-     * @param {Object | Object[] | string | string[]} libraryValue - Library standard value
-     */
-  map (importedValue, libraryValue) {
-    if (!importedValue) {
-      throw new Error('Imported value should not be empty.')
-    }
-
-    if (!libraryValue) {
-      throw new Error('Library value should not be empty.')
-    }
-
-    this.hash[importedValue] = libraryValue;
-    return this
-  }
-
-    /**
-     * Checks if value is in a map.
-     * @param {string} importedValue - A value to test.
-     * @returns {boolean} - Tru if value is in a map, false otherwise.
-     */
-  has (importedValue) {
-    return this.hash.hasOwnProperty(importedValue)
-  }
-
-    /**
-     * Returns one or more library standard values that match an external value
-     * @param {string} importedValue - External value
-     * @returns {Object | string} One or more of library standard values
-     */
-  get (importedValue) {
-    if (this.has(importedValue)) {
-      return this.hash[importedValue]
-    } else {
-      throw new Error('A value "' + importedValue + '" is not found in the importer.')
-    }
-  }
-}
-
-/**
- * Definition class for a (grammatical) feature. Stores type information and (optionally) all possible values of the feature.
- * It serves as a feature generator. If list of possible values is provided, it can generate a Feature object
- * each time a property that corresponds to a feature value is accessed. If no list of possible values provided,
- * a Feature object can be generated with get(value) method.
- *
- * An order of values determines a default sort and grouping order. If two values should have the same order,
- * they should be grouped within an array: value1, [value2, value3], value4. Here 'value2' and 'value3' have
- * the same priority for sorting and grouping.
- */
-class FeatureType {
-    // TODO: value checking
-    /**
-     * Creates and initializes a Feature Type object.
-     * @param {string} type - A type of the feature, allowed values are specified in 'types' object.
-     * @param {string[] | string[][]} values - A list of allowed values for this feature type.
-     * If an empty array is provided, there will be no
-     * allowed values as well as no ordering (can be used for items that do not need or have a simple order,
-     * such as footnotes).
-     * @param {string} language - A language of a feature, allowed values are specified in 'languages' object.
-     */
-  constructor (type, values, language) {
-    if (!Feature.types.isAllowed(type)) {
-      throw new Error('Features of "' + type + '" type are not supported.')
-    }
-    if (!values || !Array.isArray(values)) {
-      throw new Error('Values should be an array (or an empty array) of values.')
-    }
-    if (!language) {
-      throw new Error('FeatureType constructor requires a language')
-    }
-
-    this.type = type;
-    this.language = language;
-
-        /*
-         This is a sort order index for a grammatical feature values. It is determined by the order of values in
-         a 'values' array.
-         */
-    this._orderIndex = [];
-    this._orderLookup = {};
-
-    for (const [index, value] of values.entries()) {
-      this._orderIndex.push(value);
-      if (Array.isArray(value)) {
-        for (let element of value) {
-          this[element] = new Feature(element, this.type, this.language);
-          this._orderLookup[element] = index;
-        }
-      } else {
-        this[value] = new Feature(value, this.type, this.language);
-        this._orderLookup[value] = index;
-      }
-    }
-  };
-
-    /**
-     * Return a Feature with an arbitrary value. This value would not be necessarily present among FeatureType values.
-     * This can be especially useful for features that do not set: a list of predefined values, such as footnotes.
-     * @param value
-     * @returns {Feature}
-     */
-  get (value) {
-    if (value) {
-      return new Feature(value, this.type, this.language)
-    } else {
-      throw new Error('A non-empty value should be provided.')
-    }
-  }
-
-  getFromImporter (importerName, value) {
-    let mapped;
-    try {
-      mapped = this.importer[importerName].get(value);
-    } catch (e) {
-      // quietly catch not found and replace with default
-      mapped = this.get(value);
-    }
-    return mapped
-  }
-
-    /**
-     * Creates and returns a new importer with a specific name. If an importer with this name already exists,
-     * an existing Importer object will be returned.
-     * @param {string} name - A name of an importer object
-     * @returns {Importer} A new or existing Importer object that matches a name provided
-     */
-  addImporter (name) {
-    if (!name) {
-      throw new Error('Importer should have a non-empty name.')
-    }
-    this.importer = this.importer || {};
-    this.importer[name] = this.importer[name] || new FeatureImporter();
-    return this.importer[name]
-  }
-
-    /**
-     * Return copies of all feature values as Feature objects in a sorted array, according to feature type's sort order.
-     * For a similar function that returns strings instead of Feature objects see orderedValues().
-     * @returns {Feature[] | Feature[][]} Array of feature values sorted according to orderIndex.
-     * If particular feature contains multiple feature values (i.e. `masculine` and `feminine` values combined),
-     * an array of Feature objects will be returned instead of a single Feature object, as for single feature values.
-     */
-  get orderedFeatures () {
-    return this.orderedValues.map((value) => new Feature(value, this.type, this.language))
-  }
-
-    /**
-     * Return all feature values as strings in a sorted array, according to feature type's sort order.
-     * This is a main method that specifies a sort order of the feature type. orderedFeatures() relies
-     * on this method in providing a sorted array of feature values. If you want to create
-     * a custom sort order for a particular feature type that will depend on some options that are not type-related,
-     * create a wrapper around this function providing it with options arguments so it will be able to decide
-     * in what order those features will be based on those arguments.
-     * For a similar function that returns Feature objects instead of strings see orderedValues().
-     * @returns {string[]} Array of feature values sorted according to orderIndex.
-     * If particular feature contains multiple feature values (i.e. `masculine` and `feminine` values combined),
-     * an array of strings will be returned instead of a single strings, as for single feature values.
-     */
-  get orderedValues () {
-    return this._orderIndex
-  }
-
-    /**
-     * Returns a lookup table for type values as:
-     *  {value1: order1, value2: order2}, where order is a sort order of an item. If two items have the same sort order,
-     *  their order value will be the same.
-     * @returns {object}
-     */
-  get orderLookup () {
-    return this._orderLookup
-  }
-
-    /**
-     * Sets an order of grammatical feature values for a grammatical feature. Used mostly for sorting, filtering,
-     * and displaying.
-     *
-     * @param {Feature[] | Feature[][]} values - a list of grammatical features that specify their order for
-     * sorting and filtering. Some features can be grouped as [[genders.masculine, genders.feminine], LibLatin.genders.neuter].
-     * It means that genders.masculine and genders.feminine belong to the same group. They will have the same index
-     * and will be stored inside an _orderIndex as an array. genders.masculine and genders.feminine will be grouped together
-     * during filtering and will be in the same bin during sorting.
-     *
-     */
-  set order (values) {
-    if (!values || (Array.isArray(values) && values.length === 0)) {
-      throw new Error('A non-empty list of values should be provided.')
-    }
-
-        // If a single value is provided, convert it into an array
-    if (!Array.isArray(values)) {
-      values = [values];
-    }
-
-    for (let value of values) {
-      if (Array.isArray(value)) {
-        for (let element of value) {
-          if (!this.hasOwnProperty(element.value)) {
-            throw new Error('Trying to order an element with "' + element.value + '" value that is not stored in a "' + this.type + '" type.')
-          }
-
-          if (element.type !== this.type) {
-            throw new Error('Trying to order an element with type "' + element.type + '" that is different from "' + this.type + '".')
-          }
-
-          if (element.language !== this.language) {
-            throw new Error('Trying to order an element with language "' + element.language + '" that is different from "' + this.language + '".')
-          }
-        }
-      } else {
-        if (!this.hasOwnProperty(value.value)) {
-          throw new Error('Trying to order an element with "' + value.value + '" value that is not stored in a "' + this.type + '" type.')
-        }
-
-        if (value.type !== this.type) {
-          throw new Error('Trying to order an element with type "' + value.type + '" that is different from "' + this.type + '".')
-        }
-
-        if (value.language !== this.language) {
-          throw new Error('Trying to order an element with language "' + value.language + '" that is different from "' + this.language + '".')
-        }
-      }
-    }
-
-        // Erase whatever sort order was set previously
-    this._orderLookup = {};
-    this._orderIndex = [];
-
-        // Define a new sort order
-    for (const [index, element] of values.entries()) {
-      if (Array.isArray(element)) {
-                // If it is an array, all values should have the same order
-        let elements = [];
-        for (const subElement of element) {
-          this._orderLookup[subElement.value] = index;
-          elements.push(subElement.value);
-        }
-        this._orderIndex[index] = elements;
-      } else {
-                // If is a single value
-        this._orderLookup[element.value] = index;
-        this._orderIndex[index] = element.value;
-      }
-    }
-  }
-}
-
-/**
- * A list of grammatical features that characterizes a language unit. Has some additional service methods,
- * compared with standard storage objects.
- */
-class FeatureList {
-    /**
-     * Initializes a feature list.
-     * @param {FeatureType[]} features - Features that build the list (optional, can be set later).
-     */
-  constructor (features = []) {
-    this._features = [];
-    this._types = {};
-    this.add(features);
-  }
-
-  add (features) {
-    if (!features || !Array.isArray(features)) {
-      throw new Error('Features must be defined and must come in an array.')
-    }
-
-    for (let feature of features) {
-      this._features.push(feature);
-      this._types[feature.type] = feature;
-    }
-  }
-
-    /**
-     * Returns an array of grouping features.
-     * @returns {FeatureType[]} - An array of grouping features.
-     */
-  get items () {
-    return this._features
-  }
-
-  forEach (callback) {
-    this._features.forEach(callback);
-  }
-
-    /**
-     * Returns a feature of a particular type. If such feature does not exist in a list, returns undefined.
-     * @param {string} type - Feature type as defined in `types` object.
-     * @return {FeatureType | undefined} A feature if a particular type if contains it. Undefined otherwise.
-     */
-  ofType (type) {
-    if (this.hasType(type)) {
-      return this._types[type]
-    }
-  }
-
-    /**
-     * Checks whether a feature list has a feature of a specific type.
-     * @param {string} type - Feature type as defined in `types` object.
-     * @return {boolean} Whether a feature list has a feature of a particular type.
-     */
-  hasType (type) {
-    return this._types.hasOwnProperty(type)
-  }
-}
-
-/**
- * @class  LanguageModel is the base class for language-specific behavior
- */
-class LanguageModel {
-   /**
-   */
-  constructor () {
-    this.sourceLanguage = null;
-    this.contextForward = 0;
-    this.context_backward = 0;
-    this.direction = LANG_DIR_LTR;
-    this.baseUnit = LANG_UNIT_WORD;
-    this.codes = [];
-  }
-
-  _initializeFeatures () {
-    let features = {};
-    let code = this.toCode();
-    features[Feature.types.part] = new FeatureType(Feature.types.part,
-      [ POFS_ADVERB,
-        POFS_ADVERBIAL,
-        POFS_ADJECTIVE,
-        POFS_ARTICLE,
-        POFS_CONJUNCTION,
-        POFS_EXCLAMATION,
-        POFS_INTERJECTION,
-        POFS_NOUN,
-        POFS_NUMERAL,
-        POFS_PARTICLE,
-        POFS_PREFIX,
-        POFS_PREPOSITION,
-        POFS_PRONOUN,
-        POFS_SUFFIX,
-        POFS_SUPINE,
-        POFS_VERB,
-        POFS_VERB_PARTICIPLE ], code);
-    features[Feature.types.gender] = new FeatureType(Feature.types.gender,
-      [ GEND_MASCULINE, GEND_FEMININE, GEND_NEUTER ], code);
-    features[Feature.types.type] = new FeatureType(Feature.types.type,
-      [TYPE_REGULAR, TYPE_IRREGULAR], code);
-    features[Feature.types.person] = new FeatureType(Feature.types.person,
-      [ORD_1ST, ORD_2ND, ORD_3RD], code);
-    return features
-  }
-
-  /**
-   * Handler which can be used as the contextHander.
-   * It uses language-specific configuration to identify
-   * the elements from the alph-text popup which should produce links
-   * to the language-specific grammar.
-   * @see #contextHandler
-   */
-  grammarContext (doc) {
-      // used to bind a click handler on the .alph-entry items in the
-      // popup which retrieved the context attribute from the clicked
-      // term and used that to construct a link and open the grammar
-      // at the apporopriate place.
-      // var links = this.getGrammarLinks();
-
-      // for (var link_name in links)
-      // {
-      //   if (links.hasOwnProperty(link_name))
-      //    {
-              // Alph.$(".alph-entry ." + link_name,a_doc).bind('click',link_name,
-              //   function(a_e)
-              //    {
-                        // build target inside grammar
-                        // var target = a_e.data;
-                        // var rngContext = Alph.$(this).attr("context");
-                        // if (rngContext != null)
-                        // {
-                        //  target += "-" + rngContext.split(/-/)[0];
-                        // }
-                        // myobj.openGrammar(a_e.originaEvent,this,target);
-               //   }
-              // );
-       //   }
-      // }
-  }
-
-  /**
-   * Check to see if this language tool can produce an inflection table display
-   * for the current node
-   */
-  canInflect (node) {
-    return false
-  }
-
-  /**
-   * Check to see if the supplied language code is supported by this tool
-   * @param {string} code the language code
-   * @returns true if supported false if not
-   * @type Boolean
-   */
-  static supportsLanguage (code) {
-    return this.codes.includes[code]
-  }
-
-  /**
-   * Return a normalized version of a word which can be used to compare the word for equality
-   * @param {string} word the source word
-   * @returns the normalized form of the word (default version just returns the same word,
-   *          override in language-specific subclass)
-   * @type String
-   */
-  normalizeWord (word) {
-    return word
-  }
-
-  /**
-   * Get a list of valid puncutation for this language
-   * @returns {String} a string containing valid puncutation symbols
-   */
-  getPunctuation () {
-    return ".,;:!?'\"(){}\\[\\]<>/\\\u00A0\u2010\u2011\u2012\u2013\u2014\u2015\u2018\u2019\u201C\u201D\u0387\u00B7\n\r"
-  }
-
-  toString () {
-    return String(this.sourceLanguage)
-  }
-
-  isEqual (model) {
-    return this.sourceLanguage === model.sourceLanguage
-  }
-
-  toCode () {
-    return null
-  }
-}
-
-/**
- * @class  LatinLanguageModel is the lass for Latin specific behavior
- */
-class LatinLanguageModel extends LanguageModel {
-   /**
-   */
-  constructor () {
-    super();
-    this.sourceLanguage = LANG_LATIN;
-    this.contextForward = 0;
-    this.contextBackward = 0;
-    this.direction = LANG_DIR_LTR;
-    this.baseUnit = LANG_UNIT_WORD;
-    this.codes = [STR_LANG_CODE_LA, STR_LANG_CODE_LAT];
-    this.features = this._initializeFeatures();
-  }
-
-  _initializeFeatures () {
-    let features = super._initializeFeatures();
-    let code = this.toCode();
-    features[Feature.types.number] = new FeatureType(Feature.types.number, [NUM_SINGULAR, NUM_PLURAL], code);
-    features[Feature.types.grmCase] = new FeatureType(Feature.types.grmCase,
-      [ CASE_NOMINATIVE,
-        CASE_GENITIVE,
-        CASE_DATIVE,
-        CASE_ACCUSATIVE,
-        CASE_ABLATIVE,
-        CASE_LOCATIVE,
-        CASE_VOCATIVE
-      ], code);
-    features[Feature.types.declension] = new FeatureType(Feature.types.declension,
-      [ ORD_1ST, ORD_2ND, ORD_3RD, ORD_4TH, ORD_5TH ], code);
-    features[Feature.types.tense] = new FeatureType(Feature.types.tense,
-      [ TENSE_PRESENT,
-        TENSE_IMPERFECT,
-        TENSE_FUTURE,
-        TENSE_PERFECT,
-        TENSE_PLUPERFECT,
-        TENSE_FUTURE_PERFECT
-      ], code);
-    features[Feature.types.voice] = new FeatureType(Feature.types.voice, [VOICE_PASSIVE, VOICE_ACTIVE], code);
-    features[Feature.types.mood] = new FeatureType(Feature.types.mood, [MOOD_INDICATIVE, MOOD_SUBJUNCTIVE], code);
-    features[Feature.types.conjugation] = new FeatureType(Feature.types.conjugation,
-      [ ORD_1ST,
-        ORD_2ND,
-        ORD_3RD,
-        ORD_4TH
-      ], code);
-    return features
-  }
-
-  /**
-   * Check to see if this language tool can produce an inflection table display
-   * for the current node
-   */
-  canInflect (node) {
-    return true
-  }
-
-  /**
-   * Return a normalized version of a word which can be used to compare the word for equality
-   * @param {String} word the source word
-   * @returns the normalized form of the word (default version just returns the same word,
-   *          override in language-specific subclass)
-   * @type String
-   */
-  normalizeWord (word) {
-    return word
-  }
-
-  /**
-   * Get a list of valid puncutation for this language
-   * @returns {String} a string containing valid puncutation symbols
-   */
-  getPunctuation () {
-    return ".,;:!?'\"(){}\\[\\]<>/\\\u00A0\u2010\u2011\u2012\u2013\u2014\u2015\u2018\u2019\u201C\u201D\u0387\u00B7\n\r"
-  }
-
-  toCode () {
-    return STR_LANG_CODE_LAT
-  }
-}
-
-/**
- * @class  LatinLanguageModel is the lass for Latin specific behavior
- */
-class GreekLanguageModel extends LanguageModel {
-   /**
-   * @constructor
-   */
-  constructor () {
-    super();
-    this.sourceLanguage = LANG_GREEK;
-    this.contextForward = 0;
-    this.contextBackward = 0;
-    this.direction = LANG_DIR_LTR;
-    this.baseUnit = LANG_UNIT_WORD;
-    this.languageCodes = [STR_LANG_CODE_GRC];
-    this.features = this._initializeFeatures();
-  }
-
-  _initializeFeatures () {
-    let features = super._initializeFeatures();
-    let code = this.toCode();
-    features[Feature.types.number] = new FeatureType(Feature.types.number, [NUM_SINGULAR, NUM_PLURAL, NUM_DUAL], code);
-    features[Feature.types.grmCase] = new FeatureType(Feature.types.grmCase,
-      [ CASE_NOMINATIVE,
-        CASE_GENITIVE,
-        CASE_DATIVE,
-        CASE_ACCUSATIVE,
-        CASE_VOCATIVE
-      ], code);
-    features[Feature.types.declension] = new FeatureType(Feature.types.declension,
-      [ ORD_1ST, ORD_2ND, ORD_3RD ], code);
-    features[Feature.types.tense] = new FeatureType(Feature.types.tense,
-      [ TENSE_PRESENT,
-        TENSE_IMPERFECT,
-        TENSE_FUTURE,
-        TENSE_PERFECT,
-        TENSE_PLUPERFECT,
-        TENSE_FUTURE_PERFECT,
-        TENSE_AORIST
-      ], code);
-    features[Feature.types.voice] = new FeatureType(Feature.types.voice,
-      [ VOICE_PASSIVE,
-        VOICE_ACTIVE,
-        VOICE_MEDIOPASSIVE,
-        VOICE_MIDDLE
-      ], code);
-    features[Feature.types.mood] = new FeatureType(Feature.types.mood,
-      [ MOOD_INDICATIVE,
-        MOOD_SUBJUNCTIVE,
-        MOOD_OPTATIVE,
-        MOOD_IMPERATIVE
-      ], code);
-    // TODO full list of greek dialects
-    features[Feature.types.dialect] = new FeatureType(Feature.types.dialect, ['attic', 'epic', 'doric'], code);
-    return features
-  }
-
-  toCode () {
-    return STR_LANG_CODE_GRC
-  }
-
-  /**
-   * Check to see if this language tool can produce an inflection table display
-   * for the current node
-   */
-  canInflect (node) {
-    return true
-  }
-
-  /**
-   * Return a normalized version of a word which can be used to compare the word for equality
-   * @param {String} word the source word
-   * @returns the normalized form of the word (default version just returns the same word,
-   *          override in language-specific subclass)
-   * @type String
-   */
-  normalizeWord (word) {
-    return word
-  }
-
-  /**
-   * Get a list of valid puncutation for this language
-   * @returns {String} a string containing valid puncutation symbols
-   */
-  getPunctuation () {
-    return ".,;:!?'\"(){}\\[\\]<>/\\\u00A0\u2010\u2011\u2012\u2013\u2014\u2015\u2018\u2019\u201C\u201D\u0387\u00B7\n\r"
-  }
-}
-
-/**
- * @class  LatinLanguageModel is the lass for Latin specific behavior
- */
-class ArabicLanguageModel extends LanguageModel {
-   /**
-   * @constructor
-   */
-  constructor () {
-    super();
-    this.sourceLanguage = LANG_ARABIC;
-    this.contextForward = 0;
-    this.contextBackward = 0;
-    this.direction = LANG_DIR_RTL;
-    this.baseUnit = LANG_UNIT_WORD;
-    this.languageCodes = [STR_LANG_CODE_ARA, STR_LANG_CODE_AR];
-    this._initializeFeatures();
-  }
-
-  _initializeFeatures () {
-    this.features = super._initializeFeatures();
-  }
-
-  toCode () {
-    return STR_LANG_CODE_ARA
-  }
-
-  /**
-   * Check to see if this language tool can produce an inflection table display
-   * for the current node
-   */
-  canInflect (node) {
-    return false
-  }
-
-  /**
-   * Return a normalized version of a word which can be used to compare the word for equality
-   * @param {String} word the source word
-   * @returns the normalized form of the word (default version just returns the same word,
-   *          override in language-specific subclass)
-   * @type String
-   */
-  normalizeWord (word) {
-    // TODO
-    return word
-  }
-
-  /**
-   * Get a list of valid puncutation for this language
-   * @returns {String} a string containing valid puncutation symbols
-   */
-  getPunctuation () {
-    return ".,;:!?'\"(){}\\[\\]<>/\\\u00A0\u2010\u2011\u2012\u2013\u2014\u2015\u2018\u2019\u201C\u201D\u0387\u00B7\n\r"
-  }
-}
-
-const MODELS = new Map([
-  [ STR_LANG_CODE_LA, LatinLanguageModel ],
-  [ STR_LANG_CODE_LAT, LatinLanguageModel ],
-  [ STR_LANG_CODE_GRC, GreekLanguageModel ],
-  [ STR_LANG_CODE_ARA, ArabicLanguageModel ],
-  [ STR_LANG_CODE_AR, ArabicLanguageModel ]
-]);
-
-class LanguageModelFactory {
-  static supportsLanguage (code) {
-    return MODELS.has(code)
-  }
-
-  static getLanguageForCode (code = null) {
-    let Model = MODELS.get(code);
-    if (Model) {
-      return new Model()
-    }
-    // for now return a default Model
-    // TODO may want to throw an error
-    return new LanguageModel()
-  }
-}
-
-/**
- * Lemma, a canonical form of a word.
- */
-class Lemma {
-    /**
-     * Initializes a Lemma object.
-     * @param {string} word - A word.
-     * @param {string} language - A language of a word.
-     */
-  constructor (word, language) {
-    if (!word) {
-      throw new Error('Word should not be empty.')
-    }
-
-    if (!language) {
-      throw new Error('Langauge should not be empty.')
-    }
-
-        // if (!languages.isAllowed(language)) {
-        //    throw new Error('Language "' + language + '" is not supported.');
-        // }
-
-    this.word = word;
-    this.language = language;
-  }
-
-  static readObject (jsonObject) {
-    return new Lemma(jsonObject.word, jsonObject.language)
-  }
-}
-
-/*
- Hierarchical structure of return value of a morphological analyzer:
-
- Homonym (a group of words that are written the same way, https://en.wikipedia.org/wiki/Homonym)
-    Lexeme 1 (a unit of lexical meaning, https://en.wikipedia.org/wiki/Lexeme)
-        Have a lemma and one or more inflections
-        Lemma (also called a headword, a canonical form of a group of words https://en.wikipedia.org/wiki/Lemma_(morphology) )
-        Inflection 1
-            Stem
-            Suffix (also called ending)
-        Inflection 2
-            Stem
-            Suffix
-    Lexeme 2
-        Lemma
-        Inflection 1
-            Stem
-            Suffix
- */
-
-/**
- * Represents an inflection of a word
- */
-class Inflection {
-    /**
-     * Initializes an Inflection object.
-     * @param {string} stem - A stem of a word.
-     * @param {string} language - A word's language.
-     */
-  constructor (stem, language) {
-    if (!stem) {
-      throw new Error('Stem should not be empty.')
-    }
-
-    if (!language) {
-      throw new Error('Langauge should not be empty.')
-    }
-
-    if (!LanguageModelFactory.supportsLanguage(language)) {
-      throw new Error(`language ${language} not supported.`)
-    }
-
-    this.stem = stem;
-    this.language = language;
-
-    // Suffix may not be present in every word. If missing, it will set to null.
-    this.suffix = null;
-
-    // Prefix may not be present in every word. If missing, it will set to null.
-    this.prefix = null;
-
-    // Example may not be provided
-    this.example = null;
-  }
-
-  static readObject (jsonObject) {
-    let inflection = new Inflection(jsonObject.stem, jsonObject.language);
-    if (jsonObject.suffix) {
-      inflection.suffix = jsonObject.suffix;
-    }
-    if (jsonObject.prefix) {
-      inflection.prefix = jsonObject.prefix;
-    }
-    if (jsonObject.example) {
-      inflection.example = jsonObject.example;
-    }
-    return inflection
-  }
-
-    /**
-     * Sets a grammatical feature in an inflection. Some features can have multiple values, In this case
-     * an array of Feature objects will be provided.
-     * Values are taken from features and stored in a 'feature.type' property as an array of values.
-     * @param {Feature | Feature[]} data
-     */
-  set feature (data) {
-    if (!data) {
-      throw new Error('Inflection feature data cannot be empty.')
-    }
-    if (!Array.isArray(data)) {
-      data = [data];
-    }
-
-    let type = data[0].type;
-    this[type] = [];
-    for (let element of data) {
-      if (!(element instanceof Feature)) {
-        throw new Error('Inflection feature data must be a Feature object.')
-      }
-
-      if (element.language !== this.language) {
-        throw new Error('Language "' + element.language + '" of a feature does not match a language "' +
-                this.language + '" of an Inflection object.')
-      }
-
-      this[type].push(element.value);
-    }
-  }
-}
-
-/**
- * A basic unit of lexical meaning. Contains a Lemma object and one or more Inflection objects.
- */
-class Lexeme {
-    /**
-     * Initializes a Lexeme object.
-     * @param {Lemma} lemma - A lemma object.
-     * @param {Inflection[]} inflections - An array of inflections.
-     * @param {string} meaning - a short definition
-     */
-  constructor (lemma, inflections, meaning = '') {
-    if (!lemma) {
-      throw new Error('Lemma should not be empty.')
-    }
-
-    if (!(lemma instanceof Lemma)) {
-      throw new Error('Lemma should be of Lemma object type.')
-    }
-
-    if (!inflections) {
-      throw new Error('Inflections data should not be empty.')
-    }
-
-    if (!Array.isArray(inflections)) {
-      throw new Error('Inflection data should be provided in an array.')
-    }
-
-    for (let inflection of inflections) {
-      if (!(inflection instanceof Inflection)) {
-        throw new Error('All inflection data should be of Inflection object type.')
-      }
-    }
-
-    this.lemma = lemma;
-    this.inflections = inflections;
-    this.meaning = meaning;
-  }
-
-  static readObject (jsonObject) {
-    let lemma = Lemma.readObject(jsonObject.lemma);
-    let inflections = [];
-    for (let inflection of jsonObject.inflections) {
-      inflections.push(Inflection.readObject(inflection));
-    }
-    return new Lexeme(lemma, inflections)
-  }
-}
-
-class Homonym {
-    /**
-     * Initializes a Homonym object.
-     * @param {Lexeme[]} lexemes - An array of Lexeme objects.
-     * @param {string} form - the form which produces the homonyms
-     */
-  constructor (lexemes, form) {
-    if (!lexemes) {
-      throw new Error('Lexemes data should not be empty.')
-    }
-
-    if (!Array.isArray(lexemes)) {
-      throw new Error('Lexeme data should be provided in an array.')
-    }
-
-    for (let lexeme of lexemes) {
-      if (!(lexeme instanceof Lexeme)) {
-        throw new Error('All lexeme data should be of Lexeme object type.')
-      }
-    }
-
-    this.lexemes = lexemes;
-    this.targetWord = form;
-  }
-
-  static readObject (jsonObject) {
-    let lexemes = [];
-    if (jsonObject.lexemes) {
-      for (let lexeme of jsonObject.lexemes) {
-        lexemes.push(Lexeme.readObject(lexeme));
-      }
-    }
-    let homonym = new Homonym(lexemes);
-    if (jsonObject.targetWord) {
-      homonym.targetWord = jsonObject.targetWord;
-    }
-    return homonym
-  }
-
-    /**
-     * Returns language of a homonym.
-     * Homonym does not have a language property, only lemmas and inflections do. We assume that all lemmas
-     * and inflections within the same homonym will have the same language, and we can determine a language
-     * by using language property of the first lemma. We chan change this logic in the future if we'll need to.
-     * @returns {string} A language code, as defined in the `languages` object.
-     */
-  get language () {
-    if (this.lexemes && this.lexemes[0] && this.lexemes[0].lemma && this.lexemes[0].lemma.language) {
-      return this.lexemes[0].lemma.language
-    } else {
-      throw new Error('Homonym has not been initialized properly. Unable to obtain language information.')
-    }
-  }
-}
+import { Constants, Feature, FeatureList, FeatureType, Homonym, LatinLanguageModel } from 'alpheios-data-models';
 
 /**
  * Shared data structures and functions
@@ -1531,7 +120,7 @@ class LanguageDataset {
 
   getSuffixes (homonym) {
         // Add support for languages
-    let result = new WordData(homonym);
+    let result = new LexicalData(homonym);
     let inflections = {};
 
         // Find partial matches first, and then full among them
@@ -1638,7 +227,7 @@ class LanguageData {
     /**
      * Finds matching suffixes for a homonym.
      * @param {Homonym} homonym - A homonym for which matching suffixes must be found.
-     * @return {WordData} A return value of an inflection query.
+     * @return {LexicalData} A return value of an inflection query.
      */
   getSuffixes (homonym) {
     let language = homonym.language;
@@ -2015,40 +604,38 @@ class SelectedWord {
 /**
  * A return value for inflection queries
  */
-class WordData {
+class LexicalData {
   constructor (homonym) {
     this.homonym = homonym;
-    this.definition = undefined;
     this[Feature.types.part] = []; // What parts of speech are represented by this object.
   }
 
   static readObject (jsonObject) {
     let homonym = Homonym.readObject(jsonObject.homonym);
 
-    let wordData = new WordData(homonym);
-    wordData.definition = jsonObject.definition;
-    wordData[Feature.types.part] = jsonObject[Feature.types.part];
+    let lexicalData = new LexicalData(homonym);
+    lexicalData[Feature.types.part] = jsonObject[Feature.types.part];
 
-    for (let part of wordData[Feature.types.part]) {
+    for (let part of lexicalData[Feature.types.part]) {
       let partData = jsonObject[part];
-      wordData[part] = {};
+      lexicalData[part] = {};
 
       if (partData.suffixes) {
-        wordData[part].suffixes = [];
+        lexicalData[part].suffixes = [];
         for (let suffix of partData.suffixes) {
-          wordData[part].suffixes.push(Suffix.readObject(suffix));
+          lexicalData[part].suffixes.push(Suffix.readObject(suffix));
         }
       }
 
       if (partData.footnotes) {
-        wordData[part].footnotes = [];
+        lexicalData[part].footnotes = [];
         for (let footnote of partData.footnotes) {
-          wordData[part].footnotes.push(Footnote.readObject(footnote));
+          lexicalData[part].footnotes.push(Footnote.readObject(footnote));
         }
       }
     }
 
-    return wordData
+    return lexicalData
   }
 
   get word () {
@@ -4147,17 +2734,17 @@ const messages = [
   new MessageBundle('en-GB', messages$2)
 ];
 
-var nounSuffixesCSV = "Ending,Number,Case,Declension,Gender,Type,Footnote\na,singular,nominative,1st,feminine,regular,\nē,singular,nominative,1st,feminine,irregular,\nēs,singular,nominative,1st,feminine,irregular,\nā,singular,nominative,1st,feminine,irregular,7\nus,singular,nominative,2nd,masculine feminine,regular,\ner,singular,nominative,2nd,masculine feminine,regular,\nir,singular,nominative,2nd,masculine feminine,regular,\n-,singular,nominative,2nd,masculine feminine,irregular,\nos,singular,nominative,2nd,masculine feminine,irregular,1\nōs,singular,nominative,2nd,masculine feminine,irregular,\nō,singular,nominative,2nd,masculine feminine,irregular,7\num,singular,nominative,2nd,neuter,regular,\nus,singular,nominative,2nd,neuter,irregular,10\non,singular,nominative,2nd,neuter,irregular,7\n-,singular,nominative,3rd,masculine feminine,regular,\nos,singular,nominative,3rd,masculine feminine,irregular,\nōn,singular,nominative,3rd,masculine feminine,irregular,7\n-,singular,nominative,3rd,neuter,regular,\nus,singular,nominative,4th,masculine feminine,regular,\nū,singular,nominative,4th,neuter,regular,\nēs,singular,nominative,5th,feminine,regular,\nae,singular,genitive,1st,feminine,regular,\nāī,singular,genitive,1st,feminine,irregular,1\nās,singular,genitive,1st,feminine,irregular,2\nēs,singular,genitive,1st,feminine,irregular,7\nī,singular,genitive,2nd,masculine feminine,regular,\nō,singular,genitive,2nd,masculine feminine,irregular,7\nī,singular,genitive,2nd,neuter,regular,\nis,singular,genitive,3rd,masculine feminine,regular,\nis,singular,genitive,3rd,neuter,regular,\nūs,singular,genitive,4th,masculine feminine,regular,\nuis,singular,genitive,4th,masculine feminine,irregular,1\nuos,singular,genitive,4th,masculine feminine,irregular,1\nī,singular,genitive,4th,masculine feminine,irregular,15\nūs,singular,genitive,4th,neuter,regular,\nēī,singular,genitive,5th,feminine,regular,\neī,singular,genitive,5th,feminine,regular,\nī,singular,genitive,5th,feminine,irregular,\nē,singular,genitive,5th,feminine,irregular,\nēs,singular,genitive,5th,feminine,irregular,6\nae,singular,dative,1st,feminine,regular,\nāī,singular,dative,1st,feminine,irregular,1\nō,singular,dative,2nd,masculine feminine,regular,\nō,singular,dative,2nd,neuter,regular,\nī,singular,dative,3rd,masculine feminine,regular,\ne,singular,dative,3rd,masculine feminine,irregular,17\nī,singular,dative,3rd,neuter,regular,\nūī,singular,dative,4th,masculine feminine,regular,\nū,singular,dative,4th,masculine feminine,regular,\nū,singular,dative,4th,neuter,regular,\nēī,singular,dative,5th,feminine,regular,\neī,singular,dative,5th,feminine,regular,\nī,singular,dative,5th,feminine,irregular,\nē,singular,dative,5th,feminine,irregular,6\nam,singular,accusative,1st,feminine,regular,\nēn,singular,accusative,1st,feminine,irregular,\nān,singular,accusative,1st,feminine,irregular,7\num,singular,accusative,2nd,masculine feminine,regular,\nom,singular,accusative,2nd,masculine feminine,irregular,1\nōn,singular,accusative,2nd,masculine feminine,irregular,7\num,singular,accusative,2nd,neuter,regular,\nus,singular,accusative,2nd,neuter,irregular,10\non,singular,accusative,2nd,neuter,irregular,7\nem,singular,accusative,3rd,masculine feminine,regular,\nim,singular,accusative,3rd,masculine feminine,irregular,11\na,singular,accusative,3rd,masculine feminine,irregular,7\n-,singular,accusative,3rd,neuter,regular,\num,singular,accusative,4th,masculine feminine,regular,\nū,singular,accusative,4th,neuter,regular,\nem,singular,accusative,5th,feminine,regular,\nā,singular,ablative,1st,feminine,regular,\nād,singular,ablative,1st,feminine,irregular,5\nē,singular,ablative,1st,feminine,irregular,7\nō,singular,ablative,2nd,masculine feminine,regular,\nōd,singular,ablative,2nd,masculine feminine,irregular,1\nō,singular,ablative,2nd,neuter,regular,\ne,singular,ablative,3rd,masculine feminine,regular,\nī,singular,ablative,3rd,masculine feminine,irregular,11\ne,singular,ablative,3rd,neuter,regular,\nī,singular,ablative,3rd,neuter,irregular,11\nū,singular,ablative,4th,masculine feminine,regular,\nūd,singular,ablative,4th,masculine feminine,irregular,1\nū,singular,ablative,4th,neuter,regular,\nē,singular,ablative,5th,feminine,regular,\nae,singular,locative,1st,feminine,regular,\nō,singular,locative,2nd,masculine feminine,regular,\nō,singular,locative,2nd,neuter,regular,\ne,singular,locative,3rd,masculine feminine,regular,\nī,singular,locative,3rd,masculine feminine,regular,\nī,singular,locative,3rd,neuter,regular,\nū,singular,locative,4th,masculine feminine,regular,\nū,singular,locative,4th,neuter,regular,\nē,singular,locative,5th,feminine,regular,\na,singular,vocative,1st,feminine,regular,\nē,singular,vocative,1st,feminine,irregular,\nā,singular,vocative,1st,feminine,irregular,7\ne,singular,vocative,2nd,masculine feminine,regular,\ner,singular,vocative,2nd,masculine feminine,regular,\nir,singular,vocative,2nd,masculine feminine,regular,\n-,singular,vocative,2nd,masculine feminine,irregular,\nī,singular,vocative,2nd,masculine feminine,irregular,8\nōs,singular,vocative,2nd,masculine feminine,irregular,\ne,singular,vocative,2nd,masculine feminine,irregular,7\num,singular,vocative,2nd,neuter,regular,\non,singular,vocative,2nd,neuter,irregular,7\n-,singular,vocative,3rd,masculine feminine,regular,\n-,singular,vocative,3rd,neuter,regular,\nus,singular,vocative,4th,masculine feminine,regular,\nū,singular,vocative,4th,neuter,regular,\nēs,singular,vocative,5th,feminine,regular,\nae,plural,nominative,1st,feminine,regular,\nī,plural,nominative,2nd,masculine feminine,regular,\noe,plural,nominative,2nd,masculine feminine,irregular,7 9\na,plural,nominative,2nd,neuter,regular,\nēs,plural,nominative,3rd,masculine feminine,regular,\nes,plural,nominative,3rd,masculine feminine,irregular,7\na,plural,nominative,3rd,neuter,regular,\nia,plural,nominative,3rd,neuter,irregular,11\nūs,plural,nominative,4th,masculine feminine,regular,\nua,plural,nominative,4th,neuter,regular,\nēs,plural,nominative,5th,feminine,regular,\nārum,plural,genitive,1st,feminine,regular,\num,plural,genitive,1st,feminine,irregular,3\nōrum,plural,genitive,2nd,masculine feminine,regular,\num,plural,genitive,2nd,masculine feminine,irregular,\nom,plural,genitive,2nd,masculine feminine,irregular,8\nōrum,plural,genitive,2nd,neuter,regular,\num,plural,genitive,2nd,neuter,irregular,\num,plural,genitive,3rd,masculine feminine,regular,\nium,plural,genitive,3rd,masculine feminine,irregular,11\nōn,plural,genitive,3rd,masculine feminine,irregular,7\num,plural,genitive,3rd,neuter,regular,\nium,plural,genitive,3rd,neuter,irregular,11\nuum,plural,genitive,4th,masculine feminine,regular,\num,plural,genitive,4th,masculine feminine,irregular,16\nuom,plural,genitive,4th,masculine feminine,irregular,1\nuum,plural,genitive,4th,neuter,regular,\nērum,plural,genitive,5th,feminine,regular,\nīs,plural,dative,1st,feminine,regular,\nābus,plural,dative,1st,feminine,irregular,4\neis,plural,dative,1st,feminine,irregular,6\nīs,plural,dative,2nd,masculine feminine,regular,\nīs,plural,dative,2nd,neuter,regular,\nibus,plural,dative,3rd,masculine feminine,regular,\nibus,plural,dative,3rd,neuter,regular,\nibus,plural,dative,4th,masculine feminine,regular,\nubus,plural,dative,4th,masculine feminine,irregular,14\nibus,plural,dative,4th,neuter,regular,\nēbus,plural,dative,5th,feminine,regular,\nās,plural,accusative,1st,feminine,regular,\nōs,plural,accusative,2nd,masculine feminine,regular,\na,plural,accusative,2nd,neuter,regular,\nēs,plural,accusative,3rd,masculine feminine,regular,\nīs,plural,accusative,3rd,masculine feminine,irregular,11\nas,plural,accusative,3rd,masculine feminine,irregular,7\na,plural,accusative,3rd,neuter,regular,\nia,plural,accusative,3rd,neuter,irregular,11\nūs,plural,accusative,4th,masculine feminine,regular,\nua,plural,accusative,4th,neuter,regular,\nēs,plural,accusative,5th,feminine,regular,\nīs,plural,ablative,1st,feminine,regular,\nābus,plural,ablative,1st,feminine,irregular,4\neis,plural,ablative,1st,feminine,irregular,6\nīs,plural,ablative,2nd,masculine feminine,regular,\nīs,plural,ablative,2nd,neuter,regular,\nibus,plural,ablative,3rd,masculine feminine,regular,\nibus,plural,ablative,3rd,neuter,regular,\nibus,plural,ablative,4th,masculine feminine,regular,\nubus,plural,ablative,4th,masculine feminine,irregular,14\nibus,plural,ablative,4th,neuter,regular,\nēbus,plural,ablative,5th,feminine,regular,\nīs,plural,locative,1st,feminine,regular,\nīs,plural,locative,2nd,masculine feminine,regular,\nīs,plural,locative,2nd,neuter,regular,\nibus,plural,locative,3rd,masculine feminine,regular,\nibus,plural,locative,3rd,neuter,regular,\nibus,plural,locative,4th,masculine feminine,regular,\nibus,plural,locative,4th,neuter,regular,\nēbus,plural,locative,5th,feminine,regular,\nae,plural,vocative,1st,feminine,regular,\nī,plural,vocative,2nd,masculine feminine,regular,\na,plural,vocative,2nd,neuter,regular,\nēs,plural,vocative,3rd,masculine feminine,regular,\na,plural,vocative,3rd,neuter,regular,\nia,plural,vocative,3rd,neuter,irregular,11\nūs,plural,vocative,4th,masculine feminine,regular,\nua,plural,vocative,4th,neuter,regular,\nēs,plural,vocative,5th,feminine,regular,";
+var nounSuffixesCSV = "Ending,Number,Case,Declension,Gender,Type,Footnote\r\na,singular,nominative,1st,feminine,regular,\r\nē,singular,nominative,1st,feminine,irregular,\r\nēs,singular,nominative,1st,feminine,irregular,\r\nā,singular,nominative,1st,feminine,irregular,7\r\nus,singular,nominative,2nd,masculine feminine,regular,\r\ner,singular,nominative,2nd,masculine feminine,regular,\r\nir,singular,nominative,2nd,masculine feminine,regular,\r\n-,singular,nominative,2nd,masculine feminine,irregular,\r\nos,singular,nominative,2nd,masculine feminine,irregular,1\r\nōs,singular,nominative,2nd,masculine feminine,irregular,\r\nō,singular,nominative,2nd,masculine feminine,irregular,7\r\num,singular,nominative,2nd,neuter,regular,\r\nus,singular,nominative,2nd,neuter,irregular,10\r\non,singular,nominative,2nd,neuter,irregular,7\r\n-,singular,nominative,3rd,masculine feminine,regular,\r\nos,singular,nominative,3rd,masculine feminine,irregular,\r\nōn,singular,nominative,3rd,masculine feminine,irregular,7\r\n-,singular,nominative,3rd,neuter,regular,\r\nus,singular,nominative,4th,masculine feminine,regular,\r\nū,singular,nominative,4th,neuter,regular,\r\nēs,singular,nominative,5th,feminine,regular,\r\nae,singular,genitive,1st,feminine,regular,\r\nāī,singular,genitive,1st,feminine,irregular,1\r\nās,singular,genitive,1st,feminine,irregular,2\r\nēs,singular,genitive,1st,feminine,irregular,7\r\nī,singular,genitive,2nd,masculine feminine,regular,\r\nō,singular,genitive,2nd,masculine feminine,irregular,7\r\nī,singular,genitive,2nd,neuter,regular,\r\nis,singular,genitive,3rd,masculine feminine,regular,\r\nis,singular,genitive,3rd,neuter,regular,\r\nūs,singular,genitive,4th,masculine feminine,regular,\r\nuis,singular,genitive,4th,masculine feminine,irregular,1\r\nuos,singular,genitive,4th,masculine feminine,irregular,1\r\nī,singular,genitive,4th,masculine feminine,irregular,15\r\nūs,singular,genitive,4th,neuter,regular,\r\nēī,singular,genitive,5th,feminine,regular,\r\neī,singular,genitive,5th,feminine,regular,\r\nī,singular,genitive,5th,feminine,irregular,\r\nē,singular,genitive,5th,feminine,irregular,\r\nēs,singular,genitive,5th,feminine,irregular,6\r\nae,singular,dative,1st,feminine,regular,\r\nāī,singular,dative,1st,feminine,irregular,1\r\nō,singular,dative,2nd,masculine feminine,regular,\r\nō,singular,dative,2nd,neuter,regular,\r\nī,singular,dative,3rd,masculine feminine,regular,\r\ne,singular,dative,3rd,masculine feminine,irregular,17\r\nī,singular,dative,3rd,neuter,regular,\r\nūī,singular,dative,4th,masculine feminine,regular,\r\nū,singular,dative,4th,masculine feminine,regular,\r\nū,singular,dative,4th,neuter,regular,\r\nēī,singular,dative,5th,feminine,regular,\r\neī,singular,dative,5th,feminine,regular,\r\nī,singular,dative,5th,feminine,irregular,\r\nē,singular,dative,5th,feminine,irregular,6\r\nam,singular,accusative,1st,feminine,regular,\r\nēn,singular,accusative,1st,feminine,irregular,\r\nān,singular,accusative,1st,feminine,irregular,7\r\num,singular,accusative,2nd,masculine feminine,regular,\r\nom,singular,accusative,2nd,masculine feminine,irregular,1\r\nōn,singular,accusative,2nd,masculine feminine,irregular,7\r\num,singular,accusative,2nd,neuter,regular,\r\nus,singular,accusative,2nd,neuter,irregular,10\r\non,singular,accusative,2nd,neuter,irregular,7\r\nem,singular,accusative,3rd,masculine feminine,regular,\r\nim,singular,accusative,3rd,masculine feminine,irregular,11\r\na,singular,accusative,3rd,masculine feminine,irregular,7\r\n-,singular,accusative,3rd,neuter,regular,\r\num,singular,accusative,4th,masculine feminine,regular,\r\nū,singular,accusative,4th,neuter,regular,\r\nem,singular,accusative,5th,feminine,regular,\r\nā,singular,ablative,1st,feminine,regular,\r\nād,singular,ablative,1st,feminine,irregular,5\r\nē,singular,ablative,1st,feminine,irregular,7\r\nō,singular,ablative,2nd,masculine feminine,regular,\r\nōd,singular,ablative,2nd,masculine feminine,irregular,1\r\nō,singular,ablative,2nd,neuter,regular,\r\ne,singular,ablative,3rd,masculine feminine,regular,\r\nī,singular,ablative,3rd,masculine feminine,irregular,11\r\ne,singular,ablative,3rd,neuter,regular,\r\nī,singular,ablative,3rd,neuter,irregular,11\r\nū,singular,ablative,4th,masculine feminine,regular,\r\nūd,singular,ablative,4th,masculine feminine,irregular,1\r\nū,singular,ablative,4th,neuter,regular,\r\nē,singular,ablative,5th,feminine,regular,\r\nae,singular,locative,1st,feminine,regular,\r\nō,singular,locative,2nd,masculine feminine,regular,\r\nō,singular,locative,2nd,neuter,regular,\r\ne,singular,locative,3rd,masculine feminine,regular,\r\nī,singular,locative,3rd,masculine feminine,regular,\r\nī,singular,locative,3rd,neuter,regular,\r\nū,singular,locative,4th,masculine feminine,regular,\r\nū,singular,locative,4th,neuter,regular,\r\nē,singular,locative,5th,feminine,regular,\r\na,singular,vocative,1st,feminine,regular,\r\nē,singular,vocative,1st,feminine,irregular,\r\nā,singular,vocative,1st,feminine,irregular,7\r\ne,singular,vocative,2nd,masculine feminine,regular,\r\ner,singular,vocative,2nd,masculine feminine,regular,\r\nir,singular,vocative,2nd,masculine feminine,regular,\r\n-,singular,vocative,2nd,masculine feminine,irregular,\r\nī,singular,vocative,2nd,masculine feminine,irregular,8\r\nōs,singular,vocative,2nd,masculine feminine,irregular,\r\ne,singular,vocative,2nd,masculine feminine,irregular,7\r\num,singular,vocative,2nd,neuter,regular,\r\non,singular,vocative,2nd,neuter,irregular,7\r\n-,singular,vocative,3rd,masculine feminine,regular,\r\n-,singular,vocative,3rd,neuter,regular,\r\nus,singular,vocative,4th,masculine feminine,regular,\r\nū,singular,vocative,4th,neuter,regular,\r\nēs,singular,vocative,5th,feminine,regular,\r\nae,plural,nominative,1st,feminine,regular,\r\nī,plural,nominative,2nd,masculine feminine,regular,\r\noe,plural,nominative,2nd,masculine feminine,irregular,7 9\r\na,plural,nominative,2nd,neuter,regular,\r\nēs,plural,nominative,3rd,masculine feminine,regular,\r\nes,plural,nominative,3rd,masculine feminine,irregular,7\r\na,plural,nominative,3rd,neuter,regular,\r\nia,plural,nominative,3rd,neuter,irregular,11\r\nūs,plural,nominative,4th,masculine feminine,regular,\r\nua,plural,nominative,4th,neuter,regular,\r\nēs,plural,nominative,5th,feminine,regular,\r\nārum,plural,genitive,1st,feminine,regular,\r\num,plural,genitive,1st,feminine,irregular,3\r\nōrum,plural,genitive,2nd,masculine feminine,regular,\r\num,plural,genitive,2nd,masculine feminine,irregular,\r\nom,plural,genitive,2nd,masculine feminine,irregular,8\r\nōrum,plural,genitive,2nd,neuter,regular,\r\num,plural,genitive,2nd,neuter,irregular,\r\num,plural,genitive,3rd,masculine feminine,regular,\r\nium,plural,genitive,3rd,masculine feminine,irregular,11\r\nōn,plural,genitive,3rd,masculine feminine,irregular,7\r\num,plural,genitive,3rd,neuter,regular,\r\nium,plural,genitive,3rd,neuter,irregular,11\r\nuum,plural,genitive,4th,masculine feminine,regular,\r\num,plural,genitive,4th,masculine feminine,irregular,16\r\nuom,plural,genitive,4th,masculine feminine,irregular,1\r\nuum,plural,genitive,4th,neuter,regular,\r\nērum,plural,genitive,5th,feminine,regular,\r\nīs,plural,dative,1st,feminine,regular,\r\nābus,plural,dative,1st,feminine,irregular,4\r\neis,plural,dative,1st,feminine,irregular,6\r\nīs,plural,dative,2nd,masculine feminine,regular,\r\nīs,plural,dative,2nd,neuter,regular,\r\nibus,plural,dative,3rd,masculine feminine,regular,\r\nibus,plural,dative,3rd,neuter,regular,\r\nibus,plural,dative,4th,masculine feminine,regular,\r\nubus,plural,dative,4th,masculine feminine,irregular,14\r\nibus,plural,dative,4th,neuter,regular,\r\nēbus,plural,dative,5th,feminine,regular,\r\nās,plural,accusative,1st,feminine,regular,\r\nōs,plural,accusative,2nd,masculine feminine,regular,\r\na,plural,accusative,2nd,neuter,regular,\r\nēs,plural,accusative,3rd,masculine feminine,regular,\r\nīs,plural,accusative,3rd,masculine feminine,irregular,11\r\nas,plural,accusative,3rd,masculine feminine,irregular,7\r\na,plural,accusative,3rd,neuter,regular,\r\nia,plural,accusative,3rd,neuter,irregular,11\r\nūs,plural,accusative,4th,masculine feminine,regular,\r\nua,plural,accusative,4th,neuter,regular,\r\nēs,plural,accusative,5th,feminine,regular,\r\nīs,plural,ablative,1st,feminine,regular,\r\nābus,plural,ablative,1st,feminine,irregular,4\r\neis,plural,ablative,1st,feminine,irregular,6\r\nīs,plural,ablative,2nd,masculine feminine,regular,\r\nīs,plural,ablative,2nd,neuter,regular,\r\nibus,plural,ablative,3rd,masculine feminine,regular,\r\nibus,plural,ablative,3rd,neuter,regular,\r\nibus,plural,ablative,4th,masculine feminine,regular,\r\nubus,plural,ablative,4th,masculine feminine,irregular,14\r\nibus,plural,ablative,4th,neuter,regular,\r\nēbus,plural,ablative,5th,feminine,regular,\r\nīs,plural,locative,1st,feminine,regular,\r\nīs,plural,locative,2nd,masculine feminine,regular,\r\nīs,plural,locative,2nd,neuter,regular,\r\nibus,plural,locative,3rd,masculine feminine,regular,\r\nibus,plural,locative,3rd,neuter,regular,\r\nibus,plural,locative,4th,masculine feminine,regular,\r\nibus,plural,locative,4th,neuter,regular,\r\nēbus,plural,locative,5th,feminine,regular,\r\nae,plural,vocative,1st,feminine,regular,\r\nī,plural,vocative,2nd,masculine feminine,regular,\r\na,plural,vocative,2nd,neuter,regular,\r\nēs,plural,vocative,3rd,masculine feminine,regular,\r\na,plural,vocative,3rd,neuter,regular,\r\nia,plural,vocative,3rd,neuter,irregular,11\r\nūs,plural,vocative,4th,masculine feminine,regular,\r\nua,plural,vocative,4th,neuter,regular,\r\nēs,plural,vocative,5th,feminine,regular,";
 
-var nounFootnotesCSV = "Index,Text\n1,archaic (final s and m of os and om may be omitted in inscriptions)\n2,only in familiās\n3,especially in Greek patronymics and compounds in -gena and -cola.\n4,always in deābus and filiābus; rarely with other words to distinguish the female\n5,archaic\n6,rare\n7,\"may occur in words of Greek origin. The forms of many Greek nouns vary among the first, second and third declensions.\"\n8,proper names in ius and filius and genius\n9,poetic\n10,\"only pelagus, vīrus, and sometimes vulgus\"\n11,may occur with i-stems\n12,several nouns (most commonly domus) show forms of both second and fourth declensions\n13,\"some nouns also have forms from the first declension (eg materia, saevitia) or the third declension (eg requiēs, satiēs, plēbēs, famēs)\"\n14,\"Always in partus and tribus, usually in artus and lacus, sometimes in other words, eg portus and specus\"\n15,Often in names of plants and trees and in nouns ending in -tus\n16,When pronounced as one syllable\n17,early\n18,dies and meridies are masculine";
+var nounFootnotesCSV = "Index,Text\r\n1,archaic (final s and m of os and om may be omitted in inscriptions)\r\n2,only in familiās\r\n3,especially in Greek patronymics and compounds in -gena and -cola.\r\n4,always in deābus and filiābus; rarely with other words to distinguish the female\r\n5,archaic\r\n6,rare\r\n7,\"may occur in words of Greek origin. The forms of many Greek nouns vary among the first, second and third declensions.\"\r\n8,proper names in ius and filius and genius\r\n9,poetic\r\n10,\"only pelagus, vīrus, and sometimes vulgus\"\r\n11,may occur with i-stems\r\n12,several nouns (most commonly domus) show forms of both second and fourth declensions\r\n13,\"some nouns also have forms from the first declension (eg materia, saevitia) or the third declension (eg requiēs, satiēs, plēbēs, famēs)\"\r\n14,\"Always in partus and tribus, usually in artus and lacus, sometimes in other words, eg portus and specus\"\r\n15,Often in names of plants and trees and in nouns ending in -tus\r\n16,When pronounced as one syllable\r\n17,early\r\n18,dies and meridies are masculine";
 
-var adjectiveSuffixesCSV = "Ending,Number,Case,Declension,Gender,Type,Footnote\na,singular,nominative,1st 2nd,feminine,regular,\nus,singular,nominative,1st 2nd,masculine,regular,\num,singular,nominative,1st 2nd,neuter,regular,\nis,singular,nominative,3rd,feminine,regular,\n-,singular,nominative,3rd,feminine,irregular,6\n-,singular,nominative,3rd,masculine,regular,\nis,singular,nominative,3rd,masculine,irregular,5\ne,singular,nominative,3rd,neuter,regular,\n-,singular,nominative,3rd,neuter,irregular,6\nae,singular,genitive,1st 2nd,feminine,regular,\nīus,singular,genitive,1st 2nd,feminine,irregular,3\nī,singular,genitive,1st 2nd,masculine,regular,\nīus,singular,genitive,1st 2nd,masculine,irregular,3\nī,singular,genitive,1st 2nd,neuter,regular,\nīus,singular,genitive,1st 2nd,neuter,irregular,3\nis,singular,genitive,3rd,feminine,regular,\nis,singular,genitive,3rd,masculine,regular,\nis,singular,genitive,3rd,neuter,regular,\nae,singular,dative,1st 2nd,feminine,regular,\nī,singular,dative,1st 2nd,feminine,irregular,3\nō,singular,dative,1st 2nd,masculine,regular,\nī,singular,dative,1st 2nd,masculine,irregular,3\nō,singular,dative,1st 2nd,neuter,regular,\nī,singular,dative,1st 2nd,neuter,irregular,3\nī,singular,dative,3rd,feminine,regular,\nī,singular,dative,3rd,masculine,regular,\nī,singular,dative,3rd,neuter,regular,\nam,singular,accusative,1st 2nd,feminine,regular,\num,singular,accusative,1st 2nd,masculine,regular,\num,singular,accusative,1st 2nd,neuter,regular,\nem,singular,accusative,3rd,feminine,regular,\nem,singular,accusative,3rd,masculine,regular,\ne,singular,accusative,3rd,neuter,regular,\n-,singular,accusative,3rd,neuter,irregular,6\nā,singular,ablative,1st 2nd,feminine,regular,\nō,singular,ablative,1st 2nd,feminine,irregular,4\nō,singular,ablative,1st 2nd,masculine,regular,\nō,singular,ablative,1st 2nd,neuter,regular,\nī,singular,ablative,3rd,feminine,regular,\ne,singular,ablative,3rd,feminine,irregular,7\nī,singular,ablative,3rd,masculine,regular,\ne,singular,ablative,3rd,masculine,irregular,7\nī,singular,ablative,3rd,neuter,regular,\nae,singular,locative,1st 2nd,feminine,regular,\nī,singular,locative,1st 2nd,masculine,regular,\nī,singular,locative,1st 2nd,neuter,regular,\nī,singular,locative,3rd,feminine,regular,\ne,singular,locative,3rd,feminine,irregular,7\nī,singular,locative,3rd,masculine,regular,\nī,singular,locative,3rd,neuter,regular,\na,singular,vocative,1st 2nd,feminine,regular,\ne,singular,vocative,1st 2nd,masculine,regular,\nī,singular,vocative,1st 2nd,masculine,irregular,\num,singular,vocative,1st 2nd,neuter,regular,\nis,singular,vocative,3rd,feminine,regular,\n-,singular,vocative,3rd,masculine,regular,\ne,singular,vocative,3rd,neuter,regular,\n-,singular,vocative,3rd,neuter,irregular,6\nae,plural,nominative,1st 2nd,feminine,regular,\nī,plural,nominative,1st 2nd,masculine,regular,\na,plural,nominative,1st 2nd,neuter,regular,\nēs,plural,nominative,3rd,feminine,regular,\nēs,plural,nominative,3rd,masculine,regular,\nia,plural,nominative,3rd,neuter,regular,\nārum,plural,genitive,1st 2nd,feminine,regular,\nōrum,plural,genitive,1st 2nd,masculine,regular,\nōrum,plural,genitive,1st 2nd,neuter,regular,\nium,plural,genitive,3rd,feminine,regular,\num,plural,genitive,3rd,feminine,irregular,8\nium,plural,genitive,3rd,masculine,regular,\num,plural,genitive,3rd,masculine,irregular,8\nium,plural,genitive,3rd,neuter,regular,\num,plural,genitive,3rd,neuter,irregular,8\nīs,plural,dative,1st 2nd,feminine,regular,\nīs,plural,dative,1st 2nd,masculine,regular,\nīs,plural,dative,1st 2nd,neuter,regular,\nibus,plural,dative,3rd,feminine,regular,\nibus,plural,dative,3rd,masculine,regular,\nibus,plural,dative,3rd,neuter,regular,\nās,plural,accusative,1st 2nd,feminine,regular,\nōs,plural,accusative,1st 2nd,masculine,regular,\na,plural,accusative,1st 2nd,neuter,regular,\nīs,plural,accusative,3rd,feminine,regular,\nēs,plural,accusative,3rd,feminine,irregular,9\nīs,plural,accusative,3rd,masculine,regular,\nēs,plural,accusative,3rd,masculine,irregular,9\nia,plural,accusative,3rd,neuter,regular,\nīs,plural,ablative,1st 2nd,feminine,regular,\nīs,plural,ablative,1st 2nd,masculine,regular,\nīs,plural,ablative,1st 2nd,neuter,regular,\nibus,plural,ablative,3rd,feminine,regular,\nibus,plural,ablative,3rd,masculine,regular,\nibus,plural,ablative,3rd,neuter,regular,\nīs,plural,locative,1st 2nd,feminine,regular,\nīs,plural,locative,1st 2nd,masculine,regular,\nīs,plural,locative,1st 2nd,neuter,regular,\nibus,plural,locative,3rd,feminine,regular,\nibus,plural,locative,3rd,masculine,regular,\nibus,plural,locative,3rd,neuter,regular,\nae,plural,vocative,1st 2nd,feminine,regular,\nī,plural,vocative,1st 2nd,masculine,regular,\na,plural,vocative,1st 2nd,neuter,regular,\nēs,plural,vocative,3rd,feminine,regular,\nēs,plural,vocative,3rd,masculine,regular,\nia,plural,vocative,3rd,neuter,regular,";
+var adjectiveSuffixesCSV = "Ending,Number,Case,Declension,Gender,Type,Footnote\r\na,singular,nominative,1st 2nd,feminine,regular,\r\nus,singular,nominative,1st 2nd,masculine,regular,\r\num,singular,nominative,1st 2nd,neuter,regular,\r\nis,singular,nominative,3rd,feminine,regular,\r\n-,singular,nominative,3rd,feminine,irregular,6\r\n-,singular,nominative,3rd,masculine,regular,\r\nis,singular,nominative,3rd,masculine,irregular,5\r\ne,singular,nominative,3rd,neuter,regular,\r\n-,singular,nominative,3rd,neuter,irregular,6\r\nae,singular,genitive,1st 2nd,feminine,regular,\r\nīus,singular,genitive,1st 2nd,feminine,irregular,3\r\nī,singular,genitive,1st 2nd,masculine,regular,\r\nīus,singular,genitive,1st 2nd,masculine,irregular,3\r\nī,singular,genitive,1st 2nd,neuter,regular,\r\nīus,singular,genitive,1st 2nd,neuter,irregular,3\r\nis,singular,genitive,3rd,feminine,regular,\r\nis,singular,genitive,3rd,masculine,regular,\r\nis,singular,genitive,3rd,neuter,regular,\r\nae,singular,dative,1st 2nd,feminine,regular,\r\nī,singular,dative,1st 2nd,feminine,irregular,3\r\nō,singular,dative,1st 2nd,masculine,regular,\r\nī,singular,dative,1st 2nd,masculine,irregular,3\r\nō,singular,dative,1st 2nd,neuter,regular,\r\nī,singular,dative,1st 2nd,neuter,irregular,3\r\nī,singular,dative,3rd,feminine,regular,\r\nī,singular,dative,3rd,masculine,regular,\r\nī,singular,dative,3rd,neuter,regular,\r\nam,singular,accusative,1st 2nd,feminine,regular,\r\num,singular,accusative,1st 2nd,masculine,regular,\r\num,singular,accusative,1st 2nd,neuter,regular,\r\nem,singular,accusative,3rd,feminine,regular,\r\nem,singular,accusative,3rd,masculine,regular,\r\ne,singular,accusative,3rd,neuter,regular,\r\n-,singular,accusative,3rd,neuter,irregular,6\r\nā,singular,ablative,1st 2nd,feminine,regular,\r\nō,singular,ablative,1st 2nd,feminine,irregular,4\r\nō,singular,ablative,1st 2nd,masculine,regular,\r\nō,singular,ablative,1st 2nd,neuter,regular,\r\nī,singular,ablative,3rd,feminine,regular,\r\ne,singular,ablative,3rd,feminine,irregular,7\r\nī,singular,ablative,3rd,masculine,regular,\r\ne,singular,ablative,3rd,masculine,irregular,7\r\nī,singular,ablative,3rd,neuter,regular,\r\nae,singular,locative,1st 2nd,feminine,regular,\r\nī,singular,locative,1st 2nd,masculine,regular,\r\nī,singular,locative,1st 2nd,neuter,regular,\r\nī,singular,locative,3rd,feminine,regular,\r\ne,singular,locative,3rd,feminine,irregular,7\r\nī,singular,locative,3rd,masculine,regular,\r\nī,singular,locative,3rd,neuter,regular,\r\na,singular,vocative,1st 2nd,feminine,regular,\r\ne,singular,vocative,1st 2nd,masculine,regular,\r\nī,singular,vocative,1st 2nd,masculine,irregular,\r\num,singular,vocative,1st 2nd,neuter,regular,\r\nis,singular,vocative,3rd,feminine,regular,\r\n-,singular,vocative,3rd,masculine,regular,\r\ne,singular,vocative,3rd,neuter,regular,\r\n-,singular,vocative,3rd,neuter,irregular,6\r\nae,plural,nominative,1st 2nd,feminine,regular,\r\nī,plural,nominative,1st 2nd,masculine,regular,\r\na,plural,nominative,1st 2nd,neuter,regular,\r\nēs,plural,nominative,3rd,feminine,regular,\r\nēs,plural,nominative,3rd,masculine,regular,\r\nia,plural,nominative,3rd,neuter,regular,\r\nārum,plural,genitive,1st 2nd,feminine,regular,\r\nōrum,plural,genitive,1st 2nd,masculine,regular,\r\nōrum,plural,genitive,1st 2nd,neuter,regular,\r\nium,plural,genitive,3rd,feminine,regular,\r\num,plural,genitive,3rd,feminine,irregular,8\r\nium,plural,genitive,3rd,masculine,regular,\r\num,plural,genitive,3rd,masculine,irregular,8\r\nium,plural,genitive,3rd,neuter,regular,\r\num,plural,genitive,3rd,neuter,irregular,8\r\nīs,plural,dative,1st 2nd,feminine,regular,\r\nīs,plural,dative,1st 2nd,masculine,regular,\r\nīs,plural,dative,1st 2nd,neuter,regular,\r\nibus,plural,dative,3rd,feminine,regular,\r\nibus,plural,dative,3rd,masculine,regular,\r\nibus,plural,dative,3rd,neuter,regular,\r\nās,plural,accusative,1st 2nd,feminine,regular,\r\nōs,plural,accusative,1st 2nd,masculine,regular,\r\na,plural,accusative,1st 2nd,neuter,regular,\r\nīs,plural,accusative,3rd,feminine,regular,\r\nēs,plural,accusative,3rd,feminine,irregular,9\r\nīs,plural,accusative,3rd,masculine,regular,\r\nēs,plural,accusative,3rd,masculine,irregular,9\r\nia,plural,accusative,3rd,neuter,regular,\r\nīs,plural,ablative,1st 2nd,feminine,regular,\r\nīs,plural,ablative,1st 2nd,masculine,regular,\r\nīs,plural,ablative,1st 2nd,neuter,regular,\r\nibus,plural,ablative,3rd,feminine,regular,\r\nibus,plural,ablative,3rd,masculine,regular,\r\nibus,plural,ablative,3rd,neuter,regular,\r\nīs,plural,locative,1st 2nd,feminine,regular,\r\nīs,plural,locative,1st 2nd,masculine,regular,\r\nīs,plural,locative,1st 2nd,neuter,regular,\r\nibus,plural,locative,3rd,feminine,regular,\r\nibus,plural,locative,3rd,masculine,regular,\r\nibus,plural,locative,3rd,neuter,regular,\r\nae,plural,vocative,1st 2nd,feminine,regular,\r\nī,plural,vocative,1st 2nd,masculine,regular,\r\na,plural,vocative,1st 2nd,neuter,regular,\r\nēs,plural,vocative,3rd,feminine,regular,\r\nēs,plural,vocative,3rd,masculine,regular,\r\nia,plural,vocative,3rd,neuter,regular,";
 
-var adjectiveFootnotesCSV = "Index,Text\n1,\"Adjectives agree with the noun they modify in gender, number and case.\"\n2,Adjectives are inflected according to either\n3,\"Only nullus, sōlus, alius (alia, aliud), tōtus, ūllus, ūnus, alter, neuter (neutra,\n            neutrum) and uter (utra, utrum).\"\n4,In a few adjectives of Greek origin.\n5,\"The \"\"two-ending\"\" adjectives use \"\"-is\"\", for both masculine and feminine nominative\n            singular.\"\n6,\"The \"\"one-ending\"\" adjectives use the same consonant ending for all three genders in the\n            nominative singular and the neuter accusative and vocative singular.\"\n7,\"An ablative singular in \"\"e\"\" is common in one-ending adjectives, but is usually confined to\n            poetry in three and two-ending adjectives.\"\n8,\"In comparatives, poetry and some one-ending adjectives.\"\n9,Chiefly in comparatives.";
+var adjectiveFootnotesCSV = "Index,Text\r\n1,\"Adjectives agree with the noun they modify in gender, number and case.\"\r\n2,Adjectives are inflected according to either\r\n3,\"Only nullus, sōlus, alius (alia, aliud), tōtus, ūllus, ūnus, alter, neuter (neutra,\r\n            neutrum) and uter (utra, utrum).\"\r\n4,In a few adjectives of Greek origin.\r\n5,\"The \"\"two-ending\"\" adjectives use \"\"-is\"\", for both masculine and feminine nominative\r\n            singular.\"\r\n6,\"The \"\"one-ending\"\" adjectives use the same consonant ending for all three genders in the\r\n            nominative singular and the neuter accusative and vocative singular.\"\r\n7,\"An ablative singular in \"\"e\"\" is common in one-ending adjectives, but is usually confined to\r\n            poetry in three and two-ending adjectives.\"\r\n8,\"In comparatives, poetry and some one-ending adjectives.\"\r\n9,Chiefly in comparatives.";
 
-var verbSuffixesCSV = "Ending,Conjugation,Voice,Mood,Tense,Number,Person,Type,Footnote\nō,1st,active,indicative,present,singular,1st,regular,\nās,1st,active,indicative,present,singular,2nd,regular,\nat,1st,active,indicative,present,singular,3rd,regular,\nāmus,1st,active,indicative,present,plural,1st,regular,\nātis,1st,active,indicative,present,plural,2nd,regular,\nant,1st,active,indicative,present,plural,3rd,regular,\nem,1st,active,subjunctive,present,singular,1st,regular,\nēs,1st,active,subjunctive,present,singular,2nd,regular,\net,1st,active,subjunctive,present,singular,3rd,regular,\nēmus,1st,active,subjunctive,present,plural,1st,regular,\nētis,1st,active,subjunctive,present,plural,2nd,regular,\nent,1st,active,subjunctive,present,plural,3rd,regular,\neō,2nd,active,indicative,present,singular,1st,regular,\nēs,2nd,active,indicative,present,singular,2nd,regular,\nēt,2nd,active,indicative,present,singular,3rd,regular,\nēmus,2nd,active,indicative,present,plural,1st,regular,\nētis,2nd,active,indicative,present,plural,2nd,regular,\nent,2nd,active,indicative,present,plural,3rd,regular,\neam,2nd,active,subjunctive,present,singular,1st,regular,\neās,2nd,active,subjunctive,present,singular,2nd,regular,\neat,2nd,active,subjunctive,present,singular,3rd,regular,\neāmus,2nd,active,subjunctive,present,plural,1st,regular,\neātis,2nd,active,subjunctive,present,plural,2nd,regular,\neant,2nd,active,subjunctive,present,plural,3rd,regular,\nō,3rd,active,indicative,present,singular,1st,regular,\nis,3rd,active,indicative,present,singular,2nd,regular,\nit,3rd,active,indicative,present,singular,3rd,regular,\nimus,3rd,active,indicative,present,plural,1st,regular,\nitis,3rd,active,indicative,present,plural,2nd,regular,\nunt,3rd,active,indicative,present,plural,3rd,regular,\nam,3rd,active,subjunctive,present,singular,1st,regular,\nās,3rd,active,subjunctive,present,singular,2nd,regular,\nat,3rd,active,subjunctive,present,singular,3rd,regular,\nāmus,3rd,active,subjunctive,present,plural,1st,regular,\nātis,3rd,active,subjunctive,present,plural,2nd,regular,\nant,3rd,active,subjunctive,present,plural,3rd,regular,\niō,4th,active,indicative,present,singular,1st,regular,\nīs,4th,active,indicative,present,singular,2nd,regular,\nit,4th,active,indicative,present,singular,3rd,regular,\nīmus,4th,active,indicative,present,plural,1st,regular,\nītis,4th,active,indicative,present,plural,2nd,regular,\niunt,4th,active,indicative,present,plural,3rd,regular,\niam,4th,active,subjunctive,present,singular,1st,regular,\niās,4th,active,subjunctive,present,singular,2nd,regular,\niat,4th,active,subjunctive,present,singular,3rd,regular,\niāmus,4th,active,subjunctive,present,plural,1st,regular,\niāatis,4th,active,subjunctive,present,plural,2nd,regular,\niant,4th,active,subjunctive,present,plural,3rd,regular,\nābam,1st,active,indicative,imperfect,singular,1st,regular,\nābas,1st,active,indicative,imperfect,singular,2nd,regular,\nābat,1st,active,indicative,imperfect,singular,3rd,regular,\nābāmus,1st,active,indicative,imperfect,plural,1st,regular,\nābātis,1st,active,indicative,imperfect,plural,2nd,regular,\nābant,1st,active,indicative,imperfect,plural,3rd,regular,\nārem,1st,active,subjunctive,imperfect,singular,1st,regular,\nārēs,1st,active,subjunctive,imperfect,singular,2nd,regular,\nāret,1st,active,subjunctive,imperfect,singular,3rd,regular,\nārēmus,1st,active,subjunctive,imperfect,plural,1st,regular,\nārētis,1st,active,subjunctive,imperfect,plural,2nd,regular,\nārent,1st,active,subjunctive,imperfect,plural,3rd,regular,\nēbam,2nd,active,indicative,imperfect,singular,1st,regular,\nēbās,2nd,active,indicative,imperfect,singular,2nd,regular,\nēbat,2nd,active,indicative,imperfect,singular,3rd,regular,\nēbāmus,2nd,active,indicative,imperfect,plural,1st,regular,\nēbātis,2nd,active,indicative,imperfect,plural,2nd,regular,\nēbant,2nd,active,indicative,imperfect,plural,3rd,regular,\nērem,2nd,active,subjunctive,imperfect,singular,1st,regular,\nērēs,2nd,active,subjunctive,imperfect,singular,2nd,regular,\nēret,2nd,active,subjunctive,imperfect,singular,3rd,regular,\nērēmus,2nd,active,subjunctive,imperfect,plural,1st,regular,\nērētis,2nd,active,subjunctive,imperfect,plural,2nd,regular,\nērēnt,2nd,active,subjunctive,imperfect,plural,3rd,regular,\nēbas,3rd,active,indicative,imperfect,singular,1st,regular,\nēbāt,3rd,active,indicative,imperfect,singular,2nd,regular,\nēbat,3rd,active,indicative,imperfect,singular,3rd,regular,\nēbāmus,3rd,active,indicative,imperfect,plural,1st,regular,\nēbātis,3rd,active,indicative,imperfect,plural,2nd,regular,\nēbant,3rd,active,indicative,imperfect,plural,3rd,regular,\nerem,3rd,active,subjunctive,imperfect,singular,1st,regular,\nerēs,3rd,active,subjunctive,imperfect,singular,2nd,regular,\neret,3rd,active,subjunctive,imperfect,singular,3rd,regular,\nerēmus,3rd,active,subjunctive,imperfect,plural,1st,regular,\nerētis,3rd,active,subjunctive,imperfect,plural,2nd,regular,\nerent,3rd,active,subjunctive,imperfect,plural,3rd,regular,\niēbam,4th,active,indicative,imperfect,singular,1st,regular,\nībam,4th,active,indicative,imperfect,singular,1st,irregular,2\niēbas,4th,active,indicative,imperfect,singular,2nd,regular,\nības,4th,active,indicative,imperfect,singular,2nd,irregular,\niēbat,4th,active,indicative,imperfect,singular,3rd,regular,\nībat,4th,active,indicative,imperfect,singular,3rd,irregular,\niēbāmus,4th,active,indicative,imperfect,plural,1st,regular,\nībāmus,4th,active,indicative,imperfect,plural,1st,irregular,\niēbātis,4th,active,indicative,imperfect,plural,2nd,regular,\nībātis,4th,active,indicative,imperfect,plural,2nd,irregular,\niēbant,4th,active,indicative,imperfect,plural,3rd,regular,\nībant,4th,active,indicative,imperfect,plural,3rd,irregular,\nīrem,4th,active,subjunctive,imperfect,singular,1st,regular,\nīrēs,4th,active,subjunctive,imperfect,singular,2nd,regular,\nīret,4th,active,subjunctive,imperfect,singular,3rd,regular,\nīrēmus,4th,active,subjunctive,imperfect,plural,1st,regular,\nīrētis,4th,active,subjunctive,imperfect,plural,2nd,regular,\nīrēnt,4th,active,subjunctive,imperfect,plural,3rd,regular,\nābo,1st,active,indicative,future,singular,1st,regular,\nābis,1st,active,indicative,future,singular,2nd,regular,\nābit,1st,active,indicative,future,singular,3rd,regular,\nābimus,1st,active,indicative,future,plural,1st,regular,\nābitis,1st,active,indicative,future,plural,2nd,regular,\nābunt,1st,active,indicative,future,plural,3rd,regular,\n,1st,active,subjunctive,future,singular,1st,,\n,1st,active,subjunctive,future,singular,2nd,,\n,1st,active,subjunctive,future,singular,3rd,,\n,1st,active,subjunctive,future,plural,1st,,\n,1st,active,subjunctive,future,plural,2nd,,\n,1st,active,subjunctive,future,plural,3rd,,\nēbō,2nd,active,indicative,future,singular,1st,regular,\nēbis,2nd,active,indicative,future,singular,2nd,regular,\nēbit,2nd,active,indicative,future,singular,3rd,regular,\nēbimus,2nd,active,indicative,future,plural,1st,regular,\nēbitis,2nd,active,indicative,future,plural,2nd,regular,\nēbunt,2nd,active,indicative,future,plural,3rd,regular,\n,2nd,active,subjunctive,future,singular,1st,regular,\n,2nd,active,subjunctive,future,singular,2nd,,\n,2nd,active,subjunctive,future,singular,3rd,,\n,2nd,active,subjunctive,future,plural,1st,,\n,2nd,active,subjunctive,future,plural,2nd,,\n,2nd,active,subjunctive,future,plural,3rd,,\nam,3rd,active,indicative,future,singular,1st,regular,\nēs,3rd,active,indicative,future,singular,2nd,regular,\net,3rd,active,indicative,future,singular,3rd,regular,\nēmus,3rd,active,indicative,future,plural,1st,regular,\nētis,3rd,active,indicative,future,plural,2nd,regular,\nent,3rd,active,indicative,future,plural,3rd,regular,\n,3rd,active,subjunctive,future,singular,1st,,\n,3rd,active,subjunctive,future,singular,2nd,,\n,3rd,active,subjunctive,future,singular,3rd,,\n,3rd,active,subjunctive,future,plural,1st,,\n,3rd,active,subjunctive,future,plural,2nd,,\n,3rd,active,subjunctive,future,plural,3rd,,\niam,4th,active,indicative,future,singular,1st,regular,\nībō,4th,active,indicative,future,singular,1st,irregular,2\niēs,4th,active,indicative,future,singular,2nd,regular,\nībis,4th,active,indicative,future,singular,2nd,irregular,\niet,4th,active,indicative,future,singular,3rd,regular,\nībit,4th,active,indicative,future,singular,3rd,irregular,\niēmus,4th,active,indicative,future,plural,1st,regular,\nībimus,4th,active,indicative,future,plural,1st,irregular,\niētis,4th,active,indicative,future,plural,2nd,regular,\nībitis,4th,active,indicative,future,plural,2nd,irregular,\nient,4th,active,indicative,future,plural,3rd,regular,\nībunt,4th,active,indicative,future,plural,3rd,irregular,\n,4th,active,subjunctive,future,singular,1st,,\n,4th,active,subjunctive,future,singular,2nd,,\n,4th,active,subjunctive,future,singular,3rd,,\n,4th,active,subjunctive,future,plural,1st,,\n,4th,active,subjunctive,future,plural,2nd,,\n,4th,active,subjunctive,future,plural,3rd,,\nāvī,1st,active,indicative,perfect,singular,1st,regular,\nāvistī,1st,active,indicative,perfect,singular,2nd,regular,\nāvit,1st,active,indicative,perfect,singular,3rd,regular,\nāvimus,1st,active,indicative,perfect,plural,1st,regular,\nāvistis,1st,active,indicative,perfect,plural,2nd,regular,\nāvērunt,1st,active,indicative,perfect,plural,3rd,regular,\nāvēre,1st,active,indicative,perfect,plural,3rd,irregular,6\nāverim,1st,active,subjunctive,perfect,singular,1st,regular,\nāveris,1st,active,subjunctive,perfect,singular,2nd,regular,\nāverit,1st,active,subjunctive,perfect,singular,3rd,regular,\nāverimus,1st,active,subjunctive,perfect,plural,1st,regular,\nāveritis,1st,active,subjunctive,perfect,plural,2nd,regular,\nāverint,1st,active,subjunctive,perfect,plural,3rd,regular,\nvī,2nd,active,indicative,perfect,singular,1st,regular,\nvistī,2nd,active,indicative,perfect,singular,2nd,regular,\nvit,2nd,active,indicative,perfect,singular,3rd,regular,\nvimus,2nd,active,indicative,perfect,plural,1st,regular,\nvistis,2nd,active,indicative,perfect,plural,2nd,regular,\nvērunt,2nd,active,indicative,perfect,plural,3rd,regular,\nvēre,2nd,active,indicative,perfect,plural,3rd,irregular,6\nverim,2nd,active,subjunctive,perfect,singular,1st,regular,\nveris,2nd,active,subjunctive,perfect,singular,2nd,regular,\nverit,2nd,active,subjunctive,perfect,singular,3rd,regular,\nverimus,2nd,active,subjunctive,perfect,plural,1st,regular,\nveritis,2nd,active,subjunctive,perfect,plural,2nd,regular,\nverint,2nd,active,subjunctive,perfect,plural,3rd,regular,\nī,3rd,active,indicative,perfect,singular,1st,regular,\nistī,3rd,active,indicative,perfect,singular,2nd,regular,\nit,3rd,active,indicative,perfect,singular,3rd,regular,\nimus,3rd,active,indicative,perfect,plural,1st,regular,\nistis,3rd,active,indicative,perfect,plural,2nd,regular,\nērunt,3rd,active,indicative,perfect,plural,3rd,regular,\nēre,3rd,active,indicative,perfect,plural,3rd,irregular,6\nerim,3rd,active,subjunctive,perfect,singular,1st,regular,\neris,3rd,active,subjunctive,perfect,singular,2nd,regular,\nerit,3rd,active,subjunctive,perfect,singular,3rd,regular,\nerimus,3rd,active,subjunctive,perfect,plural,1st,regular,\neritis,3rd,active,subjunctive,perfect,plural,2nd,regular,\nerint,3rd,active,subjunctive,perfect,plural,3rd,regular,\nīvi,4th,active,indicative,perfect,singular,1st,regular,\nīvistī,4th,active,indicative,perfect,singular,2nd,regular,\nīvit,4th,active,indicative,perfect,singular,3rd,regular,\nīvimus,4th,active,indicative,perfect,plural,1st,regular,\nīvistis,4th,active,indicative,perfect,plural,2nd,regular,\nīvērunt,4th,active,indicative,perfect,plural,3rd,regular,\nīvēre,4th,active,indicative,perfect,plural,3rd,irregular,6\nīverim,4th,active,subjunctive,perfect,singular,1st,regular,\niveris,4th,active,subjunctive,perfect,singular,2nd,regular,\nīverit,4th,active,subjunctive,perfect,singular,3rd,regular,\nīverimus,4th,active,subjunctive,perfect,plural,1st,regular,\nīveritis,4th,active,subjunctive,perfect,plural,2nd,regular,\nīverint,4th,active,subjunctive,perfect,plural,3rd,regular,\nāveram,1st,active,indicative,pluperfect,singular,1st,regular,\nāverās,1st,active,indicative,pluperfect,singular,2nd,regular,\nāverat,1st,active,indicative,pluperfect,singular,3rd,regular,\nāverāmus,1st,active,indicative,pluperfect,plural,1st,regular,\nāverātis,1st,active,indicative,pluperfect,plural,2nd,regular,\nāverant,1st,active,indicative,pluperfect,plural,3rd,regular,\nāvissem,1st,active,subjunctive,pluperfect,singular,1st,regular,\nāvissēs,1st,active,subjunctive,pluperfect,singular,2nd,regular,\nāvisset,1st,active,subjunctive,pluperfect,singular,3rd,regular,\nāvissēm,1st,active,subjunctive,pluperfect,plural,1st,regular,\nāvissēs,1st,active,subjunctive,pluperfect,plural,2nd,regular,\nāvisset,1st,active,subjunctive,pluperfect,plural,3rd,regular,\nveram,2nd,active,indicative,pluperfect,singular,1st,regular,\nverās,2nd,active,indicative,pluperfect,singular,2nd,regular,\nverat,2nd,active,indicative,pluperfect,singular,3rd,regular,\nverāmus,2nd,active,indicative,pluperfect,plural,1st,regular,\nverātis,2nd,active,indicative,pluperfect,plural,2nd,regular,\nverant,2nd,active,indicative,pluperfect,plural,3rd,regular,\nvissem,2nd,active,subjunctive,pluperfect,singular,1st,regular,\nvissēs,2nd,active,subjunctive,pluperfect,singular,2nd,regular,\nvisset,2nd,active,subjunctive,pluperfect,singular,3rd,regular,\nvissēmus,2nd,active,subjunctive,pluperfect,plural,1st,regular,\nvissētis,2nd,active,subjunctive,pluperfect,plural,2nd,regular,\nvissent,2nd,active,subjunctive,pluperfect,plural,3rd,regular,\neram,3rd,active,indicative,pluperfect,singular,1st,regular,\nerās,3rd,active,indicative,pluperfect,singular,2nd,regular,\nerat,3rd,active,indicative,pluperfect,singular,3rd,regular,\nerāmus,3rd,active,indicative,pluperfect,plural,1st,regular,\nerātis,3rd,active,indicative,pluperfect,plural,2nd,regular,\nerant,3rd,active,indicative,pluperfect,plural,3rd,regular,\nissem,3rd,active,subjunctive,pluperfect,singular,1st,regular,\nissēs,3rd,active,subjunctive,pluperfect,singular,2nd,regular,\nisset,3rd,active,subjunctive,pluperfect,singular,3rd,regular,\nissēmus,3rd,active,subjunctive,pluperfect,plural,1st,regular,\nissētis,3rd,active,subjunctive,pluperfect,plural,2nd,regular,\nissent,3rd,active,subjunctive,pluperfect,plural,3rd,regular,\nīveram,4th,active,indicative,pluperfect,singular,1st,regular,\nīverās,4th,active,indicative,pluperfect,singular,2nd,regular,\nīverat,4th,active,indicative,pluperfect,singular,3rd,regular,\nīverāmus,4th,active,indicative,pluperfect,plural,1st,regular,\nīverātis,4th,active,indicative,pluperfect,plural,2nd,regular,\nīverant,4th,active,indicative,pluperfect,plural,3rd,regular,\nīvissem,4th,active,subjunctive,pluperfect,singular,1st,regular,\nīvissēs,4th,active,subjunctive,pluperfect,singular,2nd,regular,\nīvisset,4th,active,subjunctive,pluperfect,singular,3rd,regular,\nīvissēmus,4th,active,subjunctive,pluperfect,plural,1st,regular,\nīvissētis,4th,active,subjunctive,pluperfect,plural,2nd,regular,\nīvissent,4th,active,subjunctive,pluperfect,plural,3rd,regular,\nāverō,1st,active,indicative,future_perfect,singular,1st,regular,\nāveris,1st,active,indicative,future_perfect,singular,2nd,regular,\nāverit,1st,active,indicative,future_perfect,singular,3rd,regular,\nāverimus,1st,active,indicative,future_perfect,plural,1st,regular,\nāveritis,1st,active,indicative,future_perfect,plural,2nd,regular,\nāverint,1st,active,indicative,future_perfect,plural,3rd,regular,\n,1st,active,subjunctive,future_perfect,singular,1st,,\n,1st,active,subjunctive,future_perfect,singular,2nd,,\n,1st,active,subjunctive,future_perfect,singular,3rd,,\n,1st,active,subjunctive,future_perfect,plural,1st,,\n,1st,active,subjunctive,future_perfect,plural,2nd,,\n,1st,active,subjunctive,future_perfect,plural,3rd,,\nverō,2nd,active,indicative,future_perfect,singular,1st,regular,\nvēris,2nd,active,indicative,future_perfect,singular,2nd,regular,\nvērit,2nd,active,indicative,future_perfect,singular,3rd,regular,\nvērimus,2nd,active,indicative,future_perfect,plural,1st,regular,\nvēritis,2nd,active,indicative,future_perfect,plural,2nd,regular,\nvērint,2nd,active,indicative,future_perfect,plural,3rd,regular,\n,2nd,active,subjunctive,future_perfect,singular,1st,,\n,2nd,active,subjunctive,future_perfect,singular,2nd,,\n,2nd,active,subjunctive,future_perfect,singular,3rd,,\n,2nd,active,subjunctive,future_perfect,plural,1st,,\n,2nd,active,subjunctive,future_perfect,plural,2nd,,\n,2nd,active,subjunctive,future_perfect,plural,3rd,,\nerō,3rd,active,indicative,future_perfect,singular,1st,regular,\neris,3rd,active,indicative,future_perfect,singular,2nd,regular,\nerit,3rd,active,indicative,future_perfect,singular,3rd,regular,\nerimus,3rd,active,indicative,future_perfect,plural,1st,regular,\neritis,3rd,active,indicative,future_perfect,plural,2nd,regular,\nerint,3rd,active,indicative,future_perfect,plural,3rd,regular,\n,3rd,active,subjunctive,future_perfect,singular,1st,,\n,3rd,active,subjunctive,future_perfect,singular,2nd,,\n,3rd,active,subjunctive,future_perfect,singular,3rd,,\n,3rd,active,subjunctive,future_perfect,plural,1st,,\n,3rd,active,subjunctive,future_perfect,plural,2nd,,\n,3rd,active,subjunctive,future_perfect,plural,3rd,,\nīverō,4th,active,indicative,future_perfect,singular,1st,regular,\nīveris,4th,active,indicative,future_perfect,singular,2nd,regular,\nīverit,4th,active,indicative,future_perfect,singular,3rd,regular,\nīverimus,4th,active,indicative,future_perfect,plural,1st,regular,\nīveritis,4th,active,indicative,future_perfect,plural,2nd,regular,\nīverint,4th,active,indicative,future_perfect,plural,3rd,regular,\n,4th,active,subjunctive,future_perfect,singular,1st,,\n,4th,active,subjunctive,future_perfect,singular,2nd,,\n,4th,active,subjunctive,future_perfect,singular,3rd,,\n,4th,active,subjunctive,future_perfect,plural,1st,,\n,4th,active,subjunctive,future_perfect,plural,2nd,,\n,4th,active,subjunctive,future_perfect,plural,3rd,,\nor,1st,passive,indicative,present,singular,1st,regular,\nāris,1st,passive,indicative,present,singular,2nd,regular,\nāre,1st,passive,indicative,present,singular,2nd,irregular,5\nātur,1st,passive,indicative,present,singular,3rd,regular,\nāmur,1st,passive,indicative,present,plural,1st,regular,\nāminiī,1st,passive,indicative,present,plural,2nd,regular,\nantur,1st,passive,indicative,present,plural,3rd,regular,\ner,1st,passive,subjunctive,present,singular,1st,regular,\nēris,1st,passive,subjunctive,present,singular,2nd,regular,\nēre,1st,passive,subjunctive,present,singular,2nd,regular,\nētur,1st,passive,subjunctive,present,singular,3rd,regular,\nēmur,1st,passive,subjunctive,present,plural,1st,regular,\nēminī,1st,passive,subjunctive,present,plural,2nd,regular,\nentur,1st,passive,subjunctive,present,plural,3rd,regular,\neor,2nd,passive,indicative,present,singular,1st,regular,\nēris,2nd,passive,indicative,present,singular,2nd,regular,\nēre,2nd,passive,indicative,present,singular,2nd,regular,\nētur,2nd,passive,indicative,present,singular,3rd,regular,\nēmur,2nd,passive,indicative,present,plural,1st,regular,\nēmini,2nd,passive,indicative,present,plural,2nd,regular,\nentur,2nd,passive,indicative,present,plural,3rd,regular,\near,2nd,passive,subjunctive,present,singular,1st,regular,\neāris,2nd,passive,subjunctive,present,singular,2nd,regular,\neāre,2nd,passive,subjunctive,present,singular,2nd,regular,\neātur,2nd,passive,subjunctive,present,singular,3rd,regular,\neāmur,2nd,passive,subjunctive,present,plural,1st,regular,\neāminī,2nd,passive,subjunctive,present,plural,2nd,regular,\neantur,2nd,passive,subjunctive,present,plural,3rd,regular,\nor,3rd,passive,indicative,present,singular,1st,regular,\neris,3rd,passive,indicative,present,singular,2nd,regular,\nere,3rd,passive,indicative,present,singular,2nd,regular,\nitur,3rd,passive,indicative,present,singular,3rd,regular,\nimur,3rd,passive,indicative,present,plural,1st,regular,\niminī,3rd,passive,indicative,present,plural,2nd,regular,\nuntur,3rd,passive,indicative,present,plural,3rd,regular,\nar,3rd,passive,subjunctive,present,singular,1st,regular,\nāris,3rd,passive,subjunctive,present,singular,2nd,regular,\nāre,3rd,passive,subjunctive,present,singular,2nd,regular,\nātur,3rd,passive,subjunctive,present,singular,3rd,regular,\nāmur,3rd,passive,subjunctive,present,plural,1st,regular,\nāminī,3rd,passive,subjunctive,present,plural,2nd,regular,\nantur,3rd,passive,subjunctive,present,plural,3rd,regular,\nior,4th,passive,indicative,present,singular,1st,regular,\nīris,4th,passive,indicative,present,singular,2nd,regular,\nīre,4th,passive,indicative,present,singular,2nd,regular,\nītur,4th,passive,indicative,present,singular,3rd,regular,\nīmur,4th,passive,indicative,present,plural,1st,regular,\nīminī,4th,passive,indicative,present,plural,2nd,regular,\niuntur,4th,passive,indicative,present,plural,3rd,regular,\niar,4th,passive,subjunctive,present,singular,1st,regular,\niāris,4th,passive,subjunctive,present,singular,2nd,regular,\niāre,4th,passive,subjunctive,present,singular,2nd,regular,\niātur,4th,passive,subjunctive,present,singular,3rd,regular,\niāmur,4th,passive,subjunctive,present,plural,1st,regular,\niāminī,4th,passive,subjunctive,present,plural,2nd,regular,\niantur,4th,passive,subjunctive,present,plural,3rd,regular,\nābar,1st,passive,indicative,imperfect,singular,1st,regular,\nābāaris,1st,passive,indicative,imperfect,singular,2nd,regular,\nābāre,1st,passive,indicative,imperfect,singular,2nd,regular,\nābātur,1st,passive,indicative,imperfect,singular,3rd,regular,\nābāmur,1st,passive,indicative,imperfect,plural,1st,regular,\nābāminī,1st,passive,indicative,imperfect,plural,2nd,regular,\nābantur,1st,passive,indicative,imperfect,plural,3rd,regular,\nārer,1st,passive,subjunctive,imperfect,singular,1st,regular,\nārēris,1st,passive,subjunctive,imperfect,singular,2nd,regular,\nārēre,1st,passive,subjunctive,imperfect,singular,2nd,regular,\nārētur,1st,passive,subjunctive,imperfect,singular,3rd,regular,\nārēmur,1st,passive,subjunctive,imperfect,plural,1st,regular,\nārēminī,1st,passive,subjunctive,imperfect,plural,2nd,regular,\nārentur,1st,passive,subjunctive,imperfect,plural,3rd,regular,\nēbar,2nd,passive,indicative,imperfect,singular,1st,regular,\nēbāris,2nd,passive,indicative,imperfect,singular,2nd,regular,\nēbāre,2nd,passive,indicative,imperfect,singular,2nd,regular,\nēbātur,2nd,passive,indicative,imperfect,singular,3rd,regular,\nēbāmur,2nd,passive,indicative,imperfect,plural,1st,regular,\nēbāmini,2nd,passive,indicative,imperfect,plural,2nd,regular,\nēbantur,2nd,passive,indicative,imperfect,plural,3rd,regular,\nērer,2nd,passive,subjunctive,imperfect,singular,1st,regular,\nērēris,2nd,passive,subjunctive,imperfect,singular,2nd,regular,\nērēre,2nd,passive,subjunctive,imperfect,singular,2nd,regular,\nērētur,2nd,passive,subjunctive,imperfect,singular,3rd,regular,\nērēmur,2nd,passive,subjunctive,imperfect,plural,1st,regular,\nērēminī,2nd,passive,subjunctive,imperfect,plural,2nd,regular,\nērentur,2nd,passive,subjunctive,imperfect,plural,3rd,regular,\nēbar,3rd,passive,indicative,imperfect,singular,1st,regular,\nēbāris,3rd,passive,indicative,imperfect,singular,2nd,regular,\nēbāre,3rd,passive,indicative,imperfect,singular,2nd,regular,\nēbatur,3rd,passive,indicative,imperfect,singular,3rd,regular,\nēbāmur,3rd,passive,indicative,imperfect,plural,1st,regular,\nēbāminī,3rd,passive,indicative,imperfect,plural,2nd,regular,\nēbantur,3rd,passive,indicative,imperfect,plural,3rd,regular,\nerer,3rd,passive,subjunctive,imperfect,singular,1st,regular,\nerēris,3rd,passive,subjunctive,imperfect,singular,2nd,regular,\nerēre,3rd,passive,subjunctive,imperfect,singular,2nd,regular,\nerētur,3rd,passive,subjunctive,imperfect,singular,3rd,regular,\nerēmur,3rd,passive,subjunctive,imperfect,plural,1st,regular,\nerēminī,3rd,passive,subjunctive,imperfect,plural,2nd,regular,\nerentur,3rd,passive,subjunctive,imperfect,plural,3rd,regular,\niēbar,4th,passive,indicative,imperfect,singular,1st,regular,\niēbāris,4th,passive,indicative,imperfect,singular,2nd,regular,\niēbāre,4th,passive,indicative,imperfect,singular,2nd,regular,\niēbātur,4th,passive,indicative,imperfect,singular,3rd,regular,\niēbāmur,4th,passive,indicative,imperfect,plural,1st,regular,\niēbāminī,4th,passive,indicative,imperfect,plural,2nd,regular,\niēbantur,4th,passive,indicative,imperfect,plural,3rd,regular,\nīrer,4th,passive,subjunctive,imperfect,singular,1st,regular,\nīrēris,4th,passive,subjunctive,imperfect,singular,2nd,regular,\nīrēre,4th,passive,subjunctive,imperfect,singular,2nd,regular,\nīrētur,4th,passive,subjunctive,imperfect,singular,3rd,regular,\nīrēmur,4th,passive,subjunctive,imperfect,plural,1st,regular,\nīrēminī,4th,passive,subjunctive,imperfect,plural,2nd,regular,\nīrentur,4th,passive,subjunctive,imperfect,plural,3rd,regular,\nābor,1st,passive,indicative,future,singular,1st,regular,\nāberis,1st,passive,indicative,future,singular,2nd,regular,\nābere,1st,passive,indicative,future,singular,2nd,irregular,\nābitur,1st,passive,indicative,future,singular,3rd,regular,\nābimur,1st,passive,indicative,future,plural,1st,regular,\nābiminī,1st,passive,indicative,future,plural,2nd,regular,\nābuntur,1st,passive,indicative,future,plural,3rd,regular,\n,1st,passive,subjunctive,future,singular,1st,,\n,1st,passive,subjunctive,future,singular,2nd,,\n,1st,passive,subjunctive,future,singular,3rd,,\n,1st,passive,subjunctive,future,plural,1st,,\n,1st,passive,subjunctive,future,plural,2nd,,\n,1st,passive,subjunctive,future,plural,3rd,,\nēbor,2nd,passive,indicative,future,singular,1st,regular,\nēberis,2nd,passive,indicative,future,singular,2nd,regular,\nēbere,2nd,passive,indicative,future,singular,2nd,regular,\nēbitur,2nd,passive,indicative,future,singular,3rd,regular,\nēbimur,2nd,passive,indicative,future,plural,1st,regular,\nēbiminī,2nd,passive,indicative,future,plural,2nd,regular,\nēbuntur,2nd,passive,indicative,future,plural,3rd,regular,\n,2nd,passive,subjunctive,future,singular,1st,,\n,2nd,passive,subjunctive,future,singular,2nd,,\n,2nd,passive,subjunctive,future,singular,3rd,,\n,2nd,passive,subjunctive,future,plural,1st,,\n,2nd,passive,subjunctive,future,plural,2nd,,\n,2nd,passive,subjunctive,future,plural,3rd,,\nar,3rd,passive,indicative,future,singular,1st,regular,\nēris,3rd,passive,indicative,future,singular,2nd,regular,\nēre,3rd,passive,indicative,future,singular,2nd,irregular,\nētur,3rd,passive,indicative,future,singular,3rd,regular,\nēmur,3rd,passive,indicative,future,plural,1st,regular,\nēminī,3rd,passive,indicative,future,plural,2nd,regular,\nentur,3rd,passive,indicative,future,plural,3rd,regular,\n,3rd,passive,subjunctive,future,singular,1st,,\n,3rd,passive,subjunctive,future,singular,2nd,,\n,3rd,passive,subjunctive,future,singular,3rd,,\n,3rd,passive,subjunctive,future,plural,1st,,\n,3rd,passive,subjunctive,future,plural,2nd,,\n,3rd,passive,subjunctive,future,plural,3rd,,\niar,4th,passive,indicative,future,singular,1st,regular,\niēris,4th,passive,indicative,future,singular,2nd,regular,\nīēre,4th,passive,indicative,future,singular,2nd,irregular,\niētur,4th,passive,indicative,future,singular,3rd,regular,\niēmur,4th,passive,indicative,future,plural,1st,regular,\niēminī,4th,passive,indicative,future,plural,2nd,regular,\nientur,4th,passive,indicative,future,plural,3rd,regular,\n,4th,passive,subjunctive,future,singular,1st,,\n,4th,passive,subjunctive,future,singular,2nd,,\n,4th,passive,subjunctive,future,singular,3rd,,\n,4th,passive,subjunctive,future,plural,1st,,\n,4th,passive,subjunctive,future,plural,2nd,,\n,4th,passive,subjunctive,future,plural,3rd,,\nātus sum,1st,passive,indicative,perfect,singular,1st,regular,\nātus fui,1st,passive,indicative,perfect,singular,1st,regular,\nātus es,1st,passive,indicative,perfect,singular,2nd,regular,\nātus fuisti,1st,passive,indicative,perfect,singular,2nd,regular,\nātus est,1st,passive,indicative,perfect,singular,3rd,regular,\nātus fuit,1st,passive,indicative,perfect,singular,3rd,regular,\nāti sumus,1st,passive,indicative,perfect,plural,1st,regular,\nāti fuimus,1st,passive,indicative,perfect,plural,1st,irregular,\nāti estis,1st,passive,indicative,perfect,plural,2nd,regular,\nāti fuistis,1st,passive,indicative,perfect,plural,2nd,irregular,\nāti sunt,1st,passive,indicative,perfect,plural,3rd,regular,\nāti fuerunt,1st,passive,indicative,perfect,plural,3rd,irregular,\nātus sim,1st,passive,subjunctive,perfect,singular,1st,regular,\nātus fuerim,1st,passive,subjunctive,perfect,singular,1st,irregular,\nātus sis,1st,passive,subjunctive,perfect,singular,2nd,regular,\nātus fueris,1st,passive,subjunctive,perfect,singular,2nd,irregular,\nātus sit,1st,passive,subjunctive,perfect,singular,3rd,regular,\nātus fuerit,1st,passive,subjunctive,perfect,singular,3rd,regular,\nāti sīmus,1st,passive,subjunctive,perfect,plural,1st,regular,\nāti fuerimus,1st,passive,subjunctive,perfect,plural,1st,irregular,\nāti sītis,1st,passive,subjunctive,perfect,plural,2nd,regular,\nāti fueritis,1st,passive,subjunctive,perfect,plural,2nd,irregular,\nāti sint,1st,passive,subjunctive,perfect,plural,3rd,regular,\nāti fuerint,1st,passive,subjunctive,perfect,plural,3rd,irregular,\nitus sum,2nd,passive,indicative,perfect,singular,1st,regular,\nitus es,2nd,passive,indicative,perfect,singular,2nd,regular,\nitus est,2nd,passive,indicative,perfect,singular,3rd,regular,\nitī sumus,2nd,passive,indicative,perfect,plural,1st,regular,\nitī estis,2nd,passive,indicative,perfect,plural,2nd,regular,\nitī sunt,2nd,passive,indicative,perfect,plural,3rd,regular,\nitus sim,2nd,passive,subjunctive,perfect,singular,1st,regular,\nitus sīs,2nd,passive,subjunctive,perfect,singular,2nd,regular,\nitus sit,2nd,passive,subjunctive,perfect,singular,3rd,regular,\nitī sīmus,2nd,passive,subjunctive,perfect,plural,1st,regular,\nitī sītis,2nd,passive,subjunctive,perfect,plural,2nd,regular,\nitī sint,2nd,passive,subjunctive,perfect,plural,3rd,regular,\nus sum,3rd,passive,indicative,perfect,singular,1st,regular,\nus es,3rd,passive,indicative,perfect,singular,2nd,regular,\nus est,3rd,passive,indicative,perfect,singular,3rd,regular,\nī sumus,3rd,passive,indicative,perfect,plural,1st,regular,\nī estis,3rd,passive,indicative,perfect,plural,2nd,regular,\nī sunt,3rd,passive,indicative,perfect,plural,3rd,regular,\nus sim,3rd,passive,subjunctive,perfect,singular,1st,regular,\nus sīs,3rd,passive,subjunctive,perfect,singular,2nd,regular,\nus sit,3rd,passive,subjunctive,perfect,singular,3rd,regular,\nus sīmus,3rd,passive,subjunctive,perfect,plural,1st,regular,\nus sītis,3rd,passive,subjunctive,perfect,plural,2nd,regular,\nus sint,3rd,passive,subjunctive,perfect,plural,3rd,regular,\nītus sum,4th,passive,indicative,perfect,singular,1st,regular,\nītus es,4th,passive,indicative,perfect,singular,2nd,regular,\nītus est,4th,passive,indicative,perfect,singular,3rd,regular,\nītī sumus,4th,passive,indicative,perfect,plural,1st,regular,\nīti estis,4th,passive,indicative,perfect,plural,2nd,regular,\nīti sunt,4th,passive,indicative,perfect,plural,3rd,regular,\nītus sim,4th,passive,subjunctive,perfect,singular,1st,regular,\nītus sīs,4th,passive,subjunctive,perfect,singular,2nd,regular,\nītus sit,4th,passive,subjunctive,perfect,singular,3rd,regular,\nītī sīmus,4th,passive,subjunctive,perfect,plural,1st,regular,\nīti sītis,4th,passive,subjunctive,perfect,plural,2nd,regular,\nīti sint,4th,passive,subjunctive,perfect,plural,3rd,regular,\nātus eram,1st,passive,indicative,pluperfect,singular,1st,regular,\nātus fueram,1st,passive,indicative,pluperfect,singular,1st,irregular,\nātus eras,1st,passive,indicative,pluperfect,singular,2nd,regular,\nātus fueras,1st,passive,indicative,pluperfect,singular,2nd,irregular,\nātus erat,1st,passive,indicative,pluperfect,singular,3rd,regular,\nātus fuerat,1st,passive,indicative,pluperfect,singular,3rd,irregular,\nātī erāmus,1st,passive,indicative,pluperfect,plural,1st,regular,\nātī fueramus,1st,passive,indicative,pluperfect,plural,1st,irregular,\nātī erātis,1st,passive,indicative,pluperfect,plural,2nd,regular,\nātī fueratis,1st,passive,indicative,pluperfect,plural,2nd,irregular,\nātī erant,1st,passive,indicative,pluperfect,plural,3rd,regular,\nātī fuerant,1st,passive,indicative,pluperfect,plural,3rd,irregular,\nātus essem,1st,passive,subjunctive,pluperfect,singular,1st,regular,\nātus fuissem,1st,passive,subjunctive,pluperfect,singular,1st,irregular,\nātus esses,1st,passive,subjunctive,pluperfect,singular,2nd,regular,\nātus fuissēs,1st,passive,subjunctive,pluperfect,singular,2nd,irregular,\nātus esset,1st,passive,subjunctive,pluperfect,singular,3rd,regular,\nātus fuisset,1st,passive,subjunctive,pluperfect,singular,3rd,irregular,\nāti essēmus,1st,passive,subjunctive,pluperfect,plural,1st,regular,\nāti fuissēmus,1st,passive,subjunctive,pluperfect,plural,1st,irregular,\nāti essētis,1st,passive,subjunctive,pluperfect,plural,2nd,regular,\nāti fuissētis,1st,passive,subjunctive,pluperfect,plural,2nd,regular,\nāti essent,1st,passive,subjunctive,pluperfect,plural,3rd,regular,\nāti fuissent,1st,passive,subjunctive,pluperfect,plural,3rd,regular,\nitus eram,2nd,passive,indicative,pluperfect,singular,1st,regular,\nitus erās,2nd,passive,indicative,pluperfect,singular,2nd,regular,\nitus erat,2nd,passive,indicative,pluperfect,singular,3rd,regular,\nitī erāmus,2nd,passive,indicative,pluperfect,plural,1st,regular,\nitī erātis,2nd,passive,indicative,pluperfect,plural,2nd,regular,\nitī erant,2nd,passive,indicative,pluperfect,plural,3rd,regular,\nitus essem,2nd,passive,subjunctive,pluperfect,singular,1st,regular,\nitus essēs,2nd,passive,subjunctive,pluperfect,singular,2nd,regular,\nitus esset,2nd,passive,subjunctive,pluperfect,singular,3rd,regular,\nitī essēmus,2nd,passive,subjunctive,pluperfect,plural,1st,regular,\nīti essētis,2nd,passive,subjunctive,pluperfect,plural,2nd,regular,\nīti essent,2nd,passive,subjunctive,pluperfect,plural,3rd,regular,\nus eram,3rd,passive,indicative,pluperfect,singular,1st,regular,\nus erās,3rd,passive,indicative,pluperfect,singular,2nd,regular,\nus erat,3rd,passive,indicative,pluperfect,singular,3rd,regular,\nī erāmus,3rd,passive,indicative,pluperfect,plural,1st,regular,\nī erātis,3rd,passive,indicative,pluperfect,plural,2nd,regular,\nī erant,3rd,passive,indicative,pluperfect,plural,3rd,regular,\nus essem,3rd,passive,subjunctive,pluperfect,singular,1st,regular,\nus essēs,3rd,passive,subjunctive,pluperfect,singular,2nd,regular,\nus esset,3rd,passive,subjunctive,pluperfect,singular,3rd,regular,\nī essēmus,3rd,passive,subjunctive,pluperfect,plural,1st,regular,\nī essētis,3rd,passive,subjunctive,pluperfect,plural,2nd,regular,\nī essent,3rd,passive,subjunctive,pluperfect,plural,3rd,regular,\nītus eram,4th,passive,indicative,pluperfect,singular,1st,regular,\nītus erās,4th,passive,indicative,pluperfect,singular,2nd,regular,\nītus erat,4th,passive,indicative,pluperfect,singular,3rd,regular,\nītī erāmus,4th,passive,indicative,pluperfect,plural,1st,regular,\nīti erātis,4th,passive,indicative,pluperfect,plural,2nd,regular,\nītī erant,4th,passive,indicative,pluperfect,plural,3rd,regular,\nītus essem,4th,passive,subjunctive,pluperfect,singular,1st,regular,\nītus essēs,4th,passive,subjunctive,pluperfect,singular,2nd,regular,\nītus esset,4th,passive,subjunctive,pluperfect,singular,3rd,regular,\nītī essēmus,4th,passive,subjunctive,pluperfect,plural,1st,regular,\nīti essētis,4th,passive,subjunctive,pluperfect,plural,2nd,regular,\nīti essent,4th,passive,subjunctive,pluperfect,plural,3rd,regular,\nātus erō,1st,passive,indicative,future_perfect,singular,1st,regular,\nātus eris,1st,passive,indicative,future_perfect,singular,2nd,regular,\nātus erit,1st,passive,indicative,future_perfect,singular,3rd,regular,\nāti erimus,1st,passive,indicative,future_perfect,plural,1st,regular,\nāti eritis,1st,passive,indicative,future_perfect,plural,2nd,regular,\nāti erunt,1st,passive,indicative,future_perfect,plural,3rd,regular,\n,1st,passive,subjunctive,future_perfect,singular,1st,,\n,1st,passive,subjunctive,future_perfect,singular,2nd,,\n,1st,passive,subjunctive,future_perfect,singular,3rd,,\n,1st,passive,subjunctive,future_perfect,plural,1st,,\n,1st,passive,subjunctive,future_perfect,plural,2nd,,\n,1st,passive,subjunctive,future_perfect,plural,3rd,,\nitus erō,2nd,passive,indicative,future_perfect,singular,1st,regular,\nitus eris,2nd,passive,indicative,future_perfect,singular,2nd,regular,\nitus erit,2nd,passive,indicative,future_perfect,singular,3rd,regular,\nitī erimus,2nd,passive,indicative,future_perfect,plural,1st,regular,\nitī eritis,2nd,passive,indicative,future_perfect,plural,2nd,regular,\nitī erunt,2nd,passive,indicative,future_perfect,plural,3rd,regular,\n,2nd,passive,subjunctive,future_perfect,singular,1st,,\n,2nd,passive,subjunctive,future_perfect,singular,2nd,,\n,2nd,passive,subjunctive,future_perfect,singular,3rd,,\n,2nd,passive,subjunctive,future_perfect,plural,1st,,\n,2nd,passive,subjunctive,future_perfect,plural,2nd,,\n,2nd,passive,subjunctive,future_perfect,plural,3rd,,\nus erō,3rd,passive,indicative,future_perfect,singular,1st,regular,\nus eris,3rd,passive,indicative,future_perfect,singular,2nd,regular,\nus erit,3rd,passive,indicative,future_perfect,singular,3rd,regular,\nī erimus,3rd,passive,indicative,future_perfect,plural,1st,regular,\nī eritis,3rd,passive,indicative,future_perfect,plural,2nd,regular,\nī erunt,3rd,passive,indicative,future_perfect,plural,3rd,regular,\n,3rd,passive,subjunctive,future_perfect,singular,1st,,\n,3rd,passive,subjunctive,future_perfect,singular,2nd,,\n,3rd,passive,subjunctive,future_perfect,singular,3rd,,\n,3rd,passive,subjunctive,future_perfect,plural,1st,,\n,3rd,passive,subjunctive,future_perfect,plural,2nd,,\n,3rd,passive,subjunctive,future_perfect,plural,3rd,,\nītus erō,4th,passive,indicative,future_perfect,singular,1st,regular,\nītus eris,4th,passive,indicative,future_perfect,singular,2nd,regular,\nītus erit,4th,passive,indicative,future_perfect,singular,3rd,regular,\nītī erimus,4th,passive,indicative,future_perfect,plural,1st,regular,\nītī eritis,4th,passive,indicative,future_perfect,plural,2nd,regular,\nītī erunt,4th,passive,indicative,future_perfect,plural,3rd,regular,\n,4th,passive,subjunctive,future_perfect,singular,1st,,\n,4th,passive,subjunctive,future_perfect,singular,2nd,,\n,4th,passive,subjunctive,future_perfect,singular,3rd,,\n,4th,passive,subjunctive,future_perfect,plural,1st,,\n,4th,passive,subjunctive,future_perfect,plural,2nd,,\n,4th,passive,subjunctive,future_perfect,plural,3rd,,";
+var verbSuffixesCSV = "Ending,Conjugation,Voice,Mood,Tense,Number,Person,Type,Footnote\r\nō,1st,active,indicative,present,singular,1st,regular,\r\nās,1st,active,indicative,present,singular,2nd,regular,\r\nat,1st,active,indicative,present,singular,3rd,regular,\r\nāmus,1st,active,indicative,present,plural,1st,regular,\r\nātis,1st,active,indicative,present,plural,2nd,regular,\r\nant,1st,active,indicative,present,plural,3rd,regular,\r\nem,1st,active,subjunctive,present,singular,1st,regular,\r\nēs,1st,active,subjunctive,present,singular,2nd,regular,\r\net,1st,active,subjunctive,present,singular,3rd,regular,\r\nēmus,1st,active,subjunctive,present,plural,1st,regular,\r\nētis,1st,active,subjunctive,present,plural,2nd,regular,\r\nent,1st,active,subjunctive,present,plural,3rd,regular,\r\neō,2nd,active,indicative,present,singular,1st,regular,\r\nēs,2nd,active,indicative,present,singular,2nd,regular,\r\nēt,2nd,active,indicative,present,singular,3rd,regular,\r\nēmus,2nd,active,indicative,present,plural,1st,regular,\r\nētis,2nd,active,indicative,present,plural,2nd,regular,\r\nent,2nd,active,indicative,present,plural,3rd,regular,\r\neam,2nd,active,subjunctive,present,singular,1st,regular,\r\neās,2nd,active,subjunctive,present,singular,2nd,regular,\r\neat,2nd,active,subjunctive,present,singular,3rd,regular,\r\neāmus,2nd,active,subjunctive,present,plural,1st,regular,\r\neātis,2nd,active,subjunctive,present,plural,2nd,regular,\r\neant,2nd,active,subjunctive,present,plural,3rd,regular,\r\nō,3rd,active,indicative,present,singular,1st,regular,\r\nis,3rd,active,indicative,present,singular,2nd,regular,\r\nit,3rd,active,indicative,present,singular,3rd,regular,\r\nimus,3rd,active,indicative,present,plural,1st,regular,\r\nitis,3rd,active,indicative,present,plural,2nd,regular,\r\nunt,3rd,active,indicative,present,plural,3rd,regular,\r\nam,3rd,active,subjunctive,present,singular,1st,regular,\r\nās,3rd,active,subjunctive,present,singular,2nd,regular,\r\nat,3rd,active,subjunctive,present,singular,3rd,regular,\r\nāmus,3rd,active,subjunctive,present,plural,1st,regular,\r\nātis,3rd,active,subjunctive,present,plural,2nd,regular,\r\nant,3rd,active,subjunctive,present,plural,3rd,regular,\r\niō,4th,active,indicative,present,singular,1st,regular,\r\nīs,4th,active,indicative,present,singular,2nd,regular,\r\nit,4th,active,indicative,present,singular,3rd,regular,\r\nīmus,4th,active,indicative,present,plural,1st,regular,\r\nītis,4th,active,indicative,present,plural,2nd,regular,\r\niunt,4th,active,indicative,present,plural,3rd,regular,\r\niam,4th,active,subjunctive,present,singular,1st,regular,\r\niās,4th,active,subjunctive,present,singular,2nd,regular,\r\niat,4th,active,subjunctive,present,singular,3rd,regular,\r\niāmus,4th,active,subjunctive,present,plural,1st,regular,\r\niāatis,4th,active,subjunctive,present,plural,2nd,regular,\r\niant,4th,active,subjunctive,present,plural,3rd,regular,\r\nābam,1st,active,indicative,imperfect,singular,1st,regular,\r\nābas,1st,active,indicative,imperfect,singular,2nd,regular,\r\nābat,1st,active,indicative,imperfect,singular,3rd,regular,\r\nābāmus,1st,active,indicative,imperfect,plural,1st,regular,\r\nābātis,1st,active,indicative,imperfect,plural,2nd,regular,\r\nābant,1st,active,indicative,imperfect,plural,3rd,regular,\r\nārem,1st,active,subjunctive,imperfect,singular,1st,regular,\r\nārēs,1st,active,subjunctive,imperfect,singular,2nd,regular,\r\nāret,1st,active,subjunctive,imperfect,singular,3rd,regular,\r\nārēmus,1st,active,subjunctive,imperfect,plural,1st,regular,\r\nārētis,1st,active,subjunctive,imperfect,plural,2nd,regular,\r\nārent,1st,active,subjunctive,imperfect,plural,3rd,regular,\r\nēbam,2nd,active,indicative,imperfect,singular,1st,regular,\r\nēbās,2nd,active,indicative,imperfect,singular,2nd,regular,\r\nēbat,2nd,active,indicative,imperfect,singular,3rd,regular,\r\nēbāmus,2nd,active,indicative,imperfect,plural,1st,regular,\r\nēbātis,2nd,active,indicative,imperfect,plural,2nd,regular,\r\nēbant,2nd,active,indicative,imperfect,plural,3rd,regular,\r\nērem,2nd,active,subjunctive,imperfect,singular,1st,regular,\r\nērēs,2nd,active,subjunctive,imperfect,singular,2nd,regular,\r\nēret,2nd,active,subjunctive,imperfect,singular,3rd,regular,\r\nērēmus,2nd,active,subjunctive,imperfect,plural,1st,regular,\r\nērētis,2nd,active,subjunctive,imperfect,plural,2nd,regular,\r\nērēnt,2nd,active,subjunctive,imperfect,plural,3rd,regular,\r\nēbas,3rd,active,indicative,imperfect,singular,1st,regular,\r\nēbāt,3rd,active,indicative,imperfect,singular,2nd,regular,\r\nēbat,3rd,active,indicative,imperfect,singular,3rd,regular,\r\nēbāmus,3rd,active,indicative,imperfect,plural,1st,regular,\r\nēbātis,3rd,active,indicative,imperfect,plural,2nd,regular,\r\nēbant,3rd,active,indicative,imperfect,plural,3rd,regular,\r\nerem,3rd,active,subjunctive,imperfect,singular,1st,regular,\r\nerēs,3rd,active,subjunctive,imperfect,singular,2nd,regular,\r\neret,3rd,active,subjunctive,imperfect,singular,3rd,regular,\r\nerēmus,3rd,active,subjunctive,imperfect,plural,1st,regular,\r\nerētis,3rd,active,subjunctive,imperfect,plural,2nd,regular,\r\nerent,3rd,active,subjunctive,imperfect,plural,3rd,regular,\r\niēbam,4th,active,indicative,imperfect,singular,1st,regular,\r\nībam,4th,active,indicative,imperfect,singular,1st,irregular,2\r\niēbas,4th,active,indicative,imperfect,singular,2nd,regular,\r\nības,4th,active,indicative,imperfect,singular,2nd,irregular,\r\niēbat,4th,active,indicative,imperfect,singular,3rd,regular,\r\nībat,4th,active,indicative,imperfect,singular,3rd,irregular,\r\niēbāmus,4th,active,indicative,imperfect,plural,1st,regular,\r\nībāmus,4th,active,indicative,imperfect,plural,1st,irregular,\r\niēbātis,4th,active,indicative,imperfect,plural,2nd,regular,\r\nībātis,4th,active,indicative,imperfect,plural,2nd,irregular,\r\niēbant,4th,active,indicative,imperfect,plural,3rd,regular,\r\nībant,4th,active,indicative,imperfect,plural,3rd,irregular,\r\nīrem,4th,active,subjunctive,imperfect,singular,1st,regular,\r\nīrēs,4th,active,subjunctive,imperfect,singular,2nd,regular,\r\nīret,4th,active,subjunctive,imperfect,singular,3rd,regular,\r\nīrēmus,4th,active,subjunctive,imperfect,plural,1st,regular,\r\nīrētis,4th,active,subjunctive,imperfect,plural,2nd,regular,\r\nīrēnt,4th,active,subjunctive,imperfect,plural,3rd,regular,\r\nābo,1st,active,indicative,future,singular,1st,regular,\r\nābis,1st,active,indicative,future,singular,2nd,regular,\r\nābit,1st,active,indicative,future,singular,3rd,regular,\r\nābimus,1st,active,indicative,future,plural,1st,regular,\r\nābitis,1st,active,indicative,future,plural,2nd,regular,\r\nābunt,1st,active,indicative,future,plural,3rd,regular,\r\n,1st,active,subjunctive,future,singular,1st,,\r\n,1st,active,subjunctive,future,singular,2nd,,\r\n,1st,active,subjunctive,future,singular,3rd,,\r\n,1st,active,subjunctive,future,plural,1st,,\r\n,1st,active,subjunctive,future,plural,2nd,,\r\n,1st,active,subjunctive,future,plural,3rd,,\r\nēbō,2nd,active,indicative,future,singular,1st,regular,\r\nēbis,2nd,active,indicative,future,singular,2nd,regular,\r\nēbit,2nd,active,indicative,future,singular,3rd,regular,\r\nēbimus,2nd,active,indicative,future,plural,1st,regular,\r\nēbitis,2nd,active,indicative,future,plural,2nd,regular,\r\nēbunt,2nd,active,indicative,future,plural,3rd,regular,\r\n,2nd,active,subjunctive,future,singular,1st,regular,\r\n,2nd,active,subjunctive,future,singular,2nd,,\r\n,2nd,active,subjunctive,future,singular,3rd,,\r\n,2nd,active,subjunctive,future,plural,1st,,\r\n,2nd,active,subjunctive,future,plural,2nd,,\r\n,2nd,active,subjunctive,future,plural,3rd,,\r\nam,3rd,active,indicative,future,singular,1st,regular,\r\nēs,3rd,active,indicative,future,singular,2nd,regular,\r\net,3rd,active,indicative,future,singular,3rd,regular,\r\nēmus,3rd,active,indicative,future,plural,1st,regular,\r\nētis,3rd,active,indicative,future,plural,2nd,regular,\r\nent,3rd,active,indicative,future,plural,3rd,regular,\r\n,3rd,active,subjunctive,future,singular,1st,,\r\n,3rd,active,subjunctive,future,singular,2nd,,\r\n,3rd,active,subjunctive,future,singular,3rd,,\r\n,3rd,active,subjunctive,future,plural,1st,,\r\n,3rd,active,subjunctive,future,plural,2nd,,\r\n,3rd,active,subjunctive,future,plural,3rd,,\r\niam,4th,active,indicative,future,singular,1st,regular,\r\nībō,4th,active,indicative,future,singular,1st,irregular,2\r\niēs,4th,active,indicative,future,singular,2nd,regular,\r\nībis,4th,active,indicative,future,singular,2nd,irregular,\r\niet,4th,active,indicative,future,singular,3rd,regular,\r\nībit,4th,active,indicative,future,singular,3rd,irregular,\r\niēmus,4th,active,indicative,future,plural,1st,regular,\r\nībimus,4th,active,indicative,future,plural,1st,irregular,\r\niētis,4th,active,indicative,future,plural,2nd,regular,\r\nībitis,4th,active,indicative,future,plural,2nd,irregular,\r\nient,4th,active,indicative,future,plural,3rd,regular,\r\nībunt,4th,active,indicative,future,plural,3rd,irregular,\r\n,4th,active,subjunctive,future,singular,1st,,\r\n,4th,active,subjunctive,future,singular,2nd,,\r\n,4th,active,subjunctive,future,singular,3rd,,\r\n,4th,active,subjunctive,future,plural,1st,,\r\n,4th,active,subjunctive,future,plural,2nd,,\r\n,4th,active,subjunctive,future,plural,3rd,,\r\nāvī,1st,active,indicative,perfect,singular,1st,regular,\r\nāvistī,1st,active,indicative,perfect,singular,2nd,regular,\r\nāvit,1st,active,indicative,perfect,singular,3rd,regular,\r\nāvimus,1st,active,indicative,perfect,plural,1st,regular,\r\nāvistis,1st,active,indicative,perfect,plural,2nd,regular,\r\nāvērunt,1st,active,indicative,perfect,plural,3rd,regular,\r\nāvēre,1st,active,indicative,perfect,plural,3rd,irregular,6\r\nāverim,1st,active,subjunctive,perfect,singular,1st,regular,\r\nāveris,1st,active,subjunctive,perfect,singular,2nd,regular,\r\nāverit,1st,active,subjunctive,perfect,singular,3rd,regular,\r\nāverimus,1st,active,subjunctive,perfect,plural,1st,regular,\r\nāveritis,1st,active,subjunctive,perfect,plural,2nd,regular,\r\nāverint,1st,active,subjunctive,perfect,plural,3rd,regular,\r\nvī,2nd,active,indicative,perfect,singular,1st,regular,\r\nvistī,2nd,active,indicative,perfect,singular,2nd,regular,\r\nvit,2nd,active,indicative,perfect,singular,3rd,regular,\r\nvimus,2nd,active,indicative,perfect,plural,1st,regular,\r\nvistis,2nd,active,indicative,perfect,plural,2nd,regular,\r\nvērunt,2nd,active,indicative,perfect,plural,3rd,regular,\r\nvēre,2nd,active,indicative,perfect,plural,3rd,irregular,6\r\nverim,2nd,active,subjunctive,perfect,singular,1st,regular,\r\nveris,2nd,active,subjunctive,perfect,singular,2nd,regular,\r\nverit,2nd,active,subjunctive,perfect,singular,3rd,regular,\r\nverimus,2nd,active,subjunctive,perfect,plural,1st,regular,\r\nveritis,2nd,active,subjunctive,perfect,plural,2nd,regular,\r\nverint,2nd,active,subjunctive,perfect,plural,3rd,regular,\r\nī,3rd,active,indicative,perfect,singular,1st,regular,\r\nistī,3rd,active,indicative,perfect,singular,2nd,regular,\r\nit,3rd,active,indicative,perfect,singular,3rd,regular,\r\nimus,3rd,active,indicative,perfect,plural,1st,regular,\r\nistis,3rd,active,indicative,perfect,plural,2nd,regular,\r\nērunt,3rd,active,indicative,perfect,plural,3rd,regular,\r\nēre,3rd,active,indicative,perfect,plural,3rd,irregular,6\r\nerim,3rd,active,subjunctive,perfect,singular,1st,regular,\r\neris,3rd,active,subjunctive,perfect,singular,2nd,regular,\r\nerit,3rd,active,subjunctive,perfect,singular,3rd,regular,\r\nerimus,3rd,active,subjunctive,perfect,plural,1st,regular,\r\neritis,3rd,active,subjunctive,perfect,plural,2nd,regular,\r\nerint,3rd,active,subjunctive,perfect,plural,3rd,regular,\r\nīvi,4th,active,indicative,perfect,singular,1st,regular,\r\nīvistī,4th,active,indicative,perfect,singular,2nd,regular,\r\nīvit,4th,active,indicative,perfect,singular,3rd,regular,\r\nīvimus,4th,active,indicative,perfect,plural,1st,regular,\r\nīvistis,4th,active,indicative,perfect,plural,2nd,regular,\r\nīvērunt,4th,active,indicative,perfect,plural,3rd,regular,\r\nīvēre,4th,active,indicative,perfect,plural,3rd,irregular,6\r\nīverim,4th,active,subjunctive,perfect,singular,1st,regular,\r\niveris,4th,active,subjunctive,perfect,singular,2nd,regular,\r\nīverit,4th,active,subjunctive,perfect,singular,3rd,regular,\r\nīverimus,4th,active,subjunctive,perfect,plural,1st,regular,\r\nīveritis,4th,active,subjunctive,perfect,plural,2nd,regular,\r\nīverint,4th,active,subjunctive,perfect,plural,3rd,regular,\r\nāveram,1st,active,indicative,pluperfect,singular,1st,regular,\r\nāverās,1st,active,indicative,pluperfect,singular,2nd,regular,\r\nāverat,1st,active,indicative,pluperfect,singular,3rd,regular,\r\nāverāmus,1st,active,indicative,pluperfect,plural,1st,regular,\r\nāverātis,1st,active,indicative,pluperfect,plural,2nd,regular,\r\nāverant,1st,active,indicative,pluperfect,plural,3rd,regular,\r\nāvissem,1st,active,subjunctive,pluperfect,singular,1st,regular,\r\nāvissēs,1st,active,subjunctive,pluperfect,singular,2nd,regular,\r\nāvisset,1st,active,subjunctive,pluperfect,singular,3rd,regular,\r\nāvissēm,1st,active,subjunctive,pluperfect,plural,1st,regular,\r\nāvissēs,1st,active,subjunctive,pluperfect,plural,2nd,regular,\r\nāvisset,1st,active,subjunctive,pluperfect,plural,3rd,regular,\r\nveram,2nd,active,indicative,pluperfect,singular,1st,regular,\r\nverās,2nd,active,indicative,pluperfect,singular,2nd,regular,\r\nverat,2nd,active,indicative,pluperfect,singular,3rd,regular,\r\nverāmus,2nd,active,indicative,pluperfect,plural,1st,regular,\r\nverātis,2nd,active,indicative,pluperfect,plural,2nd,regular,\r\nverant,2nd,active,indicative,pluperfect,plural,3rd,regular,\r\nvissem,2nd,active,subjunctive,pluperfect,singular,1st,regular,\r\nvissēs,2nd,active,subjunctive,pluperfect,singular,2nd,regular,\r\nvisset,2nd,active,subjunctive,pluperfect,singular,3rd,regular,\r\nvissēmus,2nd,active,subjunctive,pluperfect,plural,1st,regular,\r\nvissētis,2nd,active,subjunctive,pluperfect,plural,2nd,regular,\r\nvissent,2nd,active,subjunctive,pluperfect,plural,3rd,regular,\r\neram,3rd,active,indicative,pluperfect,singular,1st,regular,\r\nerās,3rd,active,indicative,pluperfect,singular,2nd,regular,\r\nerat,3rd,active,indicative,pluperfect,singular,3rd,regular,\r\nerāmus,3rd,active,indicative,pluperfect,plural,1st,regular,\r\nerātis,3rd,active,indicative,pluperfect,plural,2nd,regular,\r\nerant,3rd,active,indicative,pluperfect,plural,3rd,regular,\r\nissem,3rd,active,subjunctive,pluperfect,singular,1st,regular,\r\nissēs,3rd,active,subjunctive,pluperfect,singular,2nd,regular,\r\nisset,3rd,active,subjunctive,pluperfect,singular,3rd,regular,\r\nissēmus,3rd,active,subjunctive,pluperfect,plural,1st,regular,\r\nissētis,3rd,active,subjunctive,pluperfect,plural,2nd,regular,\r\nissent,3rd,active,subjunctive,pluperfect,plural,3rd,regular,\r\nīveram,4th,active,indicative,pluperfect,singular,1st,regular,\r\nīverās,4th,active,indicative,pluperfect,singular,2nd,regular,\r\nīverat,4th,active,indicative,pluperfect,singular,3rd,regular,\r\nīverāmus,4th,active,indicative,pluperfect,plural,1st,regular,\r\nīverātis,4th,active,indicative,pluperfect,plural,2nd,regular,\r\nīverant,4th,active,indicative,pluperfect,plural,3rd,regular,\r\nīvissem,4th,active,subjunctive,pluperfect,singular,1st,regular,\r\nīvissēs,4th,active,subjunctive,pluperfect,singular,2nd,regular,\r\nīvisset,4th,active,subjunctive,pluperfect,singular,3rd,regular,\r\nīvissēmus,4th,active,subjunctive,pluperfect,plural,1st,regular,\r\nīvissētis,4th,active,subjunctive,pluperfect,plural,2nd,regular,\r\nīvissent,4th,active,subjunctive,pluperfect,plural,3rd,regular,\r\nāverō,1st,active,indicative,future_perfect,singular,1st,regular,\r\nāveris,1st,active,indicative,future_perfect,singular,2nd,regular,\r\nāverit,1st,active,indicative,future_perfect,singular,3rd,regular,\r\nāverimus,1st,active,indicative,future_perfect,plural,1st,regular,\r\nāveritis,1st,active,indicative,future_perfect,plural,2nd,regular,\r\nāverint,1st,active,indicative,future_perfect,plural,3rd,regular,\r\n,1st,active,subjunctive,future_perfect,singular,1st,,\r\n,1st,active,subjunctive,future_perfect,singular,2nd,,\r\n,1st,active,subjunctive,future_perfect,singular,3rd,,\r\n,1st,active,subjunctive,future_perfect,plural,1st,,\r\n,1st,active,subjunctive,future_perfect,plural,2nd,,\r\n,1st,active,subjunctive,future_perfect,plural,3rd,,\r\nverō,2nd,active,indicative,future_perfect,singular,1st,regular,\r\nvēris,2nd,active,indicative,future_perfect,singular,2nd,regular,\r\nvērit,2nd,active,indicative,future_perfect,singular,3rd,regular,\r\nvērimus,2nd,active,indicative,future_perfect,plural,1st,regular,\r\nvēritis,2nd,active,indicative,future_perfect,plural,2nd,regular,\r\nvērint,2nd,active,indicative,future_perfect,plural,3rd,regular,\r\n,2nd,active,subjunctive,future_perfect,singular,1st,,\r\n,2nd,active,subjunctive,future_perfect,singular,2nd,,\r\n,2nd,active,subjunctive,future_perfect,singular,3rd,,\r\n,2nd,active,subjunctive,future_perfect,plural,1st,,\r\n,2nd,active,subjunctive,future_perfect,plural,2nd,,\r\n,2nd,active,subjunctive,future_perfect,plural,3rd,,\r\nerō,3rd,active,indicative,future_perfect,singular,1st,regular,\r\neris,3rd,active,indicative,future_perfect,singular,2nd,regular,\r\nerit,3rd,active,indicative,future_perfect,singular,3rd,regular,\r\nerimus,3rd,active,indicative,future_perfect,plural,1st,regular,\r\neritis,3rd,active,indicative,future_perfect,plural,2nd,regular,\r\nerint,3rd,active,indicative,future_perfect,plural,3rd,regular,\r\n,3rd,active,subjunctive,future_perfect,singular,1st,,\r\n,3rd,active,subjunctive,future_perfect,singular,2nd,,\r\n,3rd,active,subjunctive,future_perfect,singular,3rd,,\r\n,3rd,active,subjunctive,future_perfect,plural,1st,,\r\n,3rd,active,subjunctive,future_perfect,plural,2nd,,\r\n,3rd,active,subjunctive,future_perfect,plural,3rd,,\r\nīverō,4th,active,indicative,future_perfect,singular,1st,regular,\r\nīveris,4th,active,indicative,future_perfect,singular,2nd,regular,\r\nīverit,4th,active,indicative,future_perfect,singular,3rd,regular,\r\nīverimus,4th,active,indicative,future_perfect,plural,1st,regular,\r\nīveritis,4th,active,indicative,future_perfect,plural,2nd,regular,\r\nīverint,4th,active,indicative,future_perfect,plural,3rd,regular,\r\n,4th,active,subjunctive,future_perfect,singular,1st,,\r\n,4th,active,subjunctive,future_perfect,singular,2nd,,\r\n,4th,active,subjunctive,future_perfect,singular,3rd,,\r\n,4th,active,subjunctive,future_perfect,plural,1st,,\r\n,4th,active,subjunctive,future_perfect,plural,2nd,,\r\n,4th,active,subjunctive,future_perfect,plural,3rd,,\r\nor,1st,passive,indicative,present,singular,1st,regular,\r\nāris,1st,passive,indicative,present,singular,2nd,regular,\r\nāre,1st,passive,indicative,present,singular,2nd,irregular,5\r\nātur,1st,passive,indicative,present,singular,3rd,regular,\r\nāmur,1st,passive,indicative,present,plural,1st,regular,\r\nāminiī,1st,passive,indicative,present,plural,2nd,regular,\r\nantur,1st,passive,indicative,present,plural,3rd,regular,\r\ner,1st,passive,subjunctive,present,singular,1st,regular,\r\nēris,1st,passive,subjunctive,present,singular,2nd,regular,\r\nēre,1st,passive,subjunctive,present,singular,2nd,regular,\r\nētur,1st,passive,subjunctive,present,singular,3rd,regular,\r\nēmur,1st,passive,subjunctive,present,plural,1st,regular,\r\nēminī,1st,passive,subjunctive,present,plural,2nd,regular,\r\nentur,1st,passive,subjunctive,present,plural,3rd,regular,\r\neor,2nd,passive,indicative,present,singular,1st,regular,\r\nēris,2nd,passive,indicative,present,singular,2nd,regular,\r\nēre,2nd,passive,indicative,present,singular,2nd,regular,\r\nētur,2nd,passive,indicative,present,singular,3rd,regular,\r\nēmur,2nd,passive,indicative,present,plural,1st,regular,\r\nēmini,2nd,passive,indicative,present,plural,2nd,regular,\r\nentur,2nd,passive,indicative,present,plural,3rd,regular,\r\near,2nd,passive,subjunctive,present,singular,1st,regular,\r\neāris,2nd,passive,subjunctive,present,singular,2nd,regular,\r\neāre,2nd,passive,subjunctive,present,singular,2nd,regular,\r\neātur,2nd,passive,subjunctive,present,singular,3rd,regular,\r\neāmur,2nd,passive,subjunctive,present,plural,1st,regular,\r\neāminī,2nd,passive,subjunctive,present,plural,2nd,regular,\r\neantur,2nd,passive,subjunctive,present,plural,3rd,regular,\r\nor,3rd,passive,indicative,present,singular,1st,regular,\r\neris,3rd,passive,indicative,present,singular,2nd,regular,\r\nere,3rd,passive,indicative,present,singular,2nd,regular,\r\nitur,3rd,passive,indicative,present,singular,3rd,regular,\r\nimur,3rd,passive,indicative,present,plural,1st,regular,\r\niminī,3rd,passive,indicative,present,plural,2nd,regular,\r\nuntur,3rd,passive,indicative,present,plural,3rd,regular,\r\nar,3rd,passive,subjunctive,present,singular,1st,regular,\r\nāris,3rd,passive,subjunctive,present,singular,2nd,regular,\r\nāre,3rd,passive,subjunctive,present,singular,2nd,regular,\r\nātur,3rd,passive,subjunctive,present,singular,3rd,regular,\r\nāmur,3rd,passive,subjunctive,present,plural,1st,regular,\r\nāminī,3rd,passive,subjunctive,present,plural,2nd,regular,\r\nantur,3rd,passive,subjunctive,present,plural,3rd,regular,\r\nior,4th,passive,indicative,present,singular,1st,regular,\r\nīris,4th,passive,indicative,present,singular,2nd,regular,\r\nīre,4th,passive,indicative,present,singular,2nd,regular,\r\nītur,4th,passive,indicative,present,singular,3rd,regular,\r\nīmur,4th,passive,indicative,present,plural,1st,regular,\r\nīminī,4th,passive,indicative,present,plural,2nd,regular,\r\niuntur,4th,passive,indicative,present,plural,3rd,regular,\r\niar,4th,passive,subjunctive,present,singular,1st,regular,\r\niāris,4th,passive,subjunctive,present,singular,2nd,regular,\r\niāre,4th,passive,subjunctive,present,singular,2nd,regular,\r\niātur,4th,passive,subjunctive,present,singular,3rd,regular,\r\niāmur,4th,passive,subjunctive,present,plural,1st,regular,\r\niāminī,4th,passive,subjunctive,present,plural,2nd,regular,\r\niantur,4th,passive,subjunctive,present,plural,3rd,regular,\r\nābar,1st,passive,indicative,imperfect,singular,1st,regular,\r\nābāaris,1st,passive,indicative,imperfect,singular,2nd,regular,\r\nābāre,1st,passive,indicative,imperfect,singular,2nd,regular,\r\nābātur,1st,passive,indicative,imperfect,singular,3rd,regular,\r\nābāmur,1st,passive,indicative,imperfect,plural,1st,regular,\r\nābāminī,1st,passive,indicative,imperfect,plural,2nd,regular,\r\nābantur,1st,passive,indicative,imperfect,plural,3rd,regular,\r\nārer,1st,passive,subjunctive,imperfect,singular,1st,regular,\r\nārēris,1st,passive,subjunctive,imperfect,singular,2nd,regular,\r\nārēre,1st,passive,subjunctive,imperfect,singular,2nd,regular,\r\nārētur,1st,passive,subjunctive,imperfect,singular,3rd,regular,\r\nārēmur,1st,passive,subjunctive,imperfect,plural,1st,regular,\r\nārēminī,1st,passive,subjunctive,imperfect,plural,2nd,regular,\r\nārentur,1st,passive,subjunctive,imperfect,plural,3rd,regular,\r\nēbar,2nd,passive,indicative,imperfect,singular,1st,regular,\r\nēbāris,2nd,passive,indicative,imperfect,singular,2nd,regular,\r\nēbāre,2nd,passive,indicative,imperfect,singular,2nd,regular,\r\nēbātur,2nd,passive,indicative,imperfect,singular,3rd,regular,\r\nēbāmur,2nd,passive,indicative,imperfect,plural,1st,regular,\r\nēbāmini,2nd,passive,indicative,imperfect,plural,2nd,regular,\r\nēbantur,2nd,passive,indicative,imperfect,plural,3rd,regular,\r\nērer,2nd,passive,subjunctive,imperfect,singular,1st,regular,\r\nērēris,2nd,passive,subjunctive,imperfect,singular,2nd,regular,\r\nērēre,2nd,passive,subjunctive,imperfect,singular,2nd,regular,\r\nērētur,2nd,passive,subjunctive,imperfect,singular,3rd,regular,\r\nērēmur,2nd,passive,subjunctive,imperfect,plural,1st,regular,\r\nērēminī,2nd,passive,subjunctive,imperfect,plural,2nd,regular,\r\nērentur,2nd,passive,subjunctive,imperfect,plural,3rd,regular,\r\nēbar,3rd,passive,indicative,imperfect,singular,1st,regular,\r\nēbāris,3rd,passive,indicative,imperfect,singular,2nd,regular,\r\nēbāre,3rd,passive,indicative,imperfect,singular,2nd,regular,\r\nēbatur,3rd,passive,indicative,imperfect,singular,3rd,regular,\r\nēbāmur,3rd,passive,indicative,imperfect,plural,1st,regular,\r\nēbāminī,3rd,passive,indicative,imperfect,plural,2nd,regular,\r\nēbantur,3rd,passive,indicative,imperfect,plural,3rd,regular,\r\nerer,3rd,passive,subjunctive,imperfect,singular,1st,regular,\r\nerēris,3rd,passive,subjunctive,imperfect,singular,2nd,regular,\r\nerēre,3rd,passive,subjunctive,imperfect,singular,2nd,regular,\r\nerētur,3rd,passive,subjunctive,imperfect,singular,3rd,regular,\r\nerēmur,3rd,passive,subjunctive,imperfect,plural,1st,regular,\r\nerēminī,3rd,passive,subjunctive,imperfect,plural,2nd,regular,\r\nerentur,3rd,passive,subjunctive,imperfect,plural,3rd,regular,\r\niēbar,4th,passive,indicative,imperfect,singular,1st,regular,\r\niēbāris,4th,passive,indicative,imperfect,singular,2nd,regular,\r\niēbāre,4th,passive,indicative,imperfect,singular,2nd,regular,\r\niēbātur,4th,passive,indicative,imperfect,singular,3rd,regular,\r\niēbāmur,4th,passive,indicative,imperfect,plural,1st,regular,\r\niēbāminī,4th,passive,indicative,imperfect,plural,2nd,regular,\r\niēbantur,4th,passive,indicative,imperfect,plural,3rd,regular,\r\nīrer,4th,passive,subjunctive,imperfect,singular,1st,regular,\r\nīrēris,4th,passive,subjunctive,imperfect,singular,2nd,regular,\r\nīrēre,4th,passive,subjunctive,imperfect,singular,2nd,regular,\r\nīrētur,4th,passive,subjunctive,imperfect,singular,3rd,regular,\r\nīrēmur,4th,passive,subjunctive,imperfect,plural,1st,regular,\r\nīrēminī,4th,passive,subjunctive,imperfect,plural,2nd,regular,\r\nīrentur,4th,passive,subjunctive,imperfect,plural,3rd,regular,\r\nābor,1st,passive,indicative,future,singular,1st,regular,\r\nāberis,1st,passive,indicative,future,singular,2nd,regular,\r\nābere,1st,passive,indicative,future,singular,2nd,irregular,\r\nābitur,1st,passive,indicative,future,singular,3rd,regular,\r\nābimur,1st,passive,indicative,future,plural,1st,regular,\r\nābiminī,1st,passive,indicative,future,plural,2nd,regular,\r\nābuntur,1st,passive,indicative,future,plural,3rd,regular,\r\n,1st,passive,subjunctive,future,singular,1st,,\r\n,1st,passive,subjunctive,future,singular,2nd,,\r\n,1st,passive,subjunctive,future,singular,3rd,,\r\n,1st,passive,subjunctive,future,plural,1st,,\r\n,1st,passive,subjunctive,future,plural,2nd,,\r\n,1st,passive,subjunctive,future,plural,3rd,,\r\nēbor,2nd,passive,indicative,future,singular,1st,regular,\r\nēberis,2nd,passive,indicative,future,singular,2nd,regular,\r\nēbere,2nd,passive,indicative,future,singular,2nd,regular,\r\nēbitur,2nd,passive,indicative,future,singular,3rd,regular,\r\nēbimur,2nd,passive,indicative,future,plural,1st,regular,\r\nēbiminī,2nd,passive,indicative,future,plural,2nd,regular,\r\nēbuntur,2nd,passive,indicative,future,plural,3rd,regular,\r\n,2nd,passive,subjunctive,future,singular,1st,,\r\n,2nd,passive,subjunctive,future,singular,2nd,,\r\n,2nd,passive,subjunctive,future,singular,3rd,,\r\n,2nd,passive,subjunctive,future,plural,1st,,\r\n,2nd,passive,subjunctive,future,plural,2nd,,\r\n,2nd,passive,subjunctive,future,plural,3rd,,\r\nar,3rd,passive,indicative,future,singular,1st,regular,\r\nēris,3rd,passive,indicative,future,singular,2nd,regular,\r\nēre,3rd,passive,indicative,future,singular,2nd,irregular,\r\nētur,3rd,passive,indicative,future,singular,3rd,regular,\r\nēmur,3rd,passive,indicative,future,plural,1st,regular,\r\nēminī,3rd,passive,indicative,future,plural,2nd,regular,\r\nentur,3rd,passive,indicative,future,plural,3rd,regular,\r\n,3rd,passive,subjunctive,future,singular,1st,,\r\n,3rd,passive,subjunctive,future,singular,2nd,,\r\n,3rd,passive,subjunctive,future,singular,3rd,,\r\n,3rd,passive,subjunctive,future,plural,1st,,\r\n,3rd,passive,subjunctive,future,plural,2nd,,\r\n,3rd,passive,subjunctive,future,plural,3rd,,\r\niar,4th,passive,indicative,future,singular,1st,regular,\r\niēris,4th,passive,indicative,future,singular,2nd,regular,\r\nīēre,4th,passive,indicative,future,singular,2nd,irregular,\r\niētur,4th,passive,indicative,future,singular,3rd,regular,\r\niēmur,4th,passive,indicative,future,plural,1st,regular,\r\niēminī,4th,passive,indicative,future,plural,2nd,regular,\r\nientur,4th,passive,indicative,future,plural,3rd,regular,\r\n,4th,passive,subjunctive,future,singular,1st,,\r\n,4th,passive,subjunctive,future,singular,2nd,,\r\n,4th,passive,subjunctive,future,singular,3rd,,\r\n,4th,passive,subjunctive,future,plural,1st,,\r\n,4th,passive,subjunctive,future,plural,2nd,,\r\n,4th,passive,subjunctive,future,plural,3rd,,\r\nātus sum,1st,passive,indicative,perfect,singular,1st,regular,\r\nātus fui,1st,passive,indicative,perfect,singular,1st,regular,\r\nātus es,1st,passive,indicative,perfect,singular,2nd,regular,\r\nātus fuisti,1st,passive,indicative,perfect,singular,2nd,regular,\r\nātus est,1st,passive,indicative,perfect,singular,3rd,regular,\r\nātus fuit,1st,passive,indicative,perfect,singular,3rd,regular,\r\nāti sumus,1st,passive,indicative,perfect,plural,1st,regular,\r\nāti fuimus,1st,passive,indicative,perfect,plural,1st,irregular,\r\nāti estis,1st,passive,indicative,perfect,plural,2nd,regular,\r\nāti fuistis,1st,passive,indicative,perfect,plural,2nd,irregular,\r\nāti sunt,1st,passive,indicative,perfect,plural,3rd,regular,\r\nāti fuerunt,1st,passive,indicative,perfect,plural,3rd,irregular,\r\nātus sim,1st,passive,subjunctive,perfect,singular,1st,regular,\r\nātus fuerim,1st,passive,subjunctive,perfect,singular,1st,irregular,\r\nātus sis,1st,passive,subjunctive,perfect,singular,2nd,regular,\r\nātus fueris,1st,passive,subjunctive,perfect,singular,2nd,irregular,\r\nātus sit,1st,passive,subjunctive,perfect,singular,3rd,regular,\r\nātus fuerit,1st,passive,subjunctive,perfect,singular,3rd,regular,\r\nāti sīmus,1st,passive,subjunctive,perfect,plural,1st,regular,\r\nāti fuerimus,1st,passive,subjunctive,perfect,plural,1st,irregular,\r\nāti sītis,1st,passive,subjunctive,perfect,plural,2nd,regular,\r\nāti fueritis,1st,passive,subjunctive,perfect,plural,2nd,irregular,\r\nāti sint,1st,passive,subjunctive,perfect,plural,3rd,regular,\r\nāti fuerint,1st,passive,subjunctive,perfect,plural,3rd,irregular,\r\nitus sum,2nd,passive,indicative,perfect,singular,1st,regular,\r\nitus es,2nd,passive,indicative,perfect,singular,2nd,regular,\r\nitus est,2nd,passive,indicative,perfect,singular,3rd,regular,\r\nitī sumus,2nd,passive,indicative,perfect,plural,1st,regular,\r\nitī estis,2nd,passive,indicative,perfect,plural,2nd,regular,\r\nitī sunt,2nd,passive,indicative,perfect,plural,3rd,regular,\r\nitus sim,2nd,passive,subjunctive,perfect,singular,1st,regular,\r\nitus sīs,2nd,passive,subjunctive,perfect,singular,2nd,regular,\r\nitus sit,2nd,passive,subjunctive,perfect,singular,3rd,regular,\r\nitī sīmus,2nd,passive,subjunctive,perfect,plural,1st,regular,\r\nitī sītis,2nd,passive,subjunctive,perfect,plural,2nd,regular,\r\nitī sint,2nd,passive,subjunctive,perfect,plural,3rd,regular,\r\nus sum,3rd,passive,indicative,perfect,singular,1st,regular,\r\nus es,3rd,passive,indicative,perfect,singular,2nd,regular,\r\nus est,3rd,passive,indicative,perfect,singular,3rd,regular,\r\nī sumus,3rd,passive,indicative,perfect,plural,1st,regular,\r\nī estis,3rd,passive,indicative,perfect,plural,2nd,regular,\r\nī sunt,3rd,passive,indicative,perfect,plural,3rd,regular,\r\nus sim,3rd,passive,subjunctive,perfect,singular,1st,regular,\r\nus sīs,3rd,passive,subjunctive,perfect,singular,2nd,regular,\r\nus sit,3rd,passive,subjunctive,perfect,singular,3rd,regular,\r\nus sīmus,3rd,passive,subjunctive,perfect,plural,1st,regular,\r\nus sītis,3rd,passive,subjunctive,perfect,plural,2nd,regular,\r\nus sint,3rd,passive,subjunctive,perfect,plural,3rd,regular,\r\nītus sum,4th,passive,indicative,perfect,singular,1st,regular,\r\nītus es,4th,passive,indicative,perfect,singular,2nd,regular,\r\nītus est,4th,passive,indicative,perfect,singular,3rd,regular,\r\nītī sumus,4th,passive,indicative,perfect,plural,1st,regular,\r\nīti estis,4th,passive,indicative,perfect,plural,2nd,regular,\r\nīti sunt,4th,passive,indicative,perfect,plural,3rd,regular,\r\nītus sim,4th,passive,subjunctive,perfect,singular,1st,regular,\r\nītus sīs,4th,passive,subjunctive,perfect,singular,2nd,regular,\r\nītus sit,4th,passive,subjunctive,perfect,singular,3rd,regular,\r\nītī sīmus,4th,passive,subjunctive,perfect,plural,1st,regular,\r\nīti sītis,4th,passive,subjunctive,perfect,plural,2nd,regular,\r\nīti sint,4th,passive,subjunctive,perfect,plural,3rd,regular,\r\nātus eram,1st,passive,indicative,pluperfect,singular,1st,regular,\r\nātus fueram,1st,passive,indicative,pluperfect,singular,1st,irregular,\r\nātus eras,1st,passive,indicative,pluperfect,singular,2nd,regular,\r\nātus fueras,1st,passive,indicative,pluperfect,singular,2nd,irregular,\r\nātus erat,1st,passive,indicative,pluperfect,singular,3rd,regular,\r\nātus fuerat,1st,passive,indicative,pluperfect,singular,3rd,irregular,\r\nātī erāmus,1st,passive,indicative,pluperfect,plural,1st,regular,\r\nātī fueramus,1st,passive,indicative,pluperfect,plural,1st,irregular,\r\nātī erātis,1st,passive,indicative,pluperfect,plural,2nd,regular,\r\nātī fueratis,1st,passive,indicative,pluperfect,plural,2nd,irregular,\r\nātī erant,1st,passive,indicative,pluperfect,plural,3rd,regular,\r\nātī fuerant,1st,passive,indicative,pluperfect,plural,3rd,irregular,\r\nātus essem,1st,passive,subjunctive,pluperfect,singular,1st,regular,\r\nātus fuissem,1st,passive,subjunctive,pluperfect,singular,1st,irregular,\r\nātus esses,1st,passive,subjunctive,pluperfect,singular,2nd,regular,\r\nātus fuissēs,1st,passive,subjunctive,pluperfect,singular,2nd,irregular,\r\nātus esset,1st,passive,subjunctive,pluperfect,singular,3rd,regular,\r\nātus fuisset,1st,passive,subjunctive,pluperfect,singular,3rd,irregular,\r\nāti essēmus,1st,passive,subjunctive,pluperfect,plural,1st,regular,\r\nāti fuissēmus,1st,passive,subjunctive,pluperfect,plural,1st,irregular,\r\nāti essētis,1st,passive,subjunctive,pluperfect,plural,2nd,regular,\r\nāti fuissētis,1st,passive,subjunctive,pluperfect,plural,2nd,regular,\r\nāti essent,1st,passive,subjunctive,pluperfect,plural,3rd,regular,\r\nāti fuissent,1st,passive,subjunctive,pluperfect,plural,3rd,regular,\r\nitus eram,2nd,passive,indicative,pluperfect,singular,1st,regular,\r\nitus erās,2nd,passive,indicative,pluperfect,singular,2nd,regular,\r\nitus erat,2nd,passive,indicative,pluperfect,singular,3rd,regular,\r\nitī erāmus,2nd,passive,indicative,pluperfect,plural,1st,regular,\r\nitī erātis,2nd,passive,indicative,pluperfect,plural,2nd,regular,\r\nitī erant,2nd,passive,indicative,pluperfect,plural,3rd,regular,\r\nitus essem,2nd,passive,subjunctive,pluperfect,singular,1st,regular,\r\nitus essēs,2nd,passive,subjunctive,pluperfect,singular,2nd,regular,\r\nitus esset,2nd,passive,subjunctive,pluperfect,singular,3rd,regular,\r\nitī essēmus,2nd,passive,subjunctive,pluperfect,plural,1st,regular,\r\nīti essētis,2nd,passive,subjunctive,pluperfect,plural,2nd,regular,\r\nīti essent,2nd,passive,subjunctive,pluperfect,plural,3rd,regular,\r\nus eram,3rd,passive,indicative,pluperfect,singular,1st,regular,\r\nus erās,3rd,passive,indicative,pluperfect,singular,2nd,regular,\r\nus erat,3rd,passive,indicative,pluperfect,singular,3rd,regular,\r\nī erāmus,3rd,passive,indicative,pluperfect,plural,1st,regular,\r\nī erātis,3rd,passive,indicative,pluperfect,plural,2nd,regular,\r\nī erant,3rd,passive,indicative,pluperfect,plural,3rd,regular,\r\nus essem,3rd,passive,subjunctive,pluperfect,singular,1st,regular,\r\nus essēs,3rd,passive,subjunctive,pluperfect,singular,2nd,regular,\r\nus esset,3rd,passive,subjunctive,pluperfect,singular,3rd,regular,\r\nī essēmus,3rd,passive,subjunctive,pluperfect,plural,1st,regular,\r\nī essētis,3rd,passive,subjunctive,pluperfect,plural,2nd,regular,\r\nī essent,3rd,passive,subjunctive,pluperfect,plural,3rd,regular,\r\nītus eram,4th,passive,indicative,pluperfect,singular,1st,regular,\r\nītus erās,4th,passive,indicative,pluperfect,singular,2nd,regular,\r\nītus erat,4th,passive,indicative,pluperfect,singular,3rd,regular,\r\nītī erāmus,4th,passive,indicative,pluperfect,plural,1st,regular,\r\nīti erātis,4th,passive,indicative,pluperfect,plural,2nd,regular,\r\nītī erant,4th,passive,indicative,pluperfect,plural,3rd,regular,\r\nītus essem,4th,passive,subjunctive,pluperfect,singular,1st,regular,\r\nītus essēs,4th,passive,subjunctive,pluperfect,singular,2nd,regular,\r\nītus esset,4th,passive,subjunctive,pluperfect,singular,3rd,regular,\r\nītī essēmus,4th,passive,subjunctive,pluperfect,plural,1st,regular,\r\nīti essētis,4th,passive,subjunctive,pluperfect,plural,2nd,regular,\r\nīti essent,4th,passive,subjunctive,pluperfect,plural,3rd,regular,\r\nātus erō,1st,passive,indicative,future_perfect,singular,1st,regular,\r\nātus eris,1st,passive,indicative,future_perfect,singular,2nd,regular,\r\nātus erit,1st,passive,indicative,future_perfect,singular,3rd,regular,\r\nāti erimus,1st,passive,indicative,future_perfect,plural,1st,regular,\r\nāti eritis,1st,passive,indicative,future_perfect,plural,2nd,regular,\r\nāti erunt,1st,passive,indicative,future_perfect,plural,3rd,regular,\r\n,1st,passive,subjunctive,future_perfect,singular,1st,,\r\n,1st,passive,subjunctive,future_perfect,singular,2nd,,\r\n,1st,passive,subjunctive,future_perfect,singular,3rd,,\r\n,1st,passive,subjunctive,future_perfect,plural,1st,,\r\n,1st,passive,subjunctive,future_perfect,plural,2nd,,\r\n,1st,passive,subjunctive,future_perfect,plural,3rd,,\r\nitus erō,2nd,passive,indicative,future_perfect,singular,1st,regular,\r\nitus eris,2nd,passive,indicative,future_perfect,singular,2nd,regular,\r\nitus erit,2nd,passive,indicative,future_perfect,singular,3rd,regular,\r\nitī erimus,2nd,passive,indicative,future_perfect,plural,1st,regular,\r\nitī eritis,2nd,passive,indicative,future_perfect,plural,2nd,regular,\r\nitī erunt,2nd,passive,indicative,future_perfect,plural,3rd,regular,\r\n,2nd,passive,subjunctive,future_perfect,singular,1st,,\r\n,2nd,passive,subjunctive,future_perfect,singular,2nd,,\r\n,2nd,passive,subjunctive,future_perfect,singular,3rd,,\r\n,2nd,passive,subjunctive,future_perfect,plural,1st,,\r\n,2nd,passive,subjunctive,future_perfect,plural,2nd,,\r\n,2nd,passive,subjunctive,future_perfect,plural,3rd,,\r\nus erō,3rd,passive,indicative,future_perfect,singular,1st,regular,\r\nus eris,3rd,passive,indicative,future_perfect,singular,2nd,regular,\r\nus erit,3rd,passive,indicative,future_perfect,singular,3rd,regular,\r\nī erimus,3rd,passive,indicative,future_perfect,plural,1st,regular,\r\nī eritis,3rd,passive,indicative,future_perfect,plural,2nd,regular,\r\nī erunt,3rd,passive,indicative,future_perfect,plural,3rd,regular,\r\n,3rd,passive,subjunctive,future_perfect,singular,1st,,\r\n,3rd,passive,subjunctive,future_perfect,singular,2nd,,\r\n,3rd,passive,subjunctive,future_perfect,singular,3rd,,\r\n,3rd,passive,subjunctive,future_perfect,plural,1st,,\r\n,3rd,passive,subjunctive,future_perfect,plural,2nd,,\r\n,3rd,passive,subjunctive,future_perfect,plural,3rd,,\r\nītus erō,4th,passive,indicative,future_perfect,singular,1st,regular,\r\nītus eris,4th,passive,indicative,future_perfect,singular,2nd,regular,\r\nītus erit,4th,passive,indicative,future_perfect,singular,3rd,regular,\r\nītī erimus,4th,passive,indicative,future_perfect,plural,1st,regular,\r\nītī eritis,4th,passive,indicative,future_perfect,plural,2nd,regular,\r\nītī erunt,4th,passive,indicative,future_perfect,plural,3rd,regular,\r\n,4th,passive,subjunctive,future_perfect,singular,1st,,\r\n,4th,passive,subjunctive,future_perfect,singular,2nd,,\r\n,4th,passive,subjunctive,future_perfect,singular,3rd,,\r\n,4th,passive,subjunctive,future_perfect,plural,1st,,\r\n,4th,passive,subjunctive,future_perfect,plural,2nd,,\r\n,4th,passive,subjunctive,future_perfect,plural,3rd,,";
 
-var verbFootnotesCSV = "Index,Text\n2,Chiefly in poetry.\n3,\"In tenses based on the perfect stem (the perfect, pluperfect and future perfect of the Active voice) a v between two vowels is often lost with contraction of the two vowels, thus āvī to ā, ēvī to ē, ōvi to ō. Perfects in īvī often omit the v but rarely contract the vowels, except before ss or st, and sometimes in the third person. In addition to the use of v or u, the Active perfect stem can also be formed in a number of other ways, such as the addition of s to the root (eg carpsi), reduplication of the root (eg cecidi from cado), and simple lengthening of the vowel (eg vidī from video or legī from lego).\"\n4,\"Dic, duc, fac, and fer lack a final vowel in the imperative in classical Latin. The singular imperative of the verb sciō is always scītō, and the plural is usually scītōte.\"\n5,Common in epic poetry.\n6,Present in early Latin but chiefly confined to popular use until Livy and later writers.\n7,The verb fīō is a 4th conjugation verb that is irregular in only two forms: the present infinitive fierī and the imperfect subjunctive fierem.";
+var verbFootnotesCSV = "Index,Text\r\n2,Chiefly in poetry.\r\n3,\"In tenses based on the perfect stem (the perfect, pluperfect and future perfect of the Active voice) a v between two vowels is often lost with contraction of the two vowels, thus āvī to ā, ēvī to ē, ōvi to ō. Perfects in īvī often omit the v but rarely contract the vowels, except before ss or st, and sometimes in the third person. In addition to the use of v or u, the Active perfect stem can also be formed in a number of other ways, such as the addition of s to the root (eg carpsi), reduplication of the root (eg cecidi from cado), and simple lengthening of the vowel (eg vidī from video or legī from lego).\"\r\n4,\"Dic, duc, fac, and fer lack a final vowel in the imperative in classical Latin. The singular imperative of the verb sciō is always scītō, and the plural is usually scītōte.\"\r\n5,Common in epic poetry.\r\n6,Present in early Latin but chiefly confined to popular use until Livy and later writers.\r\n7,The verb fīō is a 4th conjugation verb that is irregular in only two forms: the present infinitive fierī and the imperfect subjunctive fierem.";
 
 function createCommonjsModule(fn, module) {
 	return module = { exports: {} }, fn(module, module.exports), module.exports;
@@ -5767,16 +4354,16 @@ let dataSet = new LanguageDataset(language);
 const importerName = 'csv';
 languageModel.features[types.declension].addImporter(importerName)
     .map('1st 2nd',
-  [ languageModel.features[types.declension][constants.ORD_1ST],
-    languageModel.features[types.declension][constants.ORD_2ND]
+  [ languageModel.features[types.declension][Constants.ORD_1ST],
+    languageModel.features[types.declension][Constants.ORD_2ND]
   ]);
 languageModel.features[types.gender].addImporter(importerName)
     .map('masculine feminine',
-  [ languageModel.features[types.gender][constants.GEND_MASCULINE],
-    languageModel.features[types.gender][constants.GEND_FEMININE]
+  [ languageModel.features[types.gender][Constants.GEND_MASCULINE],
+    languageModel.features[types.gender][Constants.GEND_FEMININE]
   ]);
 languageModel.features[types.tense].addImporter(importerName)
-    .map('future_perfect', languageModel.features[types.tense][constants.TENSE_FUTURE_PERFECT]);
+    .map('future_perfect', languageModel.features[types.tense][Constants.TENSE_FUTURE_PERFECT]);
 const footnotes = new FeatureType(types.footnote, [], language);
 
 // endregion Definition of grammatical features
@@ -5858,21 +4445,21 @@ dataSet.addFootnotes = function (partOfSpeech, data) {
 
 dataSet.loadData = function () {
     // Nouns
-  let partOfSpeech = languageModel.features[types.part][constants.POFS_NOUN];
+  let partOfSpeech = languageModel.features[types.part][Constants.POFS_NOUN];
   let suffixes = papaparse.parse(nounSuffixesCSV, {});
   this.addSuffixes(partOfSpeech, suffixes.data);
   let footnotes = papaparse.parse(nounFootnotesCSV, {});
   this.addFootnotes(partOfSpeech, footnotes.data);
 
     // Adjectives
-  partOfSpeech = languageModel.features[types.part][constants.POFS_ADJECTIVE];
+  partOfSpeech = languageModel.features[types.part][Constants.POFS_ADJECTIVE];
   suffixes = papaparse.parse(adjectiveSuffixesCSV, {});
   this.addSuffixes(partOfSpeech, suffixes.data);
   footnotes = papaparse.parse(adjectiveFootnotesCSV, {});
   this.addFootnotes(partOfSpeech, footnotes.data);
 
     // Verbs
-  partOfSpeech = languageModel.features[types.part][constants.POFS_VERB];
+  partOfSpeech = languageModel.features[types.part][Constants.POFS_VERB];
   suffixes = papaparse.parse(verbSuffixesCSV, {});
   this.addVerbSuffixes(partOfSpeech, suffixes.data);
   footnotes = papaparse.parse(verbFootnotesCSV, {});
@@ -7597,7 +6184,7 @@ class View {
      * Converts a WordData, returned from inflection tables library, into an HTML representation of an inflection table
      * and inserts that HTML into a `container` HTML element. `messages` provides a translation for view's texts.
      * @param {HTMLElement} container - An HTML element where this view will be inserted.
-     * @param {WordData} wordData - A result set from inflection tables library.
+     * @param {LexicalData} wordData - A result set from inflection tables library.
      * @param {MessageBundle} messages - A message bundle with message translations.
      */
   render (container, wordData, messages) {
@@ -7738,13 +6325,13 @@ class NounView extends LatinView {
     this.id = 'nounDeclension';
     this.name = 'noun declension';
     this.title = 'Noun declension';
-    this.partOfSpeech = this.language_features[Feature.types.part][constants.POFS_NOUN].value;
+    this.partOfSpeech = this.language_features[Feature.types.part][Constants.POFS_NOUN].value;
 
         // Models.Feature that are different from base class values
     this.features.genders = new GroupFeatureType(this.language_features[Feature.types.gender], 'Gender',
-      [ this.language_features[Feature.types.gender][constants.GEND_MASCULINE],
-        this.language_features[Feature.types.gender][constants.GEND_FEMININE],
-        this.language_features[Feature.types.gender][constants.GEND_NEUTER]
+      [ this.language_features[Feature.types.gender][Constants.GEND_MASCULINE],
+        this.language_features[Feature.types.gender][Constants.GEND_FEMININE],
+        this.language_features[Feature.types.gender][Constants.GEND_NEUTER]
       ]);
     this.createTable();
   }
@@ -7760,9 +6347,9 @@ class AdjectiveView extends LatinView {
 
         // Models.Feature that are different from base class values
     this.features.declensions = new GroupFeatureType(this.language_features[Feature.types.declension], 'Declension',
-      [ this.language_features[Feature.types.declension][constants.ORD_1ST],
-        this.language_features[Feature.types.declension][constants.ORD_2ND],
-        this.language_features[Feature.types.declension][constants.ORD_3RD]
+      [ this.language_features[Feature.types.declension][Constants.ORD_1ST],
+        this.language_features[Feature.types.declension][Constants.ORD_2ND],
+        this.language_features[Feature.types.declension][Constants.ORD_3RD]
       ]);
     this.createTable();
   }
@@ -7771,7 +6358,7 @@ class AdjectiveView extends LatinView {
 class VerbView extends LatinView {
   constructor () {
     super();
-    this.partOfSpeech = this.language_features[Feature.types.part][constants.POFS_VERB].value;
+    this.partOfSpeech = this.language_features[Feature.types.part][Constants.POFS_VERB].value;
 
     this.features = {
       tenses: new GroupFeatureType(this.language_features[Feature.types.tense], 'Tenses'),
@@ -7946,9 +6533,9 @@ var viewsLatin = [new NounView(), new AdjectiveView(),
   new VoiceConjugationMoodView(), new VoiceMoodConjugationView(), new ConjugationVoiceMoodView(),
   new ConjugationMoodVoiceView(), new MoodVoiceConjugationView(), new MoodConjugationVoiceView()];
 
-var nounSuffixesCSV$1 = "Ending,Number,Case,Declension,Gender,Type,Primary,Footnote\nα,dual,accusative,1st,feminine,regular,primary,\nά,dual,accusative,1st,feminine,regular,,\nᾶ,dual,accusative,1st,feminine,regular,,2\nαιν,dual,dative,1st,feminine,regular,primary,\nαῖν,dual,dative,1st,feminine,regular,,\nαιιν,dual,dative,1st,feminine,irregular,,\nαιν,dual,genitive,1st,feminine,regular,primary,\nαῖν,dual,genitive,1st,feminine,regular,,\nαιιν,dual,genitive,1st,feminine,irregular,,\nα,dual,nominative,1st,feminine,regular,primary,\nά,dual,nominative,1st,feminine,regular,,\nᾶ,dual,nominative,1st,feminine,regular,,2\nα,dual,vocative,1st,feminine,regular,primary,\nά,dual,vocative,1st,feminine,regular,,\nᾶ,dual,vocative,1st,feminine,regular,,2\nα,dual,accusative,1st,masculine,regular,primary,\nά,dual,accusative,1st,masculine,regular,,\nᾶ,dual,accusative,1st,masculine,regular,,2\nαιν,dual,dative,1st,masculine,regular,primary,\nαῖν,dual,dative,1st,masculine,regular,,\nαιιν,dual,dative,1st,masculine,irregular,,\nαιν,dual,genitive,1st,masculine,regular,primary,\nαῖν,dual,genitive,1st,masculine,regular,,\nαιιν,dual,genitive,1st,masculine,irregular,,\nα,dual,nominative,1st,masculine,regular,primary,\nά,dual,nominative,1st,masculine,regular,,\nᾶ,dual,nominative,1st,masculine,regular,,2\nα,dual,vocative,1st,masculine,regular,primary,\nά,dual,vocative,1st,masculine,regular,,\nᾶ,dual,vocative,1st,masculine,regular,,2\nας,plural,accusative,1st,feminine,regular,primary,\nάς,plural,accusative,1st,feminine,regular,,\nᾶς,plural,accusative,1st,feminine,regular,,2\nανς,plural,accusative,1st,feminine,irregular,,\nαις,plural,accusative,1st,feminine,irregular,,\nαις,plural,dative,1st,feminine,regular,primary,\nαῖς,plural,dative,1st,feminine,regular,,\nῃσι,plural,dative,1st,feminine,irregular,,44\nῃσιν,plural,dative,1st,feminine,irregular,,4 44\nῃς,plural,dative,1st,feminine,irregular,,44\nαισι,plural,dative,1st,feminine,irregular,,44\nαισιν,plural,dative,1st,feminine,irregular,,4 44\nῶν,plural,genitive,1st,feminine,regular,primary,\nάων,plural,genitive,1st,feminine,irregular,,\nέων,plural,genitive,1st,feminine,irregular,,\nήων,plural,genitive,1st,feminine,irregular,,\nᾶν,plural,genitive,1st,feminine,irregular,,\nαι,plural,nominative,1st,feminine,regular,primary,\nαί,plural,nominative,1st,feminine,regular,,\nαῖ,plural,nominative,1st,feminine,regular,,2\nαι,plural,vocative,1st,feminine,regular,primary,\nαί,plural,vocative,1st,feminine,regular,,\nαῖ,plural,vocative,1st,feminine,regular,,2\nας,plural,accusative,1st,masculine,regular,primary,\nάς,plural,accusative,1st,masculine,regular,,\nᾶς,plural,accusative,1st,masculine,regular,,3\nανς,plural,accusative,1st,masculine,irregular,,\nαις,plural,accusative,1st,masculine,irregular,,\nαις,plural,dative,1st,masculine,regular,primary,\nαῖς,plural,dative,1st,masculine,regular,,\nῃσι,plural,dative,1st,masculine,irregular,,44\nῃσιν,plural,dative,1st,masculine,irregular,,4 44\nῃς,plural,dative,1st,masculine,irregular,,44\nαισι,plural,dative,1st,masculine,irregular,,44\nαισιν,plural,dative,1st,masculine,irregular,,4 44\nῶν,plural,genitive,1st,masculine,regular,primary,\nάων,plural,genitive,1st,masculine,irregular,,\nέων,plural,genitive,1st,masculine,irregular,,\nήων,plural,genitive,1st,masculine,irregular,,\nᾶν,plural,genitive,1st,masculine,irregular,,\nαι,plural,nominative,1st,masculine,regular,primary,\nαί,plural,nominative,1st,masculine,regular,,\nαῖ,plural,nominative,1st,masculine,regular,,3\nαι,plural,vocative,1st,masculine,regular,primary,\nαί,plural,vocative,1st,masculine,regular,,\nαῖ,plural,vocative,1st,masculine,regular,,3\nαν,singular,accusative,1st,feminine,regular,primary,\nην,singular,accusative,1st,feminine,regular,primary,\nήν,singular,accusative,1st,feminine,regular,,\nᾶν,singular,accusative,1st,feminine,regular,,2\nῆν,singular,accusative,1st,feminine,regular,,2\nάν,singular,accusative,1st,feminine,irregular,,63\nᾳ,singular,dative,1st,feminine,regular,primary,\nῃ,singular,dative,1st,feminine,regular,primary,\nῇ,singular,dative,1st,feminine,regular,,2\nᾷ,singular,dative,1st,feminine,regular,,2\nηφι,singular,dative,1st,feminine,irregular,,45\nηφιν,singular,dative,1st,feminine,irregular,,4 45\nῆφι,singular,dative,1st,feminine,irregular,,45\nῆφιv,singular,dative,1st,feminine,irregular,,4 45\nας,singular,genitive,1st,feminine,regular,primary,\nης,singular,genitive,1st,feminine,regular,primary,\nῆs,singular,genitive,1st,feminine,regular,,\nᾶs,singular,genitive,1st,feminine,regular,,2\nηφι,singular,genitive,1st,feminine,irregular,,45\nηφιν,singular,genitive,1st,feminine,irregular,,4 45\nῆφι,singular,genitive,1st,feminine,irregular,,45\nῆφιv,singular,genitive,1st,feminine,irregular,,4 45\nα,singular,nominative,1st,feminine,regular,primary,\nη,singular,nominative,1st,feminine,regular,primary,1\nή,singular,nominative,1st,feminine,regular,,\nᾶ,singular,nominative,1st,feminine,regular,,2\nῆ,singular,nominative,1st,feminine,regular,,2\nά,singular,nominative,1st,feminine,irregular,,63\nα,singular,vocative,1st,feminine,regular,primary,\nη,singular,vocative,1st,feminine,regular,primary,\nή,singular,vocative,1st,feminine,regular,,\nᾶ,singular,vocative,1st,feminine,regular,,2\nῆ,singular,vocative,1st,feminine,regular,,2\nά,singular,vocative,1st,feminine,irregular,,63\nαν,singular,accusative,1st,masculine,regular,primary,\nην,singular,accusative,1st,masculine,regular,primary,3\nήν,singular,accusative,1st,masculine,regular,,\nᾶν,singular,accusative,1st,masculine,regular,,3\nῆν,singular,accusative,1st,masculine,regular,,3\nεα,singular,accusative,1st,masculine,irregular,,\nᾳ,singular,dative,1st,masculine,regular,primary,\nῃ,singular,dative,1st,masculine,regular,primary,\nῇ,singular,dative,1st,masculine,regular,,\nᾷ,singular,dative,1st,masculine,regular,,3\nῆ,singular,dative,1st,masculine,regular,,3\nηφι,singular,dative,1st,masculine,irregular,,45\nηφιν,singular,dative,1st,masculine,irregular,,4 45\nῆφι,singular,dative,1st,masculine,irregular,,45\nῆφιv,singular,dative,1st,masculine,irregular,,4 45\nου,singular,genitive,1st,masculine,regular,primary,\nοῦ,singular,genitive,1st,masculine,regular,,\nαο,singular,genitive,1st,masculine,irregular,,\nεω,singular,genitive,1st,masculine,irregular,,\nηφι,singular,genitive,1st,masculine,irregular,,45\nηφιν,singular,genitive,1st,masculine,irregular,,4 45\nῆφι,singular,genitive,1st,masculine,irregular,,45\nῆφιv,singular,genitive,1st,masculine,irregular,,4 45\nω,singular,genitive,1st,masculine,irregular,,\nα,singular,genitive,1st,masculine,irregular,,\nας,singular,nominative,1st,masculine,regular,primary,\nης,singular,nominative,1st,masculine,regular,primary,\nής,singular,nominative,1st,masculine,regular,,\nᾶs,singular,nominative,1st,masculine,regular,,3\nῆs,singular,nominative,1st,masculine,regular,,3\nα,singular,vocative,1st,masculine,regular,primary,\nη,singular,vocative,1st,masculine,regular,primary,\nά,singular,vocative,1st,masculine,regular,,\nᾶ,singular,vocative,1st,masculine,regular,,3\nῆ,singular,vocative,1st,masculine,regular,,3\nω,dual,accusative,2nd,masculine feminine,regular,primary,\nώ,dual,accusative,2nd,masculine feminine,regular,,5\nοιν,dual,dative,2nd,masculine feminine,regular,primary,\nοῖν,dual,dative,2nd,masculine feminine,regular,,5\nοιιν,dual,dative,2nd,masculine feminine,irregular,,\nῴν,dual,dative,2nd,masculine feminine,irregular,,7\nοιν,dual,genitive,2nd,masculine feminine,regular,primary,\nοῖν,dual,genitive,2nd,masculine feminine,regular,,5\nοιιν,dual,genitive,2nd,masculine feminine,irregular,,\nῴν,dual,genitive,2nd,masculine feminine,irregular,,7\nω,dual,nominative,2nd,masculine feminine,regular,primary,60\nώ,dual,nominative,2nd,masculine feminine,regular,,60\nω,dual,vocative,2nd,masculine feminine,regular,primary,\nώ,dual,vocative,2nd,masculine feminine,regular,,5\nω,dual,accusative,2nd,neuter,regular,primary,\nώ,dual,accusative,2nd,neuter,regular,,6\nοιν,dual,dative,2nd,neuter,regular,primary,\nοῖν,dual,dative,2nd,neuter,regular,,6\nοιιν,dual,dative,2nd,neuter,irregular,,\nοιν,dual,genitive,2nd,neuter,regular,primary,\nοῖν,dual,genitive,2nd,neuter,regular,,6\nοιιν,dual,genitive,2nd,neuter,irregular,,\nω,dual,nominative,2nd,neuter,regular,primary,\nώ,dual,nominative,2nd,neuter,regular,,6\nω,dual,vocative,2nd,neuter,regular,primary,\nώ,dual,vocative,2nd,neuter,regular,,6\nους,plural,accusative,2nd,masculine feminine,regular,primary,\nούς,plural,accusative,2nd,masculine feminine,regular,,41\nοῦς,plural,accusative,2nd,masculine feminine,regular,,5\nονς,plural,accusative,2nd,masculine feminine,irregular,,\nος,plural,accusative,2nd,masculine feminine,irregular,,\nως,plural,accusative,2nd,masculine feminine,irregular,,\nοις,plural,accusative,2nd,masculine feminine,irregular,,\nώς,plural,accusative,2nd,masculine feminine,irregular,,7\nοις,plural,dative,2nd,masculine feminine,regular,primary,\nοῖς,plural,dative,2nd,masculine feminine,regular,,5\nοισι,plural,dative,2nd,masculine feminine,irregular,,\nοισιν,plural,dative,2nd,masculine feminine,irregular,,4\nῴς,plural,dative,2nd,masculine feminine,irregular,,7\nόφι,plural,dative,2nd,masculine feminine,irregular,,45\nόφιv,plural,dative,2nd,masculine feminine,irregular,,4 45\nων,plural,genitive,2nd,masculine feminine,regular,primary,\nῶν,plural,genitive,2nd,masculine feminine,regular,,5\nών,plural,genitive,2nd,masculine feminine,irregular,,7\nόφι,plural,genitive,2nd,masculine feminine,irregular,,45\nόφιv,plural,genitive,2nd,masculine feminine,irregular,,4 45\nοι,plural,nominative,2nd,masculine feminine,regular,primary,\nοί,plural,nominative,2nd,masculine feminine,regular,,41\nοῖ,plural,nominative,2nd,masculine feminine,regular,,5\nῴ,plural,nominative,2nd,masculine feminine,irregular,,7\nοι,plural,vocative,2nd,masculine feminine,regular,primary,\nοί,plural,vocative,2nd,masculine feminine,regular,,41\nοῖ,plural,vocative,2nd,masculine feminine,regular,,5\nα,plural,accusative,2nd,neuter,regular,primary,\nᾶ,plural,accusative,2nd,neuter,regular,,6\nοις,plural,dative,2nd,neuter,regular,primary,\nοῖς,plural,dative,2nd,neuter,regular,,6\nοισι,plural,dative,2nd,neuter,irregular,,\nοισιν,plural,dative,2nd,neuter,irregular,,4\nόφι,plural,dative,2nd,neuter,irregular,,45\nόφιv,plural,dative,2nd,neuter,irregular,,4 45\nων,plural,genitive,2nd,neuter,regular,primary,\nῶν,plural,genitive,2nd,neuter,regular,,6\nόφι,plural,genitive,2nd,neuter,irregular,,45\nόφιv,plural,genitive,2nd,neuter,irregular,,4 45\nα,plural,nominative,2nd,neuter,regular,primary,\nᾶ,plural,nominative,2nd,neuter,regular,,6\nα,plural,vocative,2nd,neuter,regular,primary,\nᾶ,plural,vocative,2nd,neuter,regular,,6\nον,singular,accusative,2nd,masculine feminine,regular,primary,\nόν,singular,accusative,2nd,masculine feminine,regular,primary,41\nουν,singular,accusative,2nd,masculine feminine,regular,,5\nοῦν,singular,accusative,2nd,masculine feminine,regular,,5\nω,singular,accusative,2nd,masculine feminine,irregular,,7 5\nωv,singular,accusative,2nd,masculine feminine,irregular,,7 59\nώ,singular,accusative,2nd,masculine feminine,irregular,,7 42 59\nών,singular,accusative,2nd,masculine feminine,irregular,,7 59\nῳ,singular,dative,2nd,masculine feminine,regular,primary,\nῷ,singular,dative,2nd,masculine feminine,regular,,5\nῴ,singular,dative,2nd,masculine feminine,irregular,,7\nόφι,singular,dative,2nd,masculine feminine,irregular,,45\nόφιv,singular,dative,2nd,masculine feminine,irregular,,4 45\nου,singular,genitive,2nd,masculine feminine,regular,primary,\nοῦ,singular,genitive,2nd,masculine feminine,regular,,5\nοιο,singular,genitive,2nd,masculine feminine,irregular,,\nοο,singular,genitive,2nd,masculine feminine,irregular,,\nω,singular,genitive,2nd,masculine feminine,irregular,,\nώ,singular,genitive,2nd,masculine feminine,irregular,,7\nόφι,singular,genitive,2nd,masculine feminine,irregular,,45\nόφιv,singular,genitive,2nd,masculine feminine,irregular,,4 45\nος,singular,nominative,2nd,masculine feminine,regular,primary,\nους,singular,nominative,2nd,masculine feminine,regular,,5\noῦς,singular,nominative,2nd,masculine feminine,regular,,5\nός,singular,nominative,2nd,masculine feminine,regular,,\nώς,singular,nominative,2nd,masculine feminine,irregular,,7 42\nως,singular,nominative,2nd,masculine feminine,irregular,,\nε,singular,vocative,2nd,masculine feminine,regular,primary,\nέ,singular,vocative,2nd,masculine feminine,regular,,\nοu,singular,vocative,2nd,masculine feminine,regular,,5\nοῦ,singular,vocative,2nd,masculine feminine,regular,,42\nός,singular,vocative,2nd,masculine feminine,irregular,,57\nον,singular,accusative,2nd,neuter,regular,primary,\nοῦν,singular,accusative,2nd,neuter,regular,,6\nῳ,singular,dative,2nd,neuter,regular,primary,\nῷ,singular,dative,2nd,neuter,regular,,6\nόφι,singular,dative,2nd,neuter,irregular,,45\nόφιv,singular,dative,2nd,neuter,irregular,,4 45\nου,singular,genitive,2nd,neuter,regular,primary,\nοῦ,singular,genitive,2nd,neuter,regular,,6\nοο,singular,genitive,2nd,neuter,irregular,,\nοιο,singular,genitive,2nd,neuter,irregular,,\nω,singular,genitive,2nd,neuter,irregular,,\nόφι,singular,genitive,2nd,neuter,irregular,,45\nόφιv,singular,genitive,2nd,neuter,irregular,,4 45\nον,singular,nominative,2nd,neuter,regular,primary,\nοῦν,singular,nominative,2nd,neuter,regular,,6\nον,singular,vocative,2nd,neuter,regular,primary,\nοῦν,singular,vocative,2nd,neuter,regular,,6\nε,dual,accusative,3rd,masculine feminine,regular,primary,\nει,dual,accusative,3rd,masculine feminine,regular,,\nῆ,dual,accusative,3rd,masculine feminine,regular,,18\nω,dual,accusative,3rd,masculine feminine,irregular,,32\nῖ,dual,accusative,3rd,masculine feminine,irregular,,33\nεε,dual,accusative,3rd,masculine feminine,irregular,,16 55 61\nοιν,dual,dative,3rd,masculine feminine,regular,primary,\nοῖν,dual,dative,3rd,masculine feminine,regular,,\nοιιν,dual,dative,3rd,masculine feminine,irregular,,54\nσι,dual,dative,3rd,masculine feminine,irregular,,33 37\nεσσι,dual,dative,3rd,masculine feminine,irregular,,33\nεσι,dual,dative,3rd,masculine feminine,irregular,,33\nέοιν,dual,dative,3rd,masculine feminine,irregular,,16 61\nῳν,dual,dative,3rd,masculine feminine,irregular,,49\nοιν,dual,genitive,3rd,masculine feminine,regular,primary,\nοῖν,dual,genitive,3rd,masculine feminine,regular,,\nοιιν,dual,genitive,3rd,masculine feminine,irregular,,54\nέοιν,dual,genitive,3rd,masculine feminine,irregular,,16 61\nῳν,dual,genitive,3rd,masculine feminine,irregular,,49\nε,dual,nominative,3rd,masculine feminine,regular,primary,\nει,dual,nominative,3rd,masculine feminine,regular,,\nῆ,dual,nominative,3rd,masculine feminine,regular,,18\nω,dual,nominative,3rd,masculine feminine,irregular,,32\nῖ,dual,nominative,3rd,masculine feminine,irregular,,33\nεε,dual,nominative,3rd,masculine feminine,irregular,,16 55 61\nε,dual,vocative,3rd,masculine feminine,regular,primary,\nει,dual,vocative,3rd,masculine feminine,regular,,\nῆ,dual,vocative,3rd,masculine feminine,regular,,18\nω,dual,vocative,3rd,masculine feminine,irregular,,32\nῖ,dual,vocative,3rd,masculine feminine,irregular,,33\nεε,dual,vocative,3rd,masculine feminine,irregular,,16 55 61\nε,dual,accusative,3rd,neuter,regular,primary,\nει,dual,accusative,3rd,neuter,regular,,\nα,dual,accusative,3rd,neuter,regular,,\nεε,dual,accusative,3rd,neuter,irregular,,16 61\nαε,dual,accusative,3rd,neuter,irregular,,16 61\nοιν,dual,dative,3rd,neuter,regular,primary,\nῷν,dual,dative,3rd,neuter,regular,,\nοις,dual,dative,3rd,neuter,irregular,,33 38\nοισι,dual,dative,3rd,neuter,irregular,,33 38\nοισι(ν),dual,dative,3rd,neuter,irregular,,4 33 38\nοιιν,dual,dative,3rd,neuter,irregular,,\nέοιν,dual,dative,3rd,neuter,irregular,,16 61\nάοιν,dual,dative,3rd,neuter,irregular,,16 61\nοιν,dual,genitive,3rd,neuter,regular,primary,\nῷν,dual,genitive,3rd,neuter,regular,,\nων,dual,genitive,3rd,neuter,irregular,,33 38\nοιιν,dual,genitive,3rd,neuter,irregular,,\nέοιν,dual,genitive,3rd,neuter,irregular,,16 61\nάοιν,dual,genitive,3rd,neuter,irregular,,16 61\nε,dual,nominative,3rd,neuter,regular,primary,\nει,dual,nominative,3rd,neuter,regular,,\nα,dual,nominative,3rd,neuter,regular,,\nεε,dual,nominative,3rd,neuter,irregular,,16 61\nαε,dual,nominative,3rd,neuter,irregular,,16 61\nε,dual,vocative,3rd,neuter,regular,primary,\nει,dual,vocative,3rd,neuter,regular,,\nα,dual,vocative,3rd,neuter,regular,,\nεε,dual,vocative,3rd,neuter,irregular,,16 61\nαε,dual,vocative,3rd,neuter,irregular,,16 61\nας,plural,accusative,3rd,masculine feminine,regular,primary,\nεις,plural,accusative,3rd,masculine feminine,regular,,17 41\nες,plural,accusative,3rd,masculine feminine,regular,,\nς,plural,accusative,3rd,masculine feminine,regular,,\nῦς,plural,accusative,3rd,masculine feminine,regular,,17 18 48\nως,plural,accusative,3rd,masculine feminine,regular,,30\nῆς,plural,accusative,3rd,masculine feminine,irregular,,56\nέας,plural,accusative,3rd,masculine feminine,irregular,,\nέος,plural,accusative,3rd,masculine feminine,irregular,,\nῆος,plural,accusative,3rd,masculine feminine,irregular,,\nῆες,plural,accusative,3rd,masculine feminine,irregular,,\nῆας,plural,accusative,3rd,masculine feminine,irregular,,\nους,plural,accusative,3rd,masculine feminine,irregular,,32\nούς,plural,accusative,3rd,masculine feminine,irregular,,32\nεῖς,plural,accusative,3rd,masculine feminine,irregular,,31 41\nεες,plural,accusative,3rd,masculine feminine,irregular,,55 61\nις,plural,accusative,3rd,masculine feminine,irregular,,\nινς,plural,accusative,3rd,masculine feminine,irregular,,\nῶς,plural,accusative,3rd,masculine feminine,irregular,,48\nσι,plural,dative,3rd,masculine feminine,regular,primary,\nσιν,plural,dative,3rd,masculine feminine,regular,primary,4\nσί,plural,dative,3rd,masculine feminine,regular,,41\nσίν,plural,dative,3rd,masculine feminine,regular,,4 41\nεσι,plural,dative,3rd,masculine feminine,regular,,41\nεσιν,plural,dative,3rd,masculine feminine,regular,,4 41\nέσι,plural,dative,3rd,masculine feminine,regular,,\nέσιν,plural,dative,3rd,masculine feminine,regular,,4\nψι,plural,dative,3rd,masculine feminine,regular,,\nψιν,plural,dative,3rd,masculine feminine,regular,,4\nψί,plural,dative,3rd,masculine feminine,regular,,\nψίν,plural,dative,3rd,masculine feminine,regular,,4\nξι,plural,dative,3rd,masculine feminine,regular,,\nξιν,plural,dative,3rd,masculine feminine,regular,,4\nξί,plural,dative,3rd,masculine feminine,regular,,\nξίν,plural,dative,3rd,masculine feminine,regular,,4\nφι,plural,dative,3rd,masculine feminine,irregular,,45\nφιν,plural,dative,3rd,masculine feminine,irregular,,4 45\nηφι,plural,dative,3rd,masculine feminine,irregular,,45\nηφιv,plural,dative,3rd,masculine feminine,irregular,,4 45\nῆφι,plural,dative,3rd,masculine feminine,irregular,,45\nῆφιν,plural,dative,3rd,masculine feminine,irregular,,4 45\nόφι,plural,dative,3rd,masculine feminine,irregular,,45\nόφιν,plural,dative,3rd,masculine feminine,irregular,,4 45\nαις,plural,dative,3rd,masculine feminine,irregular,,33 41\nοῖσι,plural,dative,3rd,masculine feminine,irregular,,33\nοῖσιv,plural,dative,3rd,masculine feminine,irregular,,4 33\nεσσι,plural,dative,3rd,masculine feminine,irregular,,16 61\nεσσιv,plural,dative,3rd,masculine feminine,irregular,,4 16 61\nυσσι,plural,dative,3rd,masculine feminine,irregular,,54\nυσσιv,plural,dative,3rd,masculine feminine,irregular,,4 54\nσσί,plural,dative,3rd,masculine feminine,irregular,,54\nσσίv,plural,dative,3rd,masculine feminine,irregular,,4 54\nων,plural,genitive,3rd,masculine feminine,regular,primary,\nῶν,plural,genitive,3rd,masculine feminine,regular,,\n-,plural,genitive,3rd,masculine feminine,irregular,,41\nφι,plural,genitive,3rd,masculine feminine,irregular,,45\nφιν,plural,genitive,3rd,masculine feminine,irregular,,4 45\nηφι,plural,genitive,3rd,masculine feminine,irregular,,45\nηφιv,plural,genitive,3rd,masculine feminine,irregular,,4 45\nῆφι,plural,genitive,3rd,masculine feminine,irregular,,45\nῆφιν,plural,genitive,3rd,masculine feminine,irregular,,4 45\nόφι,plural,genitive,3rd,masculine feminine,irregular,,45\nόφιν,plural,genitive,3rd,masculine feminine,irregular,,4 45\nέων,plural,genitive,3rd,masculine feminine,irregular,,16 61\nες,plural,nominative,3rd,masculine feminine,regular,primary,\nως,plural,nominative,3rd,masculine feminine,regular,,30\nεις,plural,nominative,3rd,masculine feminine,regular,,17\nεῖς,plural,nominative,3rd,masculine feminine,regular,,18\nοί,plural,nominative,3rd,masculine feminine,irregular,,32\nαί,plural,nominative,3rd,masculine feminine,irregular,,33\nῆς,plural,nominative,3rd,masculine feminine,irregular,,18\nῄς,plural,nominative,3rd,masculine feminine,irregular,,31 41\nεες,plural,nominative,3rd,masculine feminine,irregular,,16 55 61\nοι,plural,nominative,3rd,masculine feminine,irregular,,33\nες,plural,vocative,3rd,masculine feminine,regular,primary,\nεις,plural,vocative,3rd,masculine feminine,regular,,17\nεῖς,plural,vocative,3rd,masculine feminine,regular,,18\nῆς,plural,vocative,3rd,masculine feminine,regular,,18\nως,plural,vocative,3rd,masculine feminine,regular,,30\nεες,plural,vocative,3rd,masculine feminine,irregular,,16 55 61\nα,plural,accusative,3rd,neuter,regular,primary,\nη,plural,accusative,3rd,neuter,regular,,\nς,plural,accusative,3rd,neuter,regular,,\nά,plural,accusative,3rd,neuter,irregular,,33\nαα,plural,accusative,3rd,neuter,irregular,,16 61\nεα,plural,accusative,3rd,neuter,irregular,,16 61\nσι,plural,dative,3rd,neuter,regular,primary,\nσιν,plural,dative,3rd,neuter,regular,primary,4\nσί,plural,dative,3rd,neuter,regular,,\nσίv,plural,dative,3rd,neuter,regular,,4\nασι,plural,dative,3rd,neuter,regular,,\nασιν,plural,dative,3rd,neuter,regular,,4\nεσι,plural,dative,3rd,neuter,regular,,\nεσιν,plural,dative,3rd,neuter,regular,,4\nέσι,plural,dative,3rd,neuter,regular,,\nέσιv,plural,dative,3rd,neuter,regular,,4\nεσσι,plural,dative,3rd,neuter,irregular,,54\nεσσιν,plural,dative,3rd,neuter,irregular,,4 54\nσσί,plural,dative,3rd,neuter,irregular,,54\nσσίv,plural,dative,3rd,neuter,irregular,,4 54\nασσι,plural,dative,3rd,neuter,irregular,,54\nασσιν,plural,dative,3rd,neuter,irregular,,4 54\nφι,plural,dative,3rd,neuter,irregular,,45\nφιν,plural,dative,3rd,neuter,irregular,,4 45\nηφι,plural,dative,3rd,neuter,irregular,,45\nηφιv,plural,dative,3rd,neuter,irregular,,4 45\nῆφι,plural,dative,3rd,neuter,irregular,,45\nῆφιν,plural,dative,3rd,neuter,irregular,,4 45\nόφι,plural,dative,3rd,neuter,irregular,,45\nόφιν,plural,dative,3rd,neuter,irregular,,4 45\nων,plural,genitive,3rd,neuter,regular,primary,\nῶν,plural,genitive,3rd,neuter,regular,primary,\nφι,plural,genitive,3rd,neuter,irregular,,\nφιν,plural,genitive,3rd,neuter,irregular,,4 45\nηφι,plural,genitive,3rd,neuter,irregular,,45\nηφιv,plural,genitive,3rd,neuter,irregular,,4 45\nῆφι,plural,genitive,3rd,neuter,irregular,,45\nῆφιν,plural,genitive,3rd,neuter,irregular,,4 45\nόφι,plural,genitive,3rd,neuter,irregular,,45\nόφιν,plural,genitive,3rd,neuter,irregular,,4 45\nέων,plural,genitive,3rd,neuter,irregular,,16 61\nάων,plural,genitive,3rd,neuter,irregular,,16 61\nα,plural,nominative,3rd,neuter,regular,primary,\nη,plural,nominative,3rd,neuter,regular,,\nες,plural,nominative,3rd,neuter,regular,,\nά,plural,nominative,3rd,neuter,irregular,,33\nεα,plural,nominative,3rd,neuter,irregular,,16 61\nαα,plural,nominative,3rd,neuter,irregular,,16 61\nα,plural,vocative,3rd,neuter,regular,primary,\nη,plural,vocative,3rd,neuter,regular,,\nες,plural,vocative,3rd,neuter,regular,,\nαα,plural,vocative,3rd,neuter,irregular,,16 61\nεα,plural,vocative,3rd,neuter,irregular,,16 61\nα,singular,accusative,3rd,masculine feminine,regular,primary,\nη,singular,accusative,3rd,masculine feminine,regular,,16\nν,singular,accusative,3rd,masculine feminine,regular,,\nιν,singular,accusative,3rd,masculine feminine,regular,,41\nῦν,singular,accusative,3rd,masculine feminine,regular,,18\nῶ,singular,accusative,3rd,masculine feminine,regular,,23\nυν,singular,accusative,3rd,masculine feminine,regular,,\nῦν,singular,accusative,3rd,masculine feminine,regular,,17\nύν,singular,accusative,3rd,masculine feminine,regular,,17\nέα,singular,accusative,3rd,masculine feminine,regular,,20\nην,singular,accusative,3rd,masculine feminine,regular,,24\nώ,singular,accusative,3rd,masculine feminine,regular,,19 41\nω,singular,accusative,3rd,masculine feminine,regular,,23\nεῖν,singular,accusative,3rd,masculine feminine,irregular,,31 41\nων,singular,accusative,3rd,masculine feminine,irregular,,33 41 49\nαν,singular,accusative,3rd,masculine feminine,irregular,,33 41\nον,singular,accusative,3rd,masculine feminine,irregular,,39\nῖς,singular,accusative,3rd,masculine feminine,irregular,,33\nεα,singular,accusative,3rd,masculine feminine,irregular,,61\nι,singular,dative,3rd,masculine feminine,regular,primary,\nί,singular,dative,3rd,masculine feminine,regular,,\nϊ,singular,dative,3rd,masculine feminine,regular,,17\nΐ,singular,dative,3rd,masculine feminine,regular,,40\nει,singular,dative,3rd,masculine feminine,regular,,16 17\nεῖ,singular,dative,3rd,masculine feminine,regular,,18\nαι,singular,dative,3rd,masculine feminine,regular,,\noῖ,singular,dative,3rd,masculine feminine,regular,,28 41\nῖ,singular,dative,3rd,masculine feminine,irregular,,33 46\nῆι,singular,dative,3rd,masculine feminine,irregular,,18\nᾳ,singular,dative,3rd,masculine feminine,irregular,,25\nῳ,singular,dative,3rd,masculine feminine,irregular,,33 34\nῷ,singular,dative,3rd,masculine feminine,irregular,,33\nιί,singular,dative,3rd,masculine feminine,irregular,,62\nυί,singular,dative,3rd,masculine feminine,irregular,,62\nέϊ,singular,dative,3rd,masculine feminine,irregular,,18 61\nος,singular,genitive,3rd,masculine feminine,regular,primary,\nός,singular,genitive,3rd,masculine feminine,regular,,\nους,singular,genitive,3rd,masculine feminine,regular,,16\nοῦς,singular,genitive,3rd,masculine feminine,regular,,19 46\nως,singular,genitive,3rd,masculine feminine,regular,,17 18\nώς,singular,genitive,3rd,masculine feminine,regular,,17 18 41\nῶς,singular,genitive,3rd,masculine feminine,regular,,47\nεως,singular,genitive,3rd,masculine feminine,regular,,17\nέως,singular,genitive,3rd,masculine feminine,regular,,\nεώς,singular,genitive,3rd,masculine feminine,regular,,\nέους,singular,genitive,3rd,masculine feminine,regular,,20\nω,singular,genitive,3rd,masculine feminine,irregular,,\nεος,singular,genitive,3rd,masculine feminine,irregular,,61\nΰς,singular,genitive,3rd,masculine feminine,irregular,,41 48\nῦς,singular,genitive,3rd,masculine feminine,irregular,,48\nνος,singular,genitive,3rd,masculine feminine,irregular,,22\nοῦ,singular,genitive,3rd,masculine feminine,irregular,,33\nηος,singular,genitive,3rd,masculine feminine,irregular,,55\nιός,singular,genitive,3rd,masculine feminine,irregular,,62\nuός,singular,genitive,3rd,masculine feminine,irregular,,62\nς,singular,nominative,3rd,masculine feminine,regular,primary,\n-,singular,nominative,3rd,masculine feminine,regular,primary,\nηρ,singular,nominative,3rd,masculine feminine,regular,,41\nις,singular,nominative,3rd,masculine feminine,regular,,\nϊς,singular,nominative,3rd,masculine feminine,regular,,\nώ,singular,nominative,3rd,masculine feminine,regular,,41\nψ,singular,nominative,3rd,masculine feminine,regular,,\nξ,singular,nominative,3rd,masculine feminine,regular,,\nρ,singular,nominative,3rd,masculine feminine,regular,,\nήρ,singular,nominative,3rd,masculine feminine,regular,,\nήν,singular,nominative,3rd,masculine feminine,regular,,50\nν,singular,nominative,3rd,masculine feminine,regular,,\nωρ,singular,nominative,3rd,masculine feminine,regular,,\nων,singular,nominative,3rd,masculine feminine,regular,,\nών,singular,nominative,3rd,masculine feminine,regular,,\nης,singular,nominative,3rd,masculine feminine,regular,,\nῆς,singular,nominative,3rd,masculine feminine,regular,,\nυς,singular,nominative,3rd,masculine feminine,regular,,\nῦς,singular,nominative,3rd,masculine feminine,regular,,\nεῦς,singular,nominative,3rd,masculine feminine,regular,,\nύς,singular,nominative,3rd,masculine feminine,regular,,\nής,singular,nominative,3rd,masculine feminine,regular,,33\nας,singular,nominative,3rd,masculine feminine,irregular,,\nῴ,singular,nominative,3rd,masculine feminine,irregular,,29 41\nώς,singular,nominative,3rd,masculine feminine,irregular,,27 41\nϋς,singular,nominative,3rd,masculine feminine,irregular,,41\nῄς,singular,nominative,3rd,masculine feminine,irregular,,31 41\nῖς,singular,nominative,3rd,masculine feminine,irregular,,\nεῖς,singular,nominative,3rd,masculine feminine,irregular,,31 41\nῶς,singular,nominative,3rd,masculine feminine,irregular,,48\nος,singular,nominative,3rd,masculine feminine,irregular,,33\n-,singular,vocative,3rd,masculine feminine,regular,primary,52\nς,singular,vocative,3rd,masculine feminine,regular,,30\nι,singular,vocative,3rd,masculine feminine,regular,,41\nῦ,singular,vocative,3rd,masculine feminine,regular,,15 17 18\nοῖ,singular,vocative,3rd,masculine feminine,regular,,19 41\nψ,singular,vocative,3rd,masculine feminine,regular,,\nξ,singular,vocative,3rd,masculine feminine,regular,,\nν,singular,vocative,3rd,masculine feminine,regular,,\nρ,singular,vocative,3rd,masculine feminine,regular,,\nων,singular,vocative,3rd,masculine feminine,regular,,50\nών,singular,vocative,3rd,masculine feminine,regular,,\nήν,singular,vocative,3rd,masculine feminine,regular,,\nερ,singular,vocative,3rd,masculine feminine,regular,,\nες,singular,vocative,3rd,masculine feminine,regular,,\nί,singular,vocative,3rd,masculine feminine,regular,,\nως,singular,vocative,3rd,masculine feminine,regular,,\nἶ,singular,vocative,3rd,masculine feminine,regular,,\nούς,singular,vocative,3rd,masculine feminine,regular,,51\nύ,singular,vocative,3rd,masculine feminine,regular,,15\nυ,singular,vocative,3rd,masculine feminine,regular,,51\nεις,singular,vocative,3rd,masculine feminine,regular,,20\nαν,singular,vocative,3rd,masculine feminine,regular,,\nώς,singular,vocative,3rd,masculine feminine,irregular,,27 41 46\nον,singular,vocative,3rd,masculine feminine,irregular,,\nυς,singular,vocative,3rd,masculine feminine,irregular,,33\nα,singular,accusative,3rd,neuter,regular,primary,15\n-,singular,accusative,3rd,neuter,regular,,33\nος,singular,accusative,3rd,neuter,regular,,\nας,singular,accusative,3rd,neuter,regular,,\nαρ,singular,accusative,3rd,neuter,regular,,21\nυ,singular,accusative,3rd,neuter,regular,,\nι,singular,dative,3rd,neuter,regular,primary,\nει,singular,dative,3rd,neuter,regular,,16\nαι,singular,dative,3rd,neuter,regular,,16 21\nϊ,singular,dative,3rd,neuter,irregular,,17\nᾳ,singular,dative,3rd,neuter,irregular,,25 33\nυϊ,singular,dative,3rd,neuter,irregular,,17\nαϊ,singular,dative,3rd,neuter,irregular,,21 61\nος,singular,genitive,3rd,neuter,regular,primary,\nους,singular,genitive,3rd,neuter,regular,,16\nως,singular,genitive,3rd,neuter,regular,,16\nεως,singular,genitive,3rd,neuter,regular,,17\nυς,singular,genitive,3rd,neuter,irregular,,26\nου,singular,genitive,3rd,neuter,irregular,,33\nαος,singular,genitive,3rd,neuter,irregular,,21 61\nα,singular,nominative,3rd,neuter,regular,primary,\n-,singular,nominative,3rd,neuter,regular,,33\nος,singular,nominative,3rd,neuter,regular,,\nαρ,singular,nominative,3rd,neuter,regular,,\nας,singular,nominative,3rd,neuter,regular,,16 21\nυ,singular,nominative,3rd,neuter,regular,,\nον,singular,nominative,3rd,neuter,irregular,,33\nα,singular,vocative,3rd,neuter,regular,primary,15\n-,singular,vocative,3rd,neuter,regular,,\nος,singular,vocative,3rd,neuter,regular,,\nας,singular,vocative,3rd,neuter,regular,,\nαρ,singular,vocative,3rd,neuter,regular,,21\nυ,singular,vocative,3rd,neuter,regular,,";
+var nounSuffixesCSV$1 = "Ending,Number,Case,Declension,Gender,Type,Primary,Footnote\r\nα,dual,accusative,1st,feminine,regular,primary,\r\nά,dual,accusative,1st,feminine,regular,,\r\nᾶ,dual,accusative,1st,feminine,regular,,2\r\nαιν,dual,dative,1st,feminine,regular,primary,\r\nαῖν,dual,dative,1st,feminine,regular,,\r\nαιιν,dual,dative,1st,feminine,irregular,,\r\nαιν,dual,genitive,1st,feminine,regular,primary,\r\nαῖν,dual,genitive,1st,feminine,regular,,\r\nαιιν,dual,genitive,1st,feminine,irregular,,\r\nα,dual,nominative,1st,feminine,regular,primary,\r\nά,dual,nominative,1st,feminine,regular,,\r\nᾶ,dual,nominative,1st,feminine,regular,,2\r\nα,dual,vocative,1st,feminine,regular,primary,\r\nά,dual,vocative,1st,feminine,regular,,\r\nᾶ,dual,vocative,1st,feminine,regular,,2\r\nα,dual,accusative,1st,masculine,regular,primary,\r\nά,dual,accusative,1st,masculine,regular,,\r\nᾶ,dual,accusative,1st,masculine,regular,,2\r\nαιν,dual,dative,1st,masculine,regular,primary,\r\nαῖν,dual,dative,1st,masculine,regular,,\r\nαιιν,dual,dative,1st,masculine,irregular,,\r\nαιν,dual,genitive,1st,masculine,regular,primary,\r\nαῖν,dual,genitive,1st,masculine,regular,,\r\nαιιν,dual,genitive,1st,masculine,irregular,,\r\nα,dual,nominative,1st,masculine,regular,primary,\r\nά,dual,nominative,1st,masculine,regular,,\r\nᾶ,dual,nominative,1st,masculine,regular,,2\r\nα,dual,vocative,1st,masculine,regular,primary,\r\nά,dual,vocative,1st,masculine,regular,,\r\nᾶ,dual,vocative,1st,masculine,regular,,2\r\nας,plural,accusative,1st,feminine,regular,primary,\r\nάς,plural,accusative,1st,feminine,regular,,\r\nᾶς,plural,accusative,1st,feminine,regular,,2\r\nανς,plural,accusative,1st,feminine,irregular,,\r\nαις,plural,accusative,1st,feminine,irregular,,\r\nαις,plural,dative,1st,feminine,regular,primary,\r\nαῖς,plural,dative,1st,feminine,regular,,\r\nῃσι,plural,dative,1st,feminine,irregular,,44\r\nῃσιν,plural,dative,1st,feminine,irregular,,4 44\r\nῃς,plural,dative,1st,feminine,irregular,,44\r\nαισι,plural,dative,1st,feminine,irregular,,44\r\nαισιν,plural,dative,1st,feminine,irregular,,4 44\r\nῶν,plural,genitive,1st,feminine,regular,primary,\r\nάων,plural,genitive,1st,feminine,irregular,,\r\nέων,plural,genitive,1st,feminine,irregular,,\r\nήων,plural,genitive,1st,feminine,irregular,,\r\nᾶν,plural,genitive,1st,feminine,irregular,,\r\nαι,plural,nominative,1st,feminine,regular,primary,\r\nαί,plural,nominative,1st,feminine,regular,,\r\nαῖ,plural,nominative,1st,feminine,regular,,2\r\nαι,plural,vocative,1st,feminine,regular,primary,\r\nαί,plural,vocative,1st,feminine,regular,,\r\nαῖ,plural,vocative,1st,feminine,regular,,2\r\nας,plural,accusative,1st,masculine,regular,primary,\r\nάς,plural,accusative,1st,masculine,regular,,\r\nᾶς,plural,accusative,1st,masculine,regular,,3\r\nανς,plural,accusative,1st,masculine,irregular,,\r\nαις,plural,accusative,1st,masculine,irregular,,\r\nαις,plural,dative,1st,masculine,regular,primary,\r\nαῖς,plural,dative,1st,masculine,regular,,\r\nῃσι,plural,dative,1st,masculine,irregular,,44\r\nῃσιν,plural,dative,1st,masculine,irregular,,4 44\r\nῃς,plural,dative,1st,masculine,irregular,,44\r\nαισι,plural,dative,1st,masculine,irregular,,44\r\nαισιν,plural,dative,1st,masculine,irregular,,4 44\r\nῶν,plural,genitive,1st,masculine,regular,primary,\r\nάων,plural,genitive,1st,masculine,irregular,,\r\nέων,plural,genitive,1st,masculine,irregular,,\r\nήων,plural,genitive,1st,masculine,irregular,,\r\nᾶν,plural,genitive,1st,masculine,irregular,,\r\nαι,plural,nominative,1st,masculine,regular,primary,\r\nαί,plural,nominative,1st,masculine,regular,,\r\nαῖ,plural,nominative,1st,masculine,regular,,3\r\nαι,plural,vocative,1st,masculine,regular,primary,\r\nαί,plural,vocative,1st,masculine,regular,,\r\nαῖ,plural,vocative,1st,masculine,regular,,3\r\nαν,singular,accusative,1st,feminine,regular,primary,\r\nην,singular,accusative,1st,feminine,regular,primary,\r\nήν,singular,accusative,1st,feminine,regular,,\r\nᾶν,singular,accusative,1st,feminine,regular,,2\r\nῆν,singular,accusative,1st,feminine,regular,,2\r\nάν,singular,accusative,1st,feminine,irregular,,63\r\nᾳ,singular,dative,1st,feminine,regular,primary,\r\nῃ,singular,dative,1st,feminine,regular,primary,\r\nῇ,singular,dative,1st,feminine,regular,,2\r\nᾷ,singular,dative,1st,feminine,regular,,2\r\nηφι,singular,dative,1st,feminine,irregular,,45\r\nηφιν,singular,dative,1st,feminine,irregular,,4 45\r\nῆφι,singular,dative,1st,feminine,irregular,,45\r\nῆφιv,singular,dative,1st,feminine,irregular,,4 45\r\nας,singular,genitive,1st,feminine,regular,primary,\r\nης,singular,genitive,1st,feminine,regular,primary,\r\nῆs,singular,genitive,1st,feminine,regular,,\r\nᾶs,singular,genitive,1st,feminine,regular,,2\r\nηφι,singular,genitive,1st,feminine,irregular,,45\r\nηφιν,singular,genitive,1st,feminine,irregular,,4 45\r\nῆφι,singular,genitive,1st,feminine,irregular,,45\r\nῆφιv,singular,genitive,1st,feminine,irregular,,4 45\r\nα,singular,nominative,1st,feminine,regular,primary,\r\nη,singular,nominative,1st,feminine,regular,primary,1\r\nή,singular,nominative,1st,feminine,regular,,\r\nᾶ,singular,nominative,1st,feminine,regular,,2\r\nῆ,singular,nominative,1st,feminine,regular,,2\r\nά,singular,nominative,1st,feminine,irregular,,63\r\nα,singular,vocative,1st,feminine,regular,primary,\r\nη,singular,vocative,1st,feminine,regular,primary,\r\nή,singular,vocative,1st,feminine,regular,,\r\nᾶ,singular,vocative,1st,feminine,regular,,2\r\nῆ,singular,vocative,1st,feminine,regular,,2\r\nά,singular,vocative,1st,feminine,irregular,,63\r\nαν,singular,accusative,1st,masculine,regular,primary,\r\nην,singular,accusative,1st,masculine,regular,primary,3\r\nήν,singular,accusative,1st,masculine,regular,,\r\nᾶν,singular,accusative,1st,masculine,regular,,3\r\nῆν,singular,accusative,1st,masculine,regular,,3\r\nεα,singular,accusative,1st,masculine,irregular,,\r\nᾳ,singular,dative,1st,masculine,regular,primary,\r\nῃ,singular,dative,1st,masculine,regular,primary,\r\nῇ,singular,dative,1st,masculine,regular,,\r\nᾷ,singular,dative,1st,masculine,regular,,3\r\nῆ,singular,dative,1st,masculine,regular,,3\r\nηφι,singular,dative,1st,masculine,irregular,,45\r\nηφιν,singular,dative,1st,masculine,irregular,,4 45\r\nῆφι,singular,dative,1st,masculine,irregular,,45\r\nῆφιv,singular,dative,1st,masculine,irregular,,4 45\r\nου,singular,genitive,1st,masculine,regular,primary,\r\nοῦ,singular,genitive,1st,masculine,regular,,\r\nαο,singular,genitive,1st,masculine,irregular,,\r\nεω,singular,genitive,1st,masculine,irregular,,\r\nηφι,singular,genitive,1st,masculine,irregular,,45\r\nηφιν,singular,genitive,1st,masculine,irregular,,4 45\r\nῆφι,singular,genitive,1st,masculine,irregular,,45\r\nῆφιv,singular,genitive,1st,masculine,irregular,,4 45\r\nω,singular,genitive,1st,masculine,irregular,,\r\nα,singular,genitive,1st,masculine,irregular,,\r\nας,singular,nominative,1st,masculine,regular,primary,\r\nης,singular,nominative,1st,masculine,regular,primary,\r\nής,singular,nominative,1st,masculine,regular,,\r\nᾶs,singular,nominative,1st,masculine,regular,,3\r\nῆs,singular,nominative,1st,masculine,regular,,3\r\nα,singular,vocative,1st,masculine,regular,primary,\r\nη,singular,vocative,1st,masculine,regular,primary,\r\nά,singular,vocative,1st,masculine,regular,,\r\nᾶ,singular,vocative,1st,masculine,regular,,3\r\nῆ,singular,vocative,1st,masculine,regular,,3\r\nω,dual,accusative,2nd,masculine feminine,regular,primary,\r\nώ,dual,accusative,2nd,masculine feminine,regular,,5\r\nοιν,dual,dative,2nd,masculine feminine,regular,primary,\r\nοῖν,dual,dative,2nd,masculine feminine,regular,,5\r\nοιιν,dual,dative,2nd,masculine feminine,irregular,,\r\nῴν,dual,dative,2nd,masculine feminine,irregular,,7\r\nοιν,dual,genitive,2nd,masculine feminine,regular,primary,\r\nοῖν,dual,genitive,2nd,masculine feminine,regular,,5\r\nοιιν,dual,genitive,2nd,masculine feminine,irregular,,\r\nῴν,dual,genitive,2nd,masculine feminine,irregular,,7\r\nω,dual,nominative,2nd,masculine feminine,regular,primary,60\r\nώ,dual,nominative,2nd,masculine feminine,regular,,60\r\nω,dual,vocative,2nd,masculine feminine,regular,primary,\r\nώ,dual,vocative,2nd,masculine feminine,regular,,5\r\nω,dual,accusative,2nd,neuter,regular,primary,\r\nώ,dual,accusative,2nd,neuter,regular,,6\r\nοιν,dual,dative,2nd,neuter,regular,primary,\r\nοῖν,dual,dative,2nd,neuter,regular,,6\r\nοιιν,dual,dative,2nd,neuter,irregular,,\r\nοιν,dual,genitive,2nd,neuter,regular,primary,\r\nοῖν,dual,genitive,2nd,neuter,regular,,6\r\nοιιν,dual,genitive,2nd,neuter,irregular,,\r\nω,dual,nominative,2nd,neuter,regular,primary,\r\nώ,dual,nominative,2nd,neuter,regular,,6\r\nω,dual,vocative,2nd,neuter,regular,primary,\r\nώ,dual,vocative,2nd,neuter,regular,,6\r\nους,plural,accusative,2nd,masculine feminine,regular,primary,\r\nούς,plural,accusative,2nd,masculine feminine,regular,,41\r\nοῦς,plural,accusative,2nd,masculine feminine,regular,,5\r\nονς,plural,accusative,2nd,masculine feminine,irregular,,\r\nος,plural,accusative,2nd,masculine feminine,irregular,,\r\nως,plural,accusative,2nd,masculine feminine,irregular,,\r\nοις,plural,accusative,2nd,masculine feminine,irregular,,\r\nώς,plural,accusative,2nd,masculine feminine,irregular,,7\r\nοις,plural,dative,2nd,masculine feminine,regular,primary,\r\nοῖς,plural,dative,2nd,masculine feminine,regular,,5\r\nοισι,plural,dative,2nd,masculine feminine,irregular,,\r\nοισιν,plural,dative,2nd,masculine feminine,irregular,,4\r\nῴς,plural,dative,2nd,masculine feminine,irregular,,7\r\nόφι,plural,dative,2nd,masculine feminine,irregular,,45\r\nόφιv,plural,dative,2nd,masculine feminine,irregular,,4 45\r\nων,plural,genitive,2nd,masculine feminine,regular,primary,\r\nῶν,plural,genitive,2nd,masculine feminine,regular,,5\r\nών,plural,genitive,2nd,masculine feminine,irregular,,7\r\nόφι,plural,genitive,2nd,masculine feminine,irregular,,45\r\nόφιv,plural,genitive,2nd,masculine feminine,irregular,,4 45\r\nοι,plural,nominative,2nd,masculine feminine,regular,primary,\r\nοί,plural,nominative,2nd,masculine feminine,regular,,41\r\nοῖ,plural,nominative,2nd,masculine feminine,regular,,5\r\nῴ,plural,nominative,2nd,masculine feminine,irregular,,7\r\nοι,plural,vocative,2nd,masculine feminine,regular,primary,\r\nοί,plural,vocative,2nd,masculine feminine,regular,,41\r\nοῖ,plural,vocative,2nd,masculine feminine,regular,,5\r\nα,plural,accusative,2nd,neuter,regular,primary,\r\nᾶ,plural,accusative,2nd,neuter,regular,,6\r\nοις,plural,dative,2nd,neuter,regular,primary,\r\nοῖς,plural,dative,2nd,neuter,regular,,6\r\nοισι,plural,dative,2nd,neuter,irregular,,\r\nοισιν,plural,dative,2nd,neuter,irregular,,4\r\nόφι,plural,dative,2nd,neuter,irregular,,45\r\nόφιv,plural,dative,2nd,neuter,irregular,,4 45\r\nων,plural,genitive,2nd,neuter,regular,primary,\r\nῶν,plural,genitive,2nd,neuter,regular,,6\r\nόφι,plural,genitive,2nd,neuter,irregular,,45\r\nόφιv,plural,genitive,2nd,neuter,irregular,,4 45\r\nα,plural,nominative,2nd,neuter,regular,primary,\r\nᾶ,plural,nominative,2nd,neuter,regular,,6\r\nα,plural,vocative,2nd,neuter,regular,primary,\r\nᾶ,plural,vocative,2nd,neuter,regular,,6\r\nον,singular,accusative,2nd,masculine feminine,regular,primary,\r\nόν,singular,accusative,2nd,masculine feminine,regular,primary,41\r\nουν,singular,accusative,2nd,masculine feminine,regular,,5\r\nοῦν,singular,accusative,2nd,masculine feminine,regular,,5\r\nω,singular,accusative,2nd,masculine feminine,irregular,,7 5\r\nωv,singular,accusative,2nd,masculine feminine,irregular,,7 59\r\nώ,singular,accusative,2nd,masculine feminine,irregular,,7 42 59\r\nών,singular,accusative,2nd,masculine feminine,irregular,,7 59\r\nῳ,singular,dative,2nd,masculine feminine,regular,primary,\r\nῷ,singular,dative,2nd,masculine feminine,regular,,5\r\nῴ,singular,dative,2nd,masculine feminine,irregular,,7\r\nόφι,singular,dative,2nd,masculine feminine,irregular,,45\r\nόφιv,singular,dative,2nd,masculine feminine,irregular,,4 45\r\nου,singular,genitive,2nd,masculine feminine,regular,primary,\r\nοῦ,singular,genitive,2nd,masculine feminine,regular,,5\r\nοιο,singular,genitive,2nd,masculine feminine,irregular,,\r\nοο,singular,genitive,2nd,masculine feminine,irregular,,\r\nω,singular,genitive,2nd,masculine feminine,irregular,,\r\nώ,singular,genitive,2nd,masculine feminine,irregular,,7\r\nόφι,singular,genitive,2nd,masculine feminine,irregular,,45\r\nόφιv,singular,genitive,2nd,masculine feminine,irregular,,4 45\r\nος,singular,nominative,2nd,masculine feminine,regular,primary,\r\nους,singular,nominative,2nd,masculine feminine,regular,,5\r\noῦς,singular,nominative,2nd,masculine feminine,regular,,5\r\nός,singular,nominative,2nd,masculine feminine,regular,,\r\nώς,singular,nominative,2nd,masculine feminine,irregular,,7 42\r\nως,singular,nominative,2nd,masculine feminine,irregular,,\r\nε,singular,vocative,2nd,masculine feminine,regular,primary,\r\nέ,singular,vocative,2nd,masculine feminine,regular,,\r\nοu,singular,vocative,2nd,masculine feminine,regular,,5\r\nοῦ,singular,vocative,2nd,masculine feminine,regular,,42\r\nός,singular,vocative,2nd,masculine feminine,irregular,,57\r\nον,singular,accusative,2nd,neuter,regular,primary,\r\nοῦν,singular,accusative,2nd,neuter,regular,,6\r\nῳ,singular,dative,2nd,neuter,regular,primary,\r\nῷ,singular,dative,2nd,neuter,regular,,6\r\nόφι,singular,dative,2nd,neuter,irregular,,45\r\nόφιv,singular,dative,2nd,neuter,irregular,,4 45\r\nου,singular,genitive,2nd,neuter,regular,primary,\r\nοῦ,singular,genitive,2nd,neuter,regular,,6\r\nοο,singular,genitive,2nd,neuter,irregular,,\r\nοιο,singular,genitive,2nd,neuter,irregular,,\r\nω,singular,genitive,2nd,neuter,irregular,,\r\nόφι,singular,genitive,2nd,neuter,irregular,,45\r\nόφιv,singular,genitive,2nd,neuter,irregular,,4 45\r\nον,singular,nominative,2nd,neuter,regular,primary,\r\nοῦν,singular,nominative,2nd,neuter,regular,,6\r\nον,singular,vocative,2nd,neuter,regular,primary,\r\nοῦν,singular,vocative,2nd,neuter,regular,,6\r\nε,dual,accusative,3rd,masculine feminine,regular,primary,\r\nει,dual,accusative,3rd,masculine feminine,regular,,\r\nῆ,dual,accusative,3rd,masculine feminine,regular,,18\r\nω,dual,accusative,3rd,masculine feminine,irregular,,32\r\nῖ,dual,accusative,3rd,masculine feminine,irregular,,33\r\nεε,dual,accusative,3rd,masculine feminine,irregular,,16 55 61\r\nοιν,dual,dative,3rd,masculine feminine,regular,primary,\r\nοῖν,dual,dative,3rd,masculine feminine,regular,,\r\nοιιν,dual,dative,3rd,masculine feminine,irregular,,54\r\nσι,dual,dative,3rd,masculine feminine,irregular,,33 37\r\nεσσι,dual,dative,3rd,masculine feminine,irregular,,33\r\nεσι,dual,dative,3rd,masculine feminine,irregular,,33\r\nέοιν,dual,dative,3rd,masculine feminine,irregular,,16 61\r\nῳν,dual,dative,3rd,masculine feminine,irregular,,49\r\nοιν,dual,genitive,3rd,masculine feminine,regular,primary,\r\nοῖν,dual,genitive,3rd,masculine feminine,regular,,\r\nοιιν,dual,genitive,3rd,masculine feminine,irregular,,54\r\nέοιν,dual,genitive,3rd,masculine feminine,irregular,,16 61\r\nῳν,dual,genitive,3rd,masculine feminine,irregular,,49\r\nε,dual,nominative,3rd,masculine feminine,regular,primary,\r\nει,dual,nominative,3rd,masculine feminine,regular,,\r\nῆ,dual,nominative,3rd,masculine feminine,regular,,18\r\nω,dual,nominative,3rd,masculine feminine,irregular,,32\r\nῖ,dual,nominative,3rd,masculine feminine,irregular,,33\r\nεε,dual,nominative,3rd,masculine feminine,irregular,,16 55 61\r\nε,dual,vocative,3rd,masculine feminine,regular,primary,\r\nει,dual,vocative,3rd,masculine feminine,regular,,\r\nῆ,dual,vocative,3rd,masculine feminine,regular,,18\r\nω,dual,vocative,3rd,masculine feminine,irregular,,32\r\nῖ,dual,vocative,3rd,masculine feminine,irregular,,33\r\nεε,dual,vocative,3rd,masculine feminine,irregular,,16 55 61\r\nε,dual,accusative,3rd,neuter,regular,primary,\r\nει,dual,accusative,3rd,neuter,regular,,\r\nα,dual,accusative,3rd,neuter,regular,,\r\nεε,dual,accusative,3rd,neuter,irregular,,16 61\r\nαε,dual,accusative,3rd,neuter,irregular,,16 61\r\nοιν,dual,dative,3rd,neuter,regular,primary,\r\nῷν,dual,dative,3rd,neuter,regular,,\r\nοις,dual,dative,3rd,neuter,irregular,,33 38\r\nοισι,dual,dative,3rd,neuter,irregular,,33 38\r\nοισι(ν),dual,dative,3rd,neuter,irregular,,4 33 38\r\nοιιν,dual,dative,3rd,neuter,irregular,,\r\nέοιν,dual,dative,3rd,neuter,irregular,,16 61\r\nάοιν,dual,dative,3rd,neuter,irregular,,16 61\r\nοιν,dual,genitive,3rd,neuter,regular,primary,\r\nῷν,dual,genitive,3rd,neuter,regular,,\r\nων,dual,genitive,3rd,neuter,irregular,,33 38\r\nοιιν,dual,genitive,3rd,neuter,irregular,,\r\nέοιν,dual,genitive,3rd,neuter,irregular,,16 61\r\nάοιν,dual,genitive,3rd,neuter,irregular,,16 61\r\nε,dual,nominative,3rd,neuter,regular,primary,\r\nει,dual,nominative,3rd,neuter,regular,,\r\nα,dual,nominative,3rd,neuter,regular,,\r\nεε,dual,nominative,3rd,neuter,irregular,,16 61\r\nαε,dual,nominative,3rd,neuter,irregular,,16 61\r\nε,dual,vocative,3rd,neuter,regular,primary,\r\nει,dual,vocative,3rd,neuter,regular,,\r\nα,dual,vocative,3rd,neuter,regular,,\r\nεε,dual,vocative,3rd,neuter,irregular,,16 61\r\nαε,dual,vocative,3rd,neuter,irregular,,16 61\r\nας,plural,accusative,3rd,masculine feminine,regular,primary,\r\nεις,plural,accusative,3rd,masculine feminine,regular,,17 41\r\nες,plural,accusative,3rd,masculine feminine,regular,,\r\nς,plural,accusative,3rd,masculine feminine,regular,,\r\nῦς,plural,accusative,3rd,masculine feminine,regular,,17 18 48\r\nως,plural,accusative,3rd,masculine feminine,regular,,30\r\nῆς,plural,accusative,3rd,masculine feminine,irregular,,56\r\nέας,plural,accusative,3rd,masculine feminine,irregular,,\r\nέος,plural,accusative,3rd,masculine feminine,irregular,,\r\nῆος,plural,accusative,3rd,masculine feminine,irregular,,\r\nῆες,plural,accusative,3rd,masculine feminine,irregular,,\r\nῆας,plural,accusative,3rd,masculine feminine,irregular,,\r\nους,plural,accusative,3rd,masculine feminine,irregular,,32\r\nούς,plural,accusative,3rd,masculine feminine,irregular,,32\r\nεῖς,plural,accusative,3rd,masculine feminine,irregular,,31 41\r\nεες,plural,accusative,3rd,masculine feminine,irregular,,55 61\r\nις,plural,accusative,3rd,masculine feminine,irregular,,\r\nινς,plural,accusative,3rd,masculine feminine,irregular,,\r\nῶς,plural,accusative,3rd,masculine feminine,irregular,,48\r\nσι,plural,dative,3rd,masculine feminine,regular,primary,\r\nσιν,plural,dative,3rd,masculine feminine,regular,primary,4\r\nσί,plural,dative,3rd,masculine feminine,regular,,41\r\nσίν,plural,dative,3rd,masculine feminine,regular,,4 41\r\nεσι,plural,dative,3rd,masculine feminine,regular,,41\r\nεσιν,plural,dative,3rd,masculine feminine,regular,,4 41\r\nέσι,plural,dative,3rd,masculine feminine,regular,,\r\nέσιν,plural,dative,3rd,masculine feminine,regular,,4\r\nψι,plural,dative,3rd,masculine feminine,regular,,\r\nψιν,plural,dative,3rd,masculine feminine,regular,,4\r\nψί,plural,dative,3rd,masculine feminine,regular,,\r\nψίν,plural,dative,3rd,masculine feminine,regular,,4\r\nξι,plural,dative,3rd,masculine feminine,regular,,\r\nξιν,plural,dative,3rd,masculine feminine,regular,,4\r\nξί,plural,dative,3rd,masculine feminine,regular,,\r\nξίν,plural,dative,3rd,masculine feminine,regular,,4\r\nφι,plural,dative,3rd,masculine feminine,irregular,,45\r\nφιν,plural,dative,3rd,masculine feminine,irregular,,4 45\r\nηφι,plural,dative,3rd,masculine feminine,irregular,,45\r\nηφιv,plural,dative,3rd,masculine feminine,irregular,,4 45\r\nῆφι,plural,dative,3rd,masculine feminine,irregular,,45\r\nῆφιν,plural,dative,3rd,masculine feminine,irregular,,4 45\r\nόφι,plural,dative,3rd,masculine feminine,irregular,,45\r\nόφιν,plural,dative,3rd,masculine feminine,irregular,,4 45\r\nαις,plural,dative,3rd,masculine feminine,irregular,,33 41\r\nοῖσι,plural,dative,3rd,masculine feminine,irregular,,33\r\nοῖσιv,plural,dative,3rd,masculine feminine,irregular,,4 33\r\nεσσι,plural,dative,3rd,masculine feminine,irregular,,16 61\r\nεσσιv,plural,dative,3rd,masculine feminine,irregular,,4 16 61\r\nυσσι,plural,dative,3rd,masculine feminine,irregular,,54\r\nυσσιv,plural,dative,3rd,masculine feminine,irregular,,4 54\r\nσσί,plural,dative,3rd,masculine feminine,irregular,,54\r\nσσίv,plural,dative,3rd,masculine feminine,irregular,,4 54\r\nων,plural,genitive,3rd,masculine feminine,regular,primary,\r\nῶν,plural,genitive,3rd,masculine feminine,regular,,\r\n-,plural,genitive,3rd,masculine feminine,irregular,,41\r\nφι,plural,genitive,3rd,masculine feminine,irregular,,45\r\nφιν,plural,genitive,3rd,masculine feminine,irregular,,4 45\r\nηφι,plural,genitive,3rd,masculine feminine,irregular,,45\r\nηφιv,plural,genitive,3rd,masculine feminine,irregular,,4 45\r\nῆφι,plural,genitive,3rd,masculine feminine,irregular,,45\r\nῆφιν,plural,genitive,3rd,masculine feminine,irregular,,4 45\r\nόφι,plural,genitive,3rd,masculine feminine,irregular,,45\r\nόφιν,plural,genitive,3rd,masculine feminine,irregular,,4 45\r\nέων,plural,genitive,3rd,masculine feminine,irregular,,16 61\r\nες,plural,nominative,3rd,masculine feminine,regular,primary,\r\nως,plural,nominative,3rd,masculine feminine,regular,,30\r\nεις,plural,nominative,3rd,masculine feminine,regular,,17\r\nεῖς,plural,nominative,3rd,masculine feminine,regular,,18\r\nοί,plural,nominative,3rd,masculine feminine,irregular,,32\r\nαί,plural,nominative,3rd,masculine feminine,irregular,,33\r\nῆς,plural,nominative,3rd,masculine feminine,irregular,,18\r\nῄς,plural,nominative,3rd,masculine feminine,irregular,,31 41\r\nεες,plural,nominative,3rd,masculine feminine,irregular,,16 55 61\r\nοι,plural,nominative,3rd,masculine feminine,irregular,,33\r\nες,plural,vocative,3rd,masculine feminine,regular,primary,\r\nεις,plural,vocative,3rd,masculine feminine,regular,,17\r\nεῖς,plural,vocative,3rd,masculine feminine,regular,,18\r\nῆς,plural,vocative,3rd,masculine feminine,regular,,18\r\nως,plural,vocative,3rd,masculine feminine,regular,,30\r\nεες,plural,vocative,3rd,masculine feminine,irregular,,16 55 61\r\nα,plural,accusative,3rd,neuter,regular,primary,\r\nη,plural,accusative,3rd,neuter,regular,,\r\nς,plural,accusative,3rd,neuter,regular,,\r\nά,plural,accusative,3rd,neuter,irregular,,33\r\nαα,plural,accusative,3rd,neuter,irregular,,16 61\r\nεα,plural,accusative,3rd,neuter,irregular,,16 61\r\nσι,plural,dative,3rd,neuter,regular,primary,\r\nσιν,plural,dative,3rd,neuter,regular,primary,4\r\nσί,plural,dative,3rd,neuter,regular,,\r\nσίv,plural,dative,3rd,neuter,regular,,4\r\nασι,plural,dative,3rd,neuter,regular,,\r\nασιν,plural,dative,3rd,neuter,regular,,4\r\nεσι,plural,dative,3rd,neuter,regular,,\r\nεσιν,plural,dative,3rd,neuter,regular,,4\r\nέσι,plural,dative,3rd,neuter,regular,,\r\nέσιv,plural,dative,3rd,neuter,regular,,4\r\nεσσι,plural,dative,3rd,neuter,irregular,,54\r\nεσσιν,plural,dative,3rd,neuter,irregular,,4 54\r\nσσί,plural,dative,3rd,neuter,irregular,,54\r\nσσίv,plural,dative,3rd,neuter,irregular,,4 54\r\nασσι,plural,dative,3rd,neuter,irregular,,54\r\nασσιν,plural,dative,3rd,neuter,irregular,,4 54\r\nφι,plural,dative,3rd,neuter,irregular,,45\r\nφιν,plural,dative,3rd,neuter,irregular,,4 45\r\nηφι,plural,dative,3rd,neuter,irregular,,45\r\nηφιv,plural,dative,3rd,neuter,irregular,,4 45\r\nῆφι,plural,dative,3rd,neuter,irregular,,45\r\nῆφιν,plural,dative,3rd,neuter,irregular,,4 45\r\nόφι,plural,dative,3rd,neuter,irregular,,45\r\nόφιν,plural,dative,3rd,neuter,irregular,,4 45\r\nων,plural,genitive,3rd,neuter,regular,primary,\r\nῶν,plural,genitive,3rd,neuter,regular,primary,\r\nφι,plural,genitive,3rd,neuter,irregular,,\r\nφιν,plural,genitive,3rd,neuter,irregular,,4 45\r\nηφι,plural,genitive,3rd,neuter,irregular,,45\r\nηφιv,plural,genitive,3rd,neuter,irregular,,4 45\r\nῆφι,plural,genitive,3rd,neuter,irregular,,45\r\nῆφιν,plural,genitive,3rd,neuter,irregular,,4 45\r\nόφι,plural,genitive,3rd,neuter,irregular,,45\r\nόφιν,plural,genitive,3rd,neuter,irregular,,4 45\r\nέων,plural,genitive,3rd,neuter,irregular,,16 61\r\nάων,plural,genitive,3rd,neuter,irregular,,16 61\r\nα,plural,nominative,3rd,neuter,regular,primary,\r\nη,plural,nominative,3rd,neuter,regular,,\r\nες,plural,nominative,3rd,neuter,regular,,\r\nά,plural,nominative,3rd,neuter,irregular,,33\r\nεα,plural,nominative,3rd,neuter,irregular,,16 61\r\nαα,plural,nominative,3rd,neuter,irregular,,16 61\r\nα,plural,vocative,3rd,neuter,regular,primary,\r\nη,plural,vocative,3rd,neuter,regular,,\r\nες,plural,vocative,3rd,neuter,regular,,\r\nαα,plural,vocative,3rd,neuter,irregular,,16 61\r\nεα,plural,vocative,3rd,neuter,irregular,,16 61\r\nα,singular,accusative,3rd,masculine feminine,regular,primary,\r\nη,singular,accusative,3rd,masculine feminine,regular,,16\r\nν,singular,accusative,3rd,masculine feminine,regular,,\r\nιν,singular,accusative,3rd,masculine feminine,regular,,41\r\nῦν,singular,accusative,3rd,masculine feminine,regular,,18\r\nῶ,singular,accusative,3rd,masculine feminine,regular,,23\r\nυν,singular,accusative,3rd,masculine feminine,regular,,\r\nῦν,singular,accusative,3rd,masculine feminine,regular,,17\r\nύν,singular,accusative,3rd,masculine feminine,regular,,17\r\nέα,singular,accusative,3rd,masculine feminine,regular,,20\r\nην,singular,accusative,3rd,masculine feminine,regular,,24\r\nώ,singular,accusative,3rd,masculine feminine,regular,,19 41\r\nω,singular,accusative,3rd,masculine feminine,regular,,23\r\nεῖν,singular,accusative,3rd,masculine feminine,irregular,,31 41\r\nων,singular,accusative,3rd,masculine feminine,irregular,,33 41 49\r\nαν,singular,accusative,3rd,masculine feminine,irregular,,33 41\r\nον,singular,accusative,3rd,masculine feminine,irregular,,39\r\nῖς,singular,accusative,3rd,masculine feminine,irregular,,33\r\nεα,singular,accusative,3rd,masculine feminine,irregular,,61\r\nι,singular,dative,3rd,masculine feminine,regular,primary,\r\nί,singular,dative,3rd,masculine feminine,regular,,\r\nϊ,singular,dative,3rd,masculine feminine,regular,,17\r\nΐ,singular,dative,3rd,masculine feminine,regular,,40\r\nει,singular,dative,3rd,masculine feminine,regular,,16 17\r\nεῖ,singular,dative,3rd,masculine feminine,regular,,18\r\nαι,singular,dative,3rd,masculine feminine,regular,,\r\noῖ,singular,dative,3rd,masculine feminine,regular,,28 41\r\nῖ,singular,dative,3rd,masculine feminine,irregular,,33 46\r\nῆι,singular,dative,3rd,masculine feminine,irregular,,18\r\nᾳ,singular,dative,3rd,masculine feminine,irregular,,25\r\nῳ,singular,dative,3rd,masculine feminine,irregular,,33 34\r\nῷ,singular,dative,3rd,masculine feminine,irregular,,33\r\nιί,singular,dative,3rd,masculine feminine,irregular,,62\r\nυί,singular,dative,3rd,masculine feminine,irregular,,62\r\nέϊ,singular,dative,3rd,masculine feminine,irregular,,18 61\r\nος,singular,genitive,3rd,masculine feminine,regular,primary,\r\nός,singular,genitive,3rd,masculine feminine,regular,,\r\nους,singular,genitive,3rd,masculine feminine,regular,,16\r\nοῦς,singular,genitive,3rd,masculine feminine,regular,,19 46\r\nως,singular,genitive,3rd,masculine feminine,regular,,17 18\r\nώς,singular,genitive,3rd,masculine feminine,regular,,17 18 41\r\nῶς,singular,genitive,3rd,masculine feminine,regular,,47\r\nεως,singular,genitive,3rd,masculine feminine,regular,,17\r\nέως,singular,genitive,3rd,masculine feminine,regular,,\r\nεώς,singular,genitive,3rd,masculine feminine,regular,,\r\nέους,singular,genitive,3rd,masculine feminine,regular,,20\r\nω,singular,genitive,3rd,masculine feminine,irregular,,\r\nεος,singular,genitive,3rd,masculine feminine,irregular,,61\r\nΰς,singular,genitive,3rd,masculine feminine,irregular,,41 48\r\nῦς,singular,genitive,3rd,masculine feminine,irregular,,48\r\nνος,singular,genitive,3rd,masculine feminine,irregular,,22\r\nοῦ,singular,genitive,3rd,masculine feminine,irregular,,33\r\nηος,singular,genitive,3rd,masculine feminine,irregular,,55\r\nιός,singular,genitive,3rd,masculine feminine,irregular,,62\r\nuός,singular,genitive,3rd,masculine feminine,irregular,,62\r\nς,singular,nominative,3rd,masculine feminine,regular,primary,\r\n-,singular,nominative,3rd,masculine feminine,regular,primary,\r\nηρ,singular,nominative,3rd,masculine feminine,regular,,41\r\nις,singular,nominative,3rd,masculine feminine,regular,,\r\nϊς,singular,nominative,3rd,masculine feminine,regular,,\r\nώ,singular,nominative,3rd,masculine feminine,regular,,41\r\nψ,singular,nominative,3rd,masculine feminine,regular,,\r\nξ,singular,nominative,3rd,masculine feminine,regular,,\r\nρ,singular,nominative,3rd,masculine feminine,regular,,\r\nήρ,singular,nominative,3rd,masculine feminine,regular,,\r\nήν,singular,nominative,3rd,masculine feminine,regular,,50\r\nν,singular,nominative,3rd,masculine feminine,regular,,\r\nωρ,singular,nominative,3rd,masculine feminine,regular,,\r\nων,singular,nominative,3rd,masculine feminine,regular,,\r\nών,singular,nominative,3rd,masculine feminine,regular,,\r\nης,singular,nominative,3rd,masculine feminine,regular,,\r\nῆς,singular,nominative,3rd,masculine feminine,regular,,\r\nυς,singular,nominative,3rd,masculine feminine,regular,,\r\nῦς,singular,nominative,3rd,masculine feminine,regular,,\r\nεῦς,singular,nominative,3rd,masculine feminine,regular,,\r\nύς,singular,nominative,3rd,masculine feminine,regular,,\r\nής,singular,nominative,3rd,masculine feminine,regular,,33\r\nας,singular,nominative,3rd,masculine feminine,irregular,,\r\nῴ,singular,nominative,3rd,masculine feminine,irregular,,29 41\r\nώς,singular,nominative,3rd,masculine feminine,irregular,,27 41\r\nϋς,singular,nominative,3rd,masculine feminine,irregular,,41\r\nῄς,singular,nominative,3rd,masculine feminine,irregular,,31 41\r\nῖς,singular,nominative,3rd,masculine feminine,irregular,,\r\nεῖς,singular,nominative,3rd,masculine feminine,irregular,,31 41\r\nῶς,singular,nominative,3rd,masculine feminine,irregular,,48\r\nος,singular,nominative,3rd,masculine feminine,irregular,,33\r\n-,singular,vocative,3rd,masculine feminine,regular,primary,52\r\nς,singular,vocative,3rd,masculine feminine,regular,,30\r\nι,singular,vocative,3rd,masculine feminine,regular,,41\r\nῦ,singular,vocative,3rd,masculine feminine,regular,,15 17 18\r\nοῖ,singular,vocative,3rd,masculine feminine,regular,,19 41\r\nψ,singular,vocative,3rd,masculine feminine,regular,,\r\nξ,singular,vocative,3rd,masculine feminine,regular,,\r\nν,singular,vocative,3rd,masculine feminine,regular,,\r\nρ,singular,vocative,3rd,masculine feminine,regular,,\r\nων,singular,vocative,3rd,masculine feminine,regular,,50\r\nών,singular,vocative,3rd,masculine feminine,regular,,\r\nήν,singular,vocative,3rd,masculine feminine,regular,,\r\nερ,singular,vocative,3rd,masculine feminine,regular,,\r\nες,singular,vocative,3rd,masculine feminine,regular,,\r\nί,singular,vocative,3rd,masculine feminine,regular,,\r\nως,singular,vocative,3rd,masculine feminine,regular,,\r\nἶ,singular,vocative,3rd,masculine feminine,regular,,\r\nούς,singular,vocative,3rd,masculine feminine,regular,,51\r\nύ,singular,vocative,3rd,masculine feminine,regular,,15\r\nυ,singular,vocative,3rd,masculine feminine,regular,,51\r\nεις,singular,vocative,3rd,masculine feminine,regular,,20\r\nαν,singular,vocative,3rd,masculine feminine,regular,,\r\nώς,singular,vocative,3rd,masculine feminine,irregular,,27 41 46\r\nον,singular,vocative,3rd,masculine feminine,irregular,,\r\nυς,singular,vocative,3rd,masculine feminine,irregular,,33\r\nα,singular,accusative,3rd,neuter,regular,primary,15\r\n-,singular,accusative,3rd,neuter,regular,,33\r\nος,singular,accusative,3rd,neuter,regular,,\r\nας,singular,accusative,3rd,neuter,regular,,\r\nαρ,singular,accusative,3rd,neuter,regular,,21\r\nυ,singular,accusative,3rd,neuter,regular,,\r\nι,singular,dative,3rd,neuter,regular,primary,\r\nει,singular,dative,3rd,neuter,regular,,16\r\nαι,singular,dative,3rd,neuter,regular,,16 21\r\nϊ,singular,dative,3rd,neuter,irregular,,17\r\nᾳ,singular,dative,3rd,neuter,irregular,,25 33\r\nυϊ,singular,dative,3rd,neuter,irregular,,17\r\nαϊ,singular,dative,3rd,neuter,irregular,,21 61\r\nος,singular,genitive,3rd,neuter,regular,primary,\r\nους,singular,genitive,3rd,neuter,regular,,16\r\nως,singular,genitive,3rd,neuter,regular,,16\r\nεως,singular,genitive,3rd,neuter,regular,,17\r\nυς,singular,genitive,3rd,neuter,irregular,,26\r\nου,singular,genitive,3rd,neuter,irregular,,33\r\nαος,singular,genitive,3rd,neuter,irregular,,21 61\r\nα,singular,nominative,3rd,neuter,regular,primary,\r\n-,singular,nominative,3rd,neuter,regular,,33\r\nος,singular,nominative,3rd,neuter,regular,,\r\nαρ,singular,nominative,3rd,neuter,regular,,\r\nας,singular,nominative,3rd,neuter,regular,,16 21\r\nυ,singular,nominative,3rd,neuter,regular,,\r\nον,singular,nominative,3rd,neuter,irregular,,33\r\nα,singular,vocative,3rd,neuter,regular,primary,15\r\n-,singular,vocative,3rd,neuter,regular,,\r\nος,singular,vocative,3rd,neuter,regular,,\r\nας,singular,vocative,3rd,neuter,regular,,\r\nαρ,singular,vocative,3rd,neuter,regular,,21\r\nυ,singular,vocative,3rd,neuter,regular,,";
 
-var nounFootnotesCSV$1 = "Index,Text\n1,See  for Rules of variance within regular endings\n2,See  for Table of α- and ε- stem feminine 1st declension contracts\n3,See  for Table of α- and ε- stem masculine 1st declension contracts\n4,\"Previous, with (ν)\"\n5,See  for Table of o- and ε- stem masculine  2nd declension contracts\n6,See  for Table of o- and ε- stem neuter 2nd declension contracts\n7,(Attic) contracts of o-stems preceded by a long vowel\n15,\"This is not actually an “ending,” but the last letter of the “pure stem”. See\"\n16,\"See  &  for Table of Sigma (ες,ας,ος) stem contracts\"\n17,See  for Table of  ι and υ - stem contracts\n18,\"See  for Table of  ευ,αυ,and ου - stem contracts\"\n19,See  for stems in οι feminine 3rd declension contracts\n20,See  for Table of 3rd declension contracts of stems in -εσ- preceded by ε\n21,See  for Table of stems in τ and ατ neuter 3rd declension contracts\n22,\"On stem ending in ν, ν doubled in gen. Sing Aeolic (e.g. μῆνς,μῆννος...)\"\n23,Also in inscriptions and expressions of swearing\n24,(Borrowed from 1st decl) Sometimes in proper names whose nominative ends in -ης\n25,From -ας-stems (properly αι)\n26,(ε)υς instead of (ε)ος or ους (gen) for (3rd decl) words whose nominative ends in -ος\n27,In 3rd decl. Only in the words αἰδώς (Attic) and ἠώς (Homer and Ionic)\n28,Contraction of a stem in οι  and an ι-ending\n29,Stronger form of Ionic contractions of οι-stems (in the nominative)\n30,See  for Table of ω - stem contracts (masculine only)\n31,Nominative plural contraction of  -ειδ+ες  after dropping the δ (used for accusative too). See .a\n32,\"Plurals & duals occur rarely (and w/ 2nd decl endings) for 3rd decl οι-stem nouns. See .D.a,b,c\"\n33,See  for description and examples of Irreg. Decl involving 3rd decl endings\n34,(Homer)  for Attic  (ῳτ)ι\n35,(Homer) for Cretan ινς\n36,Also an irregular ending for other stem(s)\n37,In inscriptions\n38,\"Plural endings for otherwise dual noun,οσσε (eyes)\"\n39,\"“Poetical” (acc for ἔρως). See ,11\"\n40,\"Poetic for χρωτι,dat. of ὁ χρως\"\n41,No Masculine of this Form\n42,No Feminine of this Form\n44,See  D.9 and #215 regarding dialectic alternate forms of the Dative Plural\n45,\"Surviving in Homer (See ) Not truly genitive or dative, but instrumental/locative/ablative, associated with the remaining oblique cases (genitive & dative) only after being lost as cases themselves in Greek\"\n46,See Smyth # 266 for only surviving ος-stem in Attic (fem. singular of αἰδως)\n47,See  for Substantives in -εύς preceded by a vowel.\n48,\"See Smyth,  #275 D.1,2,3\"\n49,\"See , List of Principal Irregular Substantives\"\n50,\"See  for Table of stems in a Liquid (λ,ρ) or a Nasal (ν), and Note #259D for variants including Κρονίων...\"\n51,\"See  for Table of stems in a Dental (τ,δ,θ) or a Nasal (ν), and its notes including Ν.κόρυς (Voc. Κόρυ) & ὀδούς\"\n52,See  for general rule re 3rd Declension Masc/Fem Singular Vocative\n54,See  D\n55,See\n56,\"See  for other forms of endings for contracts of ευ,αυ,and ου - stems\"\n57,Nominative form used as Vocative. See\n58,\"See ,b\"\n59,\"See ,d\"\n60,This (Feminine or Masculine) Form only Masculine when derived from ε- or ο- contraction\n61,See Smyth Note 264 D.1 regarding Homer's use of Open Forms\n62,See Smyth Note 269 for alternate i-stem and u-stem endings\n63,See  D.2\n64,See  D.1";
+var nounFootnotesCSV$1 = "Index,Text\r\n1,See  for Rules of variance within regular endings\r\n2,See  for Table of α- and ε- stem feminine 1st declension contracts\r\n3,See  for Table of α- and ε- stem masculine 1st declension contracts\r\n4,\"Previous, with (ν)\"\r\n5,See  for Table of o- and ε- stem masculine  2nd declension contracts\r\n6,See  for Table of o- and ε- stem neuter 2nd declension contracts\r\n7,(Attic) contracts of o-stems preceded by a long vowel\r\n15,\"This is not actually an “ending,” but the last letter of the “pure stem”. See\"\r\n16,\"See  &  for Table of Sigma (ες,ας,ος) stem contracts\"\r\n17,See  for Table of  ι and υ - stem contracts\r\n18,\"See  for Table of  ευ,αυ,and ου - stem contracts\"\r\n19,See  for stems in οι feminine 3rd declension contracts\r\n20,See  for Table of 3rd declension contracts of stems in -εσ- preceded by ε\r\n21,See  for Table of stems in τ and ατ neuter 3rd declension contracts\r\n22,\"On stem ending in ν, ν doubled in gen. Sing Aeolic (e.g. μῆνς,μῆννος...)\"\r\n23,Also in inscriptions and expressions of swearing\r\n24,(Borrowed from 1st decl) Sometimes in proper names whose nominative ends in -ης\r\n25,From -ας-stems (properly αι)\r\n26,(ε)υς instead of (ε)ος or ους (gen) for (3rd decl) words whose nominative ends in -ος\r\n27,In 3rd decl. Only in the words αἰδώς (Attic) and ἠώς (Homer and Ionic)\r\n28,Contraction of a stem in οι  and an ι-ending\r\n29,Stronger form of Ionic contractions of οι-stems (in the nominative)\r\n30,See  for Table of ω - stem contracts (masculine only)\r\n31,Nominative plural contraction of  -ειδ+ες  after dropping the δ (used for accusative too). See .a\r\n32,\"Plurals & duals occur rarely (and w/ 2nd decl endings) for 3rd decl οι-stem nouns. See .D.a,b,c\"\r\n33,See  for description and examples of Irreg. Decl involving 3rd decl endings\r\n34,(Homer)  for Attic  (ῳτ)ι\r\n35,(Homer) for Cretan ινς\r\n36,Also an irregular ending for other stem(s)\r\n37,In inscriptions\r\n38,\"Plural endings for otherwise dual noun,οσσε (eyes)\"\r\n39,\"“Poetical” (acc for ἔρως). See ,11\"\r\n40,\"Poetic for χρωτι,dat. of ὁ χρως\"\r\n41,No Masculine of this Form\r\n42,No Feminine of this Form\r\n44,See  D.9 and #215 regarding dialectic alternate forms of the Dative Plural\r\n45,\"Surviving in Homer (See ) Not truly genitive or dative, but instrumental/locative/ablative, associated with the remaining oblique cases (genitive & dative) only after being lost as cases themselves in Greek\"\r\n46,See Smyth # 266 for only surviving ος-stem in Attic (fem. singular of αἰδως)\r\n47,See  for Substantives in -εύς preceded by a vowel.\r\n48,\"See Smyth,  #275 D.1,2,3\"\r\n49,\"See , List of Principal Irregular Substantives\"\r\n50,\"See  for Table of stems in a Liquid (λ,ρ) or a Nasal (ν), and Note #259D for variants including Κρονίων...\"\r\n51,\"See  for Table of stems in a Dental (τ,δ,θ) or a Nasal (ν), and its notes including Ν.κόρυς (Voc. Κόρυ) & ὀδούς\"\r\n52,See  for general rule re 3rd Declension Masc/Fem Singular Vocative\r\n54,See  D\r\n55,See\r\n56,\"See  for other forms of endings for contracts of ευ,αυ,and ου - stems\"\r\n57,Nominative form used as Vocative. See\r\n58,\"See ,b\"\r\n59,\"See ,d\"\r\n60,This (Feminine or Masculine) Form only Masculine when derived from ε- or ο- contraction\r\n61,See Smyth Note 264 D.1 regarding Homer's use of Open Forms\r\n62,See Smyth Note 269 for alternate i-stem and u-stem endings\r\n63,See  D.2\r\n64,See  D.1";
 
 /*
  * Latin language data module
@@ -8455,5 +7042,4 @@ class Presenter {
   }
 }
 
-export { dataSet as LatinDataSet, dataSet$1 as GreekDataSet, languages, LanguageDataset, LanguageData, Suffix, Footnote, MatchData, ExtendedLanguageData, ExtendedGreekData, WordData, loadData, SelectedWord, Presenter };
-//# sourceMappingURL=inflection-tables.js.map
+export { dataSet as LatinDataSet, dataSet$1 as GreekDataSet, languages, LanguageDataset, LanguageData, Suffix, Footnote, MatchData, ExtendedLanguageData, ExtendedGreekData, LexicalData, loadData, SelectedWord, Presenter };

--- a/dist/inflection-tables.standalone.js
+++ b/dist/inflection-tables.standalone.js
@@ -1,9 +1,3 @@
-(function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
-	typeof define === 'function' && define.amd ? define(factory) :
-	(factory());
-}(this, (function () { 'use strict';
-
 /* eslint-disable no-unused-vars */
 const LANG_UNIT_WORD = Symbol('word');
 const LANG_UNIT_CHAR = Symbol('char');
@@ -2368,6 +2362,17 @@ class ExtendedGreekData extends ExtendedLanguageData {
   }
 }
 
+class SelectedWord {
+  constructor (language, word) {
+    this.language = language;
+    this.word = word;
+  }
+
+  static readObjects (jsonObject) {
+    return new SelectedWord(jsonObject.language, jsonObject.word)
+  }
+}
+
 /**
  * A return value for inflection queries
  */
@@ -2417,6 +2422,23 @@ class LexicalData {
     return this.homonym.language
   }
 }
+
+/**
+ * Load text data form an external fil with an asynchronous XHR request.
+ * @param {string} filePath - A path to a file we need to load.
+ * @returns {Promise} - A promise that will be resolved with either
+ * file content (a string) in case of success of with a status message
+ * in case of failure.
+ */
+let loadData = function loadData (filePath) {
+  return new Promise((resolve, reject) => {
+    const xhr = new window.XMLHttpRequest();
+    xhr.open('GET', filePath);
+    xhr.onload = () => resolve(xhr.responseText);
+    xhr.onerror = () => reject(xhr.statusText);
+    xhr.send();
+  })
+};
 
 let messages$1 = {
   Number: 'Number',
@@ -4484,6 +4506,1844 @@ const messages = [
   new MessageBundle('en-GB', messages$2)
 ];
 
+var nounSuffixesCSV = "Ending,Number,Case,Declension,Gender,Type,Footnote\r\na,singular,nominative,1st,feminine,regular,\r\nē,singular,nominative,1st,feminine,irregular,\r\nēs,singular,nominative,1st,feminine,irregular,\r\nā,singular,nominative,1st,feminine,irregular,7\r\nus,singular,nominative,2nd,masculine feminine,regular,\r\ner,singular,nominative,2nd,masculine feminine,regular,\r\nir,singular,nominative,2nd,masculine feminine,regular,\r\n-,singular,nominative,2nd,masculine feminine,irregular,\r\nos,singular,nominative,2nd,masculine feminine,irregular,1\r\nōs,singular,nominative,2nd,masculine feminine,irregular,\r\nō,singular,nominative,2nd,masculine feminine,irregular,7\r\num,singular,nominative,2nd,neuter,regular,\r\nus,singular,nominative,2nd,neuter,irregular,10\r\non,singular,nominative,2nd,neuter,irregular,7\r\n-,singular,nominative,3rd,masculine feminine,regular,\r\nos,singular,nominative,3rd,masculine feminine,irregular,\r\nōn,singular,nominative,3rd,masculine feminine,irregular,7\r\n-,singular,nominative,3rd,neuter,regular,\r\nus,singular,nominative,4th,masculine feminine,regular,\r\nū,singular,nominative,4th,neuter,regular,\r\nēs,singular,nominative,5th,feminine,regular,\r\nae,singular,genitive,1st,feminine,regular,\r\nāī,singular,genitive,1st,feminine,irregular,1\r\nās,singular,genitive,1st,feminine,irregular,2\r\nēs,singular,genitive,1st,feminine,irregular,7\r\nī,singular,genitive,2nd,masculine feminine,regular,\r\nō,singular,genitive,2nd,masculine feminine,irregular,7\r\nī,singular,genitive,2nd,neuter,regular,\r\nis,singular,genitive,3rd,masculine feminine,regular,\r\nis,singular,genitive,3rd,neuter,regular,\r\nūs,singular,genitive,4th,masculine feminine,regular,\r\nuis,singular,genitive,4th,masculine feminine,irregular,1\r\nuos,singular,genitive,4th,masculine feminine,irregular,1\r\nī,singular,genitive,4th,masculine feminine,irregular,15\r\nūs,singular,genitive,4th,neuter,regular,\r\nēī,singular,genitive,5th,feminine,regular,\r\neī,singular,genitive,5th,feminine,regular,\r\nī,singular,genitive,5th,feminine,irregular,\r\nē,singular,genitive,5th,feminine,irregular,\r\nēs,singular,genitive,5th,feminine,irregular,6\r\nae,singular,dative,1st,feminine,regular,\r\nāī,singular,dative,1st,feminine,irregular,1\r\nō,singular,dative,2nd,masculine feminine,regular,\r\nō,singular,dative,2nd,neuter,regular,\r\nī,singular,dative,3rd,masculine feminine,regular,\r\ne,singular,dative,3rd,masculine feminine,irregular,17\r\nī,singular,dative,3rd,neuter,regular,\r\nūī,singular,dative,4th,masculine feminine,regular,\r\nū,singular,dative,4th,masculine feminine,regular,\r\nū,singular,dative,4th,neuter,regular,\r\nēī,singular,dative,5th,feminine,regular,\r\neī,singular,dative,5th,feminine,regular,\r\nī,singular,dative,5th,feminine,irregular,\r\nē,singular,dative,5th,feminine,irregular,6\r\nam,singular,accusative,1st,feminine,regular,\r\nēn,singular,accusative,1st,feminine,irregular,\r\nān,singular,accusative,1st,feminine,irregular,7\r\num,singular,accusative,2nd,masculine feminine,regular,\r\nom,singular,accusative,2nd,masculine feminine,irregular,1\r\nōn,singular,accusative,2nd,masculine feminine,irregular,7\r\num,singular,accusative,2nd,neuter,regular,\r\nus,singular,accusative,2nd,neuter,irregular,10\r\non,singular,accusative,2nd,neuter,irregular,7\r\nem,singular,accusative,3rd,masculine feminine,regular,\r\nim,singular,accusative,3rd,masculine feminine,irregular,11\r\na,singular,accusative,3rd,masculine feminine,irregular,7\r\n-,singular,accusative,3rd,neuter,regular,\r\num,singular,accusative,4th,masculine feminine,regular,\r\nū,singular,accusative,4th,neuter,regular,\r\nem,singular,accusative,5th,feminine,regular,\r\nā,singular,ablative,1st,feminine,regular,\r\nād,singular,ablative,1st,feminine,irregular,5\r\nē,singular,ablative,1st,feminine,irregular,7\r\nō,singular,ablative,2nd,masculine feminine,regular,\r\nōd,singular,ablative,2nd,masculine feminine,irregular,1\r\nō,singular,ablative,2nd,neuter,regular,\r\ne,singular,ablative,3rd,masculine feminine,regular,\r\nī,singular,ablative,3rd,masculine feminine,irregular,11\r\ne,singular,ablative,3rd,neuter,regular,\r\nī,singular,ablative,3rd,neuter,irregular,11\r\nū,singular,ablative,4th,masculine feminine,regular,\r\nūd,singular,ablative,4th,masculine feminine,irregular,1\r\nū,singular,ablative,4th,neuter,regular,\r\nē,singular,ablative,5th,feminine,regular,\r\nae,singular,locative,1st,feminine,regular,\r\nō,singular,locative,2nd,masculine feminine,regular,\r\nō,singular,locative,2nd,neuter,regular,\r\ne,singular,locative,3rd,masculine feminine,regular,\r\nī,singular,locative,3rd,masculine feminine,regular,\r\nī,singular,locative,3rd,neuter,regular,\r\nū,singular,locative,4th,masculine feminine,regular,\r\nū,singular,locative,4th,neuter,regular,\r\nē,singular,locative,5th,feminine,regular,\r\na,singular,vocative,1st,feminine,regular,\r\nē,singular,vocative,1st,feminine,irregular,\r\nā,singular,vocative,1st,feminine,irregular,7\r\ne,singular,vocative,2nd,masculine feminine,regular,\r\ner,singular,vocative,2nd,masculine feminine,regular,\r\nir,singular,vocative,2nd,masculine feminine,regular,\r\n-,singular,vocative,2nd,masculine feminine,irregular,\r\nī,singular,vocative,2nd,masculine feminine,irregular,8\r\nōs,singular,vocative,2nd,masculine feminine,irregular,\r\ne,singular,vocative,2nd,masculine feminine,irregular,7\r\num,singular,vocative,2nd,neuter,regular,\r\non,singular,vocative,2nd,neuter,irregular,7\r\n-,singular,vocative,3rd,masculine feminine,regular,\r\n-,singular,vocative,3rd,neuter,regular,\r\nus,singular,vocative,4th,masculine feminine,regular,\r\nū,singular,vocative,4th,neuter,regular,\r\nēs,singular,vocative,5th,feminine,regular,\r\nae,plural,nominative,1st,feminine,regular,\r\nī,plural,nominative,2nd,masculine feminine,regular,\r\noe,plural,nominative,2nd,masculine feminine,irregular,7 9\r\na,plural,nominative,2nd,neuter,regular,\r\nēs,plural,nominative,3rd,masculine feminine,regular,\r\nes,plural,nominative,3rd,masculine feminine,irregular,7\r\na,plural,nominative,3rd,neuter,regular,\r\nia,plural,nominative,3rd,neuter,irregular,11\r\nūs,plural,nominative,4th,masculine feminine,regular,\r\nua,plural,nominative,4th,neuter,regular,\r\nēs,plural,nominative,5th,feminine,regular,\r\nārum,plural,genitive,1st,feminine,regular,\r\num,plural,genitive,1st,feminine,irregular,3\r\nōrum,plural,genitive,2nd,masculine feminine,regular,\r\num,plural,genitive,2nd,masculine feminine,irregular,\r\nom,plural,genitive,2nd,masculine feminine,irregular,8\r\nōrum,plural,genitive,2nd,neuter,regular,\r\num,plural,genitive,2nd,neuter,irregular,\r\num,plural,genitive,3rd,masculine feminine,regular,\r\nium,plural,genitive,3rd,masculine feminine,irregular,11\r\nōn,plural,genitive,3rd,masculine feminine,irregular,7\r\num,plural,genitive,3rd,neuter,regular,\r\nium,plural,genitive,3rd,neuter,irregular,11\r\nuum,plural,genitive,4th,masculine feminine,regular,\r\num,plural,genitive,4th,masculine feminine,irregular,16\r\nuom,plural,genitive,4th,masculine feminine,irregular,1\r\nuum,plural,genitive,4th,neuter,regular,\r\nērum,plural,genitive,5th,feminine,regular,\r\nīs,plural,dative,1st,feminine,regular,\r\nābus,plural,dative,1st,feminine,irregular,4\r\neis,plural,dative,1st,feminine,irregular,6\r\nīs,plural,dative,2nd,masculine feminine,regular,\r\nīs,plural,dative,2nd,neuter,regular,\r\nibus,plural,dative,3rd,masculine feminine,regular,\r\nibus,plural,dative,3rd,neuter,regular,\r\nibus,plural,dative,4th,masculine feminine,regular,\r\nubus,plural,dative,4th,masculine feminine,irregular,14\r\nibus,plural,dative,4th,neuter,regular,\r\nēbus,plural,dative,5th,feminine,regular,\r\nās,plural,accusative,1st,feminine,regular,\r\nōs,plural,accusative,2nd,masculine feminine,regular,\r\na,plural,accusative,2nd,neuter,regular,\r\nēs,plural,accusative,3rd,masculine feminine,regular,\r\nīs,plural,accusative,3rd,masculine feminine,irregular,11\r\nas,plural,accusative,3rd,masculine feminine,irregular,7\r\na,plural,accusative,3rd,neuter,regular,\r\nia,plural,accusative,3rd,neuter,irregular,11\r\nūs,plural,accusative,4th,masculine feminine,regular,\r\nua,plural,accusative,4th,neuter,regular,\r\nēs,plural,accusative,5th,feminine,regular,\r\nīs,plural,ablative,1st,feminine,regular,\r\nābus,plural,ablative,1st,feminine,irregular,4\r\neis,plural,ablative,1st,feminine,irregular,6\r\nīs,plural,ablative,2nd,masculine feminine,regular,\r\nīs,plural,ablative,2nd,neuter,regular,\r\nibus,plural,ablative,3rd,masculine feminine,regular,\r\nibus,plural,ablative,3rd,neuter,regular,\r\nibus,plural,ablative,4th,masculine feminine,regular,\r\nubus,plural,ablative,4th,masculine feminine,irregular,14\r\nibus,plural,ablative,4th,neuter,regular,\r\nēbus,plural,ablative,5th,feminine,regular,\r\nīs,plural,locative,1st,feminine,regular,\r\nīs,plural,locative,2nd,masculine feminine,regular,\r\nīs,plural,locative,2nd,neuter,regular,\r\nibus,plural,locative,3rd,masculine feminine,regular,\r\nibus,plural,locative,3rd,neuter,regular,\r\nibus,plural,locative,4th,masculine feminine,regular,\r\nibus,plural,locative,4th,neuter,regular,\r\nēbus,plural,locative,5th,feminine,regular,\r\nae,plural,vocative,1st,feminine,regular,\r\nī,plural,vocative,2nd,masculine feminine,regular,\r\na,plural,vocative,2nd,neuter,regular,\r\nēs,plural,vocative,3rd,masculine feminine,regular,\r\na,plural,vocative,3rd,neuter,regular,\r\nia,plural,vocative,3rd,neuter,irregular,11\r\nūs,plural,vocative,4th,masculine feminine,regular,\r\nua,plural,vocative,4th,neuter,regular,\r\nēs,plural,vocative,5th,feminine,regular,";
+
+var nounFootnotesCSV = "Index,Text\r\n1,archaic (final s and m of os and om may be omitted in inscriptions)\r\n2,only in familiās\r\n3,especially in Greek patronymics and compounds in -gena and -cola.\r\n4,always in deābus and filiābus; rarely with other words to distinguish the female\r\n5,archaic\r\n6,rare\r\n7,\"may occur in words of Greek origin. The forms of many Greek nouns vary among the first, second and third declensions.\"\r\n8,proper names in ius and filius and genius\r\n9,poetic\r\n10,\"only pelagus, vīrus, and sometimes vulgus\"\r\n11,may occur with i-stems\r\n12,several nouns (most commonly domus) show forms of both second and fourth declensions\r\n13,\"some nouns also have forms from the first declension (eg materia, saevitia) or the third declension (eg requiēs, satiēs, plēbēs, famēs)\"\r\n14,\"Always in partus and tribus, usually in artus and lacus, sometimes in other words, eg portus and specus\"\r\n15,Often in names of plants and trees and in nouns ending in -tus\r\n16,When pronounced as one syllable\r\n17,early\r\n18,dies and meridies are masculine";
+
+var adjectiveSuffixesCSV = "Ending,Number,Case,Declension,Gender,Type,Footnote\r\na,singular,nominative,1st 2nd,feminine,regular,\r\nus,singular,nominative,1st 2nd,masculine,regular,\r\num,singular,nominative,1st 2nd,neuter,regular,\r\nis,singular,nominative,3rd,feminine,regular,\r\n-,singular,nominative,3rd,feminine,irregular,6\r\n-,singular,nominative,3rd,masculine,regular,\r\nis,singular,nominative,3rd,masculine,irregular,5\r\ne,singular,nominative,3rd,neuter,regular,\r\n-,singular,nominative,3rd,neuter,irregular,6\r\nae,singular,genitive,1st 2nd,feminine,regular,\r\nīus,singular,genitive,1st 2nd,feminine,irregular,3\r\nī,singular,genitive,1st 2nd,masculine,regular,\r\nīus,singular,genitive,1st 2nd,masculine,irregular,3\r\nī,singular,genitive,1st 2nd,neuter,regular,\r\nīus,singular,genitive,1st 2nd,neuter,irregular,3\r\nis,singular,genitive,3rd,feminine,regular,\r\nis,singular,genitive,3rd,masculine,regular,\r\nis,singular,genitive,3rd,neuter,regular,\r\nae,singular,dative,1st 2nd,feminine,regular,\r\nī,singular,dative,1st 2nd,feminine,irregular,3\r\nō,singular,dative,1st 2nd,masculine,regular,\r\nī,singular,dative,1st 2nd,masculine,irregular,3\r\nō,singular,dative,1st 2nd,neuter,regular,\r\nī,singular,dative,1st 2nd,neuter,irregular,3\r\nī,singular,dative,3rd,feminine,regular,\r\nī,singular,dative,3rd,masculine,regular,\r\nī,singular,dative,3rd,neuter,regular,\r\nam,singular,accusative,1st 2nd,feminine,regular,\r\num,singular,accusative,1st 2nd,masculine,regular,\r\num,singular,accusative,1st 2nd,neuter,regular,\r\nem,singular,accusative,3rd,feminine,regular,\r\nem,singular,accusative,3rd,masculine,regular,\r\ne,singular,accusative,3rd,neuter,regular,\r\n-,singular,accusative,3rd,neuter,irregular,6\r\nā,singular,ablative,1st 2nd,feminine,regular,\r\nō,singular,ablative,1st 2nd,feminine,irregular,4\r\nō,singular,ablative,1st 2nd,masculine,regular,\r\nō,singular,ablative,1st 2nd,neuter,regular,\r\nī,singular,ablative,3rd,feminine,regular,\r\ne,singular,ablative,3rd,feminine,irregular,7\r\nī,singular,ablative,3rd,masculine,regular,\r\ne,singular,ablative,3rd,masculine,irregular,7\r\nī,singular,ablative,3rd,neuter,regular,\r\nae,singular,locative,1st 2nd,feminine,regular,\r\nī,singular,locative,1st 2nd,masculine,regular,\r\nī,singular,locative,1st 2nd,neuter,regular,\r\nī,singular,locative,3rd,feminine,regular,\r\ne,singular,locative,3rd,feminine,irregular,7\r\nī,singular,locative,3rd,masculine,regular,\r\nī,singular,locative,3rd,neuter,regular,\r\na,singular,vocative,1st 2nd,feminine,regular,\r\ne,singular,vocative,1st 2nd,masculine,regular,\r\nī,singular,vocative,1st 2nd,masculine,irregular,\r\num,singular,vocative,1st 2nd,neuter,regular,\r\nis,singular,vocative,3rd,feminine,regular,\r\n-,singular,vocative,3rd,masculine,regular,\r\ne,singular,vocative,3rd,neuter,regular,\r\n-,singular,vocative,3rd,neuter,irregular,6\r\nae,plural,nominative,1st 2nd,feminine,regular,\r\nī,plural,nominative,1st 2nd,masculine,regular,\r\na,plural,nominative,1st 2nd,neuter,regular,\r\nēs,plural,nominative,3rd,feminine,regular,\r\nēs,plural,nominative,3rd,masculine,regular,\r\nia,plural,nominative,3rd,neuter,regular,\r\nārum,plural,genitive,1st 2nd,feminine,regular,\r\nōrum,plural,genitive,1st 2nd,masculine,regular,\r\nōrum,plural,genitive,1st 2nd,neuter,regular,\r\nium,plural,genitive,3rd,feminine,regular,\r\num,plural,genitive,3rd,feminine,irregular,8\r\nium,plural,genitive,3rd,masculine,regular,\r\num,plural,genitive,3rd,masculine,irregular,8\r\nium,plural,genitive,3rd,neuter,regular,\r\num,plural,genitive,3rd,neuter,irregular,8\r\nīs,plural,dative,1st 2nd,feminine,regular,\r\nīs,plural,dative,1st 2nd,masculine,regular,\r\nīs,plural,dative,1st 2nd,neuter,regular,\r\nibus,plural,dative,3rd,feminine,regular,\r\nibus,plural,dative,3rd,masculine,regular,\r\nibus,plural,dative,3rd,neuter,regular,\r\nās,plural,accusative,1st 2nd,feminine,regular,\r\nōs,plural,accusative,1st 2nd,masculine,regular,\r\na,plural,accusative,1st 2nd,neuter,regular,\r\nīs,plural,accusative,3rd,feminine,regular,\r\nēs,plural,accusative,3rd,feminine,irregular,9\r\nīs,plural,accusative,3rd,masculine,regular,\r\nēs,plural,accusative,3rd,masculine,irregular,9\r\nia,plural,accusative,3rd,neuter,regular,\r\nīs,plural,ablative,1st 2nd,feminine,regular,\r\nīs,plural,ablative,1st 2nd,masculine,regular,\r\nīs,plural,ablative,1st 2nd,neuter,regular,\r\nibus,plural,ablative,3rd,feminine,regular,\r\nibus,plural,ablative,3rd,masculine,regular,\r\nibus,plural,ablative,3rd,neuter,regular,\r\nīs,plural,locative,1st 2nd,feminine,regular,\r\nīs,plural,locative,1st 2nd,masculine,regular,\r\nīs,plural,locative,1st 2nd,neuter,regular,\r\nibus,plural,locative,3rd,feminine,regular,\r\nibus,plural,locative,3rd,masculine,regular,\r\nibus,plural,locative,3rd,neuter,regular,\r\nae,plural,vocative,1st 2nd,feminine,regular,\r\nī,plural,vocative,1st 2nd,masculine,regular,\r\na,plural,vocative,1st 2nd,neuter,regular,\r\nēs,plural,vocative,3rd,feminine,regular,\r\nēs,plural,vocative,3rd,masculine,regular,\r\nia,plural,vocative,3rd,neuter,regular,";
+
+var adjectiveFootnotesCSV = "Index,Text\r\n1,\"Adjectives agree with the noun they modify in gender, number and case.\"\r\n2,Adjectives are inflected according to either\r\n3,\"Only nullus, sōlus, alius (alia, aliud), tōtus, ūllus, ūnus, alter, neuter (neutra,\r\n            neutrum) and uter (utra, utrum).\"\r\n4,In a few adjectives of Greek origin.\r\n5,\"The \"\"two-ending\"\" adjectives use \"\"-is\"\", for both masculine and feminine nominative\r\n            singular.\"\r\n6,\"The \"\"one-ending\"\" adjectives use the same consonant ending for all three genders in the\r\n            nominative singular and the neuter accusative and vocative singular.\"\r\n7,\"An ablative singular in \"\"e\"\" is common in one-ending adjectives, but is usually confined to\r\n            poetry in three and two-ending adjectives.\"\r\n8,\"In comparatives, poetry and some one-ending adjectives.\"\r\n9,Chiefly in comparatives.";
+
+var verbSuffixesCSV = "Ending,Conjugation,Voice,Mood,Tense,Number,Person,Type,Footnote\r\nō,1st,active,indicative,present,singular,1st,regular,\r\nās,1st,active,indicative,present,singular,2nd,regular,\r\nat,1st,active,indicative,present,singular,3rd,regular,\r\nāmus,1st,active,indicative,present,plural,1st,regular,\r\nātis,1st,active,indicative,present,plural,2nd,regular,\r\nant,1st,active,indicative,present,plural,3rd,regular,\r\nem,1st,active,subjunctive,present,singular,1st,regular,\r\nēs,1st,active,subjunctive,present,singular,2nd,regular,\r\net,1st,active,subjunctive,present,singular,3rd,regular,\r\nēmus,1st,active,subjunctive,present,plural,1st,regular,\r\nētis,1st,active,subjunctive,present,plural,2nd,regular,\r\nent,1st,active,subjunctive,present,plural,3rd,regular,\r\neō,2nd,active,indicative,present,singular,1st,regular,\r\nēs,2nd,active,indicative,present,singular,2nd,regular,\r\nēt,2nd,active,indicative,present,singular,3rd,regular,\r\nēmus,2nd,active,indicative,present,plural,1st,regular,\r\nētis,2nd,active,indicative,present,plural,2nd,regular,\r\nent,2nd,active,indicative,present,plural,3rd,regular,\r\neam,2nd,active,subjunctive,present,singular,1st,regular,\r\neās,2nd,active,subjunctive,present,singular,2nd,regular,\r\neat,2nd,active,subjunctive,present,singular,3rd,regular,\r\neāmus,2nd,active,subjunctive,present,plural,1st,regular,\r\neātis,2nd,active,subjunctive,present,plural,2nd,regular,\r\neant,2nd,active,subjunctive,present,plural,3rd,regular,\r\nō,3rd,active,indicative,present,singular,1st,regular,\r\nis,3rd,active,indicative,present,singular,2nd,regular,\r\nit,3rd,active,indicative,present,singular,3rd,regular,\r\nimus,3rd,active,indicative,present,plural,1st,regular,\r\nitis,3rd,active,indicative,present,plural,2nd,regular,\r\nunt,3rd,active,indicative,present,plural,3rd,regular,\r\nam,3rd,active,subjunctive,present,singular,1st,regular,\r\nās,3rd,active,subjunctive,present,singular,2nd,regular,\r\nat,3rd,active,subjunctive,present,singular,3rd,regular,\r\nāmus,3rd,active,subjunctive,present,plural,1st,regular,\r\nātis,3rd,active,subjunctive,present,plural,2nd,regular,\r\nant,3rd,active,subjunctive,present,plural,3rd,regular,\r\niō,4th,active,indicative,present,singular,1st,regular,\r\nīs,4th,active,indicative,present,singular,2nd,regular,\r\nit,4th,active,indicative,present,singular,3rd,regular,\r\nīmus,4th,active,indicative,present,plural,1st,regular,\r\nītis,4th,active,indicative,present,plural,2nd,regular,\r\niunt,4th,active,indicative,present,plural,3rd,regular,\r\niam,4th,active,subjunctive,present,singular,1st,regular,\r\niās,4th,active,subjunctive,present,singular,2nd,regular,\r\niat,4th,active,subjunctive,present,singular,3rd,regular,\r\niāmus,4th,active,subjunctive,present,plural,1st,regular,\r\niāatis,4th,active,subjunctive,present,plural,2nd,regular,\r\niant,4th,active,subjunctive,present,plural,3rd,regular,\r\nābam,1st,active,indicative,imperfect,singular,1st,regular,\r\nābas,1st,active,indicative,imperfect,singular,2nd,regular,\r\nābat,1st,active,indicative,imperfect,singular,3rd,regular,\r\nābāmus,1st,active,indicative,imperfect,plural,1st,regular,\r\nābātis,1st,active,indicative,imperfect,plural,2nd,regular,\r\nābant,1st,active,indicative,imperfect,plural,3rd,regular,\r\nārem,1st,active,subjunctive,imperfect,singular,1st,regular,\r\nārēs,1st,active,subjunctive,imperfect,singular,2nd,regular,\r\nāret,1st,active,subjunctive,imperfect,singular,3rd,regular,\r\nārēmus,1st,active,subjunctive,imperfect,plural,1st,regular,\r\nārētis,1st,active,subjunctive,imperfect,plural,2nd,regular,\r\nārent,1st,active,subjunctive,imperfect,plural,3rd,regular,\r\nēbam,2nd,active,indicative,imperfect,singular,1st,regular,\r\nēbās,2nd,active,indicative,imperfect,singular,2nd,regular,\r\nēbat,2nd,active,indicative,imperfect,singular,3rd,regular,\r\nēbāmus,2nd,active,indicative,imperfect,plural,1st,regular,\r\nēbātis,2nd,active,indicative,imperfect,plural,2nd,regular,\r\nēbant,2nd,active,indicative,imperfect,plural,3rd,regular,\r\nērem,2nd,active,subjunctive,imperfect,singular,1st,regular,\r\nērēs,2nd,active,subjunctive,imperfect,singular,2nd,regular,\r\nēret,2nd,active,subjunctive,imperfect,singular,3rd,regular,\r\nērēmus,2nd,active,subjunctive,imperfect,plural,1st,regular,\r\nērētis,2nd,active,subjunctive,imperfect,plural,2nd,regular,\r\nērēnt,2nd,active,subjunctive,imperfect,plural,3rd,regular,\r\nēbas,3rd,active,indicative,imperfect,singular,1st,regular,\r\nēbāt,3rd,active,indicative,imperfect,singular,2nd,regular,\r\nēbat,3rd,active,indicative,imperfect,singular,3rd,regular,\r\nēbāmus,3rd,active,indicative,imperfect,plural,1st,regular,\r\nēbātis,3rd,active,indicative,imperfect,plural,2nd,regular,\r\nēbant,3rd,active,indicative,imperfect,plural,3rd,regular,\r\nerem,3rd,active,subjunctive,imperfect,singular,1st,regular,\r\nerēs,3rd,active,subjunctive,imperfect,singular,2nd,regular,\r\neret,3rd,active,subjunctive,imperfect,singular,3rd,regular,\r\nerēmus,3rd,active,subjunctive,imperfect,plural,1st,regular,\r\nerētis,3rd,active,subjunctive,imperfect,plural,2nd,regular,\r\nerent,3rd,active,subjunctive,imperfect,plural,3rd,regular,\r\niēbam,4th,active,indicative,imperfect,singular,1st,regular,\r\nībam,4th,active,indicative,imperfect,singular,1st,irregular,2\r\niēbas,4th,active,indicative,imperfect,singular,2nd,regular,\r\nības,4th,active,indicative,imperfect,singular,2nd,irregular,\r\niēbat,4th,active,indicative,imperfect,singular,3rd,regular,\r\nībat,4th,active,indicative,imperfect,singular,3rd,irregular,\r\niēbāmus,4th,active,indicative,imperfect,plural,1st,regular,\r\nībāmus,4th,active,indicative,imperfect,plural,1st,irregular,\r\niēbātis,4th,active,indicative,imperfect,plural,2nd,regular,\r\nībātis,4th,active,indicative,imperfect,plural,2nd,irregular,\r\niēbant,4th,active,indicative,imperfect,plural,3rd,regular,\r\nībant,4th,active,indicative,imperfect,plural,3rd,irregular,\r\nīrem,4th,active,subjunctive,imperfect,singular,1st,regular,\r\nīrēs,4th,active,subjunctive,imperfect,singular,2nd,regular,\r\nīret,4th,active,subjunctive,imperfect,singular,3rd,regular,\r\nīrēmus,4th,active,subjunctive,imperfect,plural,1st,regular,\r\nīrētis,4th,active,subjunctive,imperfect,plural,2nd,regular,\r\nīrēnt,4th,active,subjunctive,imperfect,plural,3rd,regular,\r\nābo,1st,active,indicative,future,singular,1st,regular,\r\nābis,1st,active,indicative,future,singular,2nd,regular,\r\nābit,1st,active,indicative,future,singular,3rd,regular,\r\nābimus,1st,active,indicative,future,plural,1st,regular,\r\nābitis,1st,active,indicative,future,plural,2nd,regular,\r\nābunt,1st,active,indicative,future,plural,3rd,regular,\r\n,1st,active,subjunctive,future,singular,1st,,\r\n,1st,active,subjunctive,future,singular,2nd,,\r\n,1st,active,subjunctive,future,singular,3rd,,\r\n,1st,active,subjunctive,future,plural,1st,,\r\n,1st,active,subjunctive,future,plural,2nd,,\r\n,1st,active,subjunctive,future,plural,3rd,,\r\nēbō,2nd,active,indicative,future,singular,1st,regular,\r\nēbis,2nd,active,indicative,future,singular,2nd,regular,\r\nēbit,2nd,active,indicative,future,singular,3rd,regular,\r\nēbimus,2nd,active,indicative,future,plural,1st,regular,\r\nēbitis,2nd,active,indicative,future,plural,2nd,regular,\r\nēbunt,2nd,active,indicative,future,plural,3rd,regular,\r\n,2nd,active,subjunctive,future,singular,1st,regular,\r\n,2nd,active,subjunctive,future,singular,2nd,,\r\n,2nd,active,subjunctive,future,singular,3rd,,\r\n,2nd,active,subjunctive,future,plural,1st,,\r\n,2nd,active,subjunctive,future,plural,2nd,,\r\n,2nd,active,subjunctive,future,plural,3rd,,\r\nam,3rd,active,indicative,future,singular,1st,regular,\r\nēs,3rd,active,indicative,future,singular,2nd,regular,\r\net,3rd,active,indicative,future,singular,3rd,regular,\r\nēmus,3rd,active,indicative,future,plural,1st,regular,\r\nētis,3rd,active,indicative,future,plural,2nd,regular,\r\nent,3rd,active,indicative,future,plural,3rd,regular,\r\n,3rd,active,subjunctive,future,singular,1st,,\r\n,3rd,active,subjunctive,future,singular,2nd,,\r\n,3rd,active,subjunctive,future,singular,3rd,,\r\n,3rd,active,subjunctive,future,plural,1st,,\r\n,3rd,active,subjunctive,future,plural,2nd,,\r\n,3rd,active,subjunctive,future,plural,3rd,,\r\niam,4th,active,indicative,future,singular,1st,regular,\r\nībō,4th,active,indicative,future,singular,1st,irregular,2\r\niēs,4th,active,indicative,future,singular,2nd,regular,\r\nībis,4th,active,indicative,future,singular,2nd,irregular,\r\niet,4th,active,indicative,future,singular,3rd,regular,\r\nībit,4th,active,indicative,future,singular,3rd,irregular,\r\niēmus,4th,active,indicative,future,plural,1st,regular,\r\nībimus,4th,active,indicative,future,plural,1st,irregular,\r\niētis,4th,active,indicative,future,plural,2nd,regular,\r\nībitis,4th,active,indicative,future,plural,2nd,irregular,\r\nient,4th,active,indicative,future,plural,3rd,regular,\r\nībunt,4th,active,indicative,future,plural,3rd,irregular,\r\n,4th,active,subjunctive,future,singular,1st,,\r\n,4th,active,subjunctive,future,singular,2nd,,\r\n,4th,active,subjunctive,future,singular,3rd,,\r\n,4th,active,subjunctive,future,plural,1st,,\r\n,4th,active,subjunctive,future,plural,2nd,,\r\n,4th,active,subjunctive,future,plural,3rd,,\r\nāvī,1st,active,indicative,perfect,singular,1st,regular,\r\nāvistī,1st,active,indicative,perfect,singular,2nd,regular,\r\nāvit,1st,active,indicative,perfect,singular,3rd,regular,\r\nāvimus,1st,active,indicative,perfect,plural,1st,regular,\r\nāvistis,1st,active,indicative,perfect,plural,2nd,regular,\r\nāvērunt,1st,active,indicative,perfect,plural,3rd,regular,\r\nāvēre,1st,active,indicative,perfect,plural,3rd,irregular,6\r\nāverim,1st,active,subjunctive,perfect,singular,1st,regular,\r\nāveris,1st,active,subjunctive,perfect,singular,2nd,regular,\r\nāverit,1st,active,subjunctive,perfect,singular,3rd,regular,\r\nāverimus,1st,active,subjunctive,perfect,plural,1st,regular,\r\nāveritis,1st,active,subjunctive,perfect,plural,2nd,regular,\r\nāverint,1st,active,subjunctive,perfect,plural,3rd,regular,\r\nvī,2nd,active,indicative,perfect,singular,1st,regular,\r\nvistī,2nd,active,indicative,perfect,singular,2nd,regular,\r\nvit,2nd,active,indicative,perfect,singular,3rd,regular,\r\nvimus,2nd,active,indicative,perfect,plural,1st,regular,\r\nvistis,2nd,active,indicative,perfect,plural,2nd,regular,\r\nvērunt,2nd,active,indicative,perfect,plural,3rd,regular,\r\nvēre,2nd,active,indicative,perfect,plural,3rd,irregular,6\r\nverim,2nd,active,subjunctive,perfect,singular,1st,regular,\r\nveris,2nd,active,subjunctive,perfect,singular,2nd,regular,\r\nverit,2nd,active,subjunctive,perfect,singular,3rd,regular,\r\nverimus,2nd,active,subjunctive,perfect,plural,1st,regular,\r\nveritis,2nd,active,subjunctive,perfect,plural,2nd,regular,\r\nverint,2nd,active,subjunctive,perfect,plural,3rd,regular,\r\nī,3rd,active,indicative,perfect,singular,1st,regular,\r\nistī,3rd,active,indicative,perfect,singular,2nd,regular,\r\nit,3rd,active,indicative,perfect,singular,3rd,regular,\r\nimus,3rd,active,indicative,perfect,plural,1st,regular,\r\nistis,3rd,active,indicative,perfect,plural,2nd,regular,\r\nērunt,3rd,active,indicative,perfect,plural,3rd,regular,\r\nēre,3rd,active,indicative,perfect,plural,3rd,irregular,6\r\nerim,3rd,active,subjunctive,perfect,singular,1st,regular,\r\neris,3rd,active,subjunctive,perfect,singular,2nd,regular,\r\nerit,3rd,active,subjunctive,perfect,singular,3rd,regular,\r\nerimus,3rd,active,subjunctive,perfect,plural,1st,regular,\r\neritis,3rd,active,subjunctive,perfect,plural,2nd,regular,\r\nerint,3rd,active,subjunctive,perfect,plural,3rd,regular,\r\nīvi,4th,active,indicative,perfect,singular,1st,regular,\r\nīvistī,4th,active,indicative,perfect,singular,2nd,regular,\r\nīvit,4th,active,indicative,perfect,singular,3rd,regular,\r\nīvimus,4th,active,indicative,perfect,plural,1st,regular,\r\nīvistis,4th,active,indicative,perfect,plural,2nd,regular,\r\nīvērunt,4th,active,indicative,perfect,plural,3rd,regular,\r\nīvēre,4th,active,indicative,perfect,plural,3rd,irregular,6\r\nīverim,4th,active,subjunctive,perfect,singular,1st,regular,\r\niveris,4th,active,subjunctive,perfect,singular,2nd,regular,\r\nīverit,4th,active,subjunctive,perfect,singular,3rd,regular,\r\nīverimus,4th,active,subjunctive,perfect,plural,1st,regular,\r\nīveritis,4th,active,subjunctive,perfect,plural,2nd,regular,\r\nīverint,4th,active,subjunctive,perfect,plural,3rd,regular,\r\nāveram,1st,active,indicative,pluperfect,singular,1st,regular,\r\nāverās,1st,active,indicative,pluperfect,singular,2nd,regular,\r\nāverat,1st,active,indicative,pluperfect,singular,3rd,regular,\r\nāverāmus,1st,active,indicative,pluperfect,plural,1st,regular,\r\nāverātis,1st,active,indicative,pluperfect,plural,2nd,regular,\r\nāverant,1st,active,indicative,pluperfect,plural,3rd,regular,\r\nāvissem,1st,active,subjunctive,pluperfect,singular,1st,regular,\r\nāvissēs,1st,active,subjunctive,pluperfect,singular,2nd,regular,\r\nāvisset,1st,active,subjunctive,pluperfect,singular,3rd,regular,\r\nāvissēm,1st,active,subjunctive,pluperfect,plural,1st,regular,\r\nāvissēs,1st,active,subjunctive,pluperfect,plural,2nd,regular,\r\nāvisset,1st,active,subjunctive,pluperfect,plural,3rd,regular,\r\nveram,2nd,active,indicative,pluperfect,singular,1st,regular,\r\nverās,2nd,active,indicative,pluperfect,singular,2nd,regular,\r\nverat,2nd,active,indicative,pluperfect,singular,3rd,regular,\r\nverāmus,2nd,active,indicative,pluperfect,plural,1st,regular,\r\nverātis,2nd,active,indicative,pluperfect,plural,2nd,regular,\r\nverant,2nd,active,indicative,pluperfect,plural,3rd,regular,\r\nvissem,2nd,active,subjunctive,pluperfect,singular,1st,regular,\r\nvissēs,2nd,active,subjunctive,pluperfect,singular,2nd,regular,\r\nvisset,2nd,active,subjunctive,pluperfect,singular,3rd,regular,\r\nvissēmus,2nd,active,subjunctive,pluperfect,plural,1st,regular,\r\nvissētis,2nd,active,subjunctive,pluperfect,plural,2nd,regular,\r\nvissent,2nd,active,subjunctive,pluperfect,plural,3rd,regular,\r\neram,3rd,active,indicative,pluperfect,singular,1st,regular,\r\nerās,3rd,active,indicative,pluperfect,singular,2nd,regular,\r\nerat,3rd,active,indicative,pluperfect,singular,3rd,regular,\r\nerāmus,3rd,active,indicative,pluperfect,plural,1st,regular,\r\nerātis,3rd,active,indicative,pluperfect,plural,2nd,regular,\r\nerant,3rd,active,indicative,pluperfect,plural,3rd,regular,\r\nissem,3rd,active,subjunctive,pluperfect,singular,1st,regular,\r\nissēs,3rd,active,subjunctive,pluperfect,singular,2nd,regular,\r\nisset,3rd,active,subjunctive,pluperfect,singular,3rd,regular,\r\nissēmus,3rd,active,subjunctive,pluperfect,plural,1st,regular,\r\nissētis,3rd,active,subjunctive,pluperfect,plural,2nd,regular,\r\nissent,3rd,active,subjunctive,pluperfect,plural,3rd,regular,\r\nīveram,4th,active,indicative,pluperfect,singular,1st,regular,\r\nīverās,4th,active,indicative,pluperfect,singular,2nd,regular,\r\nīverat,4th,active,indicative,pluperfect,singular,3rd,regular,\r\nīverāmus,4th,active,indicative,pluperfect,plural,1st,regular,\r\nīverātis,4th,active,indicative,pluperfect,plural,2nd,regular,\r\nīverant,4th,active,indicative,pluperfect,plural,3rd,regular,\r\nīvissem,4th,active,subjunctive,pluperfect,singular,1st,regular,\r\nīvissēs,4th,active,subjunctive,pluperfect,singular,2nd,regular,\r\nīvisset,4th,active,subjunctive,pluperfect,singular,3rd,regular,\r\nīvissēmus,4th,active,subjunctive,pluperfect,plural,1st,regular,\r\nīvissētis,4th,active,subjunctive,pluperfect,plural,2nd,regular,\r\nīvissent,4th,active,subjunctive,pluperfect,plural,3rd,regular,\r\nāverō,1st,active,indicative,future_perfect,singular,1st,regular,\r\nāveris,1st,active,indicative,future_perfect,singular,2nd,regular,\r\nāverit,1st,active,indicative,future_perfect,singular,3rd,regular,\r\nāverimus,1st,active,indicative,future_perfect,plural,1st,regular,\r\nāveritis,1st,active,indicative,future_perfect,plural,2nd,regular,\r\nāverint,1st,active,indicative,future_perfect,plural,3rd,regular,\r\n,1st,active,subjunctive,future_perfect,singular,1st,,\r\n,1st,active,subjunctive,future_perfect,singular,2nd,,\r\n,1st,active,subjunctive,future_perfect,singular,3rd,,\r\n,1st,active,subjunctive,future_perfect,plural,1st,,\r\n,1st,active,subjunctive,future_perfect,plural,2nd,,\r\n,1st,active,subjunctive,future_perfect,plural,3rd,,\r\nverō,2nd,active,indicative,future_perfect,singular,1st,regular,\r\nvēris,2nd,active,indicative,future_perfect,singular,2nd,regular,\r\nvērit,2nd,active,indicative,future_perfect,singular,3rd,regular,\r\nvērimus,2nd,active,indicative,future_perfect,plural,1st,regular,\r\nvēritis,2nd,active,indicative,future_perfect,plural,2nd,regular,\r\nvērint,2nd,active,indicative,future_perfect,plural,3rd,regular,\r\n,2nd,active,subjunctive,future_perfect,singular,1st,,\r\n,2nd,active,subjunctive,future_perfect,singular,2nd,,\r\n,2nd,active,subjunctive,future_perfect,singular,3rd,,\r\n,2nd,active,subjunctive,future_perfect,plural,1st,,\r\n,2nd,active,subjunctive,future_perfect,plural,2nd,,\r\n,2nd,active,subjunctive,future_perfect,plural,3rd,,\r\nerō,3rd,active,indicative,future_perfect,singular,1st,regular,\r\neris,3rd,active,indicative,future_perfect,singular,2nd,regular,\r\nerit,3rd,active,indicative,future_perfect,singular,3rd,regular,\r\nerimus,3rd,active,indicative,future_perfect,plural,1st,regular,\r\neritis,3rd,active,indicative,future_perfect,plural,2nd,regular,\r\nerint,3rd,active,indicative,future_perfect,plural,3rd,regular,\r\n,3rd,active,subjunctive,future_perfect,singular,1st,,\r\n,3rd,active,subjunctive,future_perfect,singular,2nd,,\r\n,3rd,active,subjunctive,future_perfect,singular,3rd,,\r\n,3rd,active,subjunctive,future_perfect,plural,1st,,\r\n,3rd,active,subjunctive,future_perfect,plural,2nd,,\r\n,3rd,active,subjunctive,future_perfect,plural,3rd,,\r\nīverō,4th,active,indicative,future_perfect,singular,1st,regular,\r\nīveris,4th,active,indicative,future_perfect,singular,2nd,regular,\r\nīverit,4th,active,indicative,future_perfect,singular,3rd,regular,\r\nīverimus,4th,active,indicative,future_perfect,plural,1st,regular,\r\nīveritis,4th,active,indicative,future_perfect,plural,2nd,regular,\r\nīverint,4th,active,indicative,future_perfect,plural,3rd,regular,\r\n,4th,active,subjunctive,future_perfect,singular,1st,,\r\n,4th,active,subjunctive,future_perfect,singular,2nd,,\r\n,4th,active,subjunctive,future_perfect,singular,3rd,,\r\n,4th,active,subjunctive,future_perfect,plural,1st,,\r\n,4th,active,subjunctive,future_perfect,plural,2nd,,\r\n,4th,active,subjunctive,future_perfect,plural,3rd,,\r\nor,1st,passive,indicative,present,singular,1st,regular,\r\nāris,1st,passive,indicative,present,singular,2nd,regular,\r\nāre,1st,passive,indicative,present,singular,2nd,irregular,5\r\nātur,1st,passive,indicative,present,singular,3rd,regular,\r\nāmur,1st,passive,indicative,present,plural,1st,regular,\r\nāminiī,1st,passive,indicative,present,plural,2nd,regular,\r\nantur,1st,passive,indicative,present,plural,3rd,regular,\r\ner,1st,passive,subjunctive,present,singular,1st,regular,\r\nēris,1st,passive,subjunctive,present,singular,2nd,regular,\r\nēre,1st,passive,subjunctive,present,singular,2nd,regular,\r\nētur,1st,passive,subjunctive,present,singular,3rd,regular,\r\nēmur,1st,passive,subjunctive,present,plural,1st,regular,\r\nēminī,1st,passive,subjunctive,present,plural,2nd,regular,\r\nentur,1st,passive,subjunctive,present,plural,3rd,regular,\r\neor,2nd,passive,indicative,present,singular,1st,regular,\r\nēris,2nd,passive,indicative,present,singular,2nd,regular,\r\nēre,2nd,passive,indicative,present,singular,2nd,regular,\r\nētur,2nd,passive,indicative,present,singular,3rd,regular,\r\nēmur,2nd,passive,indicative,present,plural,1st,regular,\r\nēmini,2nd,passive,indicative,present,plural,2nd,regular,\r\nentur,2nd,passive,indicative,present,plural,3rd,regular,\r\near,2nd,passive,subjunctive,present,singular,1st,regular,\r\neāris,2nd,passive,subjunctive,present,singular,2nd,regular,\r\neāre,2nd,passive,subjunctive,present,singular,2nd,regular,\r\neātur,2nd,passive,subjunctive,present,singular,3rd,regular,\r\neāmur,2nd,passive,subjunctive,present,plural,1st,regular,\r\neāminī,2nd,passive,subjunctive,present,plural,2nd,regular,\r\neantur,2nd,passive,subjunctive,present,plural,3rd,regular,\r\nor,3rd,passive,indicative,present,singular,1st,regular,\r\neris,3rd,passive,indicative,present,singular,2nd,regular,\r\nere,3rd,passive,indicative,present,singular,2nd,regular,\r\nitur,3rd,passive,indicative,present,singular,3rd,regular,\r\nimur,3rd,passive,indicative,present,plural,1st,regular,\r\niminī,3rd,passive,indicative,present,plural,2nd,regular,\r\nuntur,3rd,passive,indicative,present,plural,3rd,regular,\r\nar,3rd,passive,subjunctive,present,singular,1st,regular,\r\nāris,3rd,passive,subjunctive,present,singular,2nd,regular,\r\nāre,3rd,passive,subjunctive,present,singular,2nd,regular,\r\nātur,3rd,passive,subjunctive,present,singular,3rd,regular,\r\nāmur,3rd,passive,subjunctive,present,plural,1st,regular,\r\nāminī,3rd,passive,subjunctive,present,plural,2nd,regular,\r\nantur,3rd,passive,subjunctive,present,plural,3rd,regular,\r\nior,4th,passive,indicative,present,singular,1st,regular,\r\nīris,4th,passive,indicative,present,singular,2nd,regular,\r\nīre,4th,passive,indicative,present,singular,2nd,regular,\r\nītur,4th,passive,indicative,present,singular,3rd,regular,\r\nīmur,4th,passive,indicative,present,plural,1st,regular,\r\nīminī,4th,passive,indicative,present,plural,2nd,regular,\r\niuntur,4th,passive,indicative,present,plural,3rd,regular,\r\niar,4th,passive,subjunctive,present,singular,1st,regular,\r\niāris,4th,passive,subjunctive,present,singular,2nd,regular,\r\niāre,4th,passive,subjunctive,present,singular,2nd,regular,\r\niātur,4th,passive,subjunctive,present,singular,3rd,regular,\r\niāmur,4th,passive,subjunctive,present,plural,1st,regular,\r\niāminī,4th,passive,subjunctive,present,plural,2nd,regular,\r\niantur,4th,passive,subjunctive,present,plural,3rd,regular,\r\nābar,1st,passive,indicative,imperfect,singular,1st,regular,\r\nābāaris,1st,passive,indicative,imperfect,singular,2nd,regular,\r\nābāre,1st,passive,indicative,imperfect,singular,2nd,regular,\r\nābātur,1st,passive,indicative,imperfect,singular,3rd,regular,\r\nābāmur,1st,passive,indicative,imperfect,plural,1st,regular,\r\nābāminī,1st,passive,indicative,imperfect,plural,2nd,regular,\r\nābantur,1st,passive,indicative,imperfect,plural,3rd,regular,\r\nārer,1st,passive,subjunctive,imperfect,singular,1st,regular,\r\nārēris,1st,passive,subjunctive,imperfect,singular,2nd,regular,\r\nārēre,1st,passive,subjunctive,imperfect,singular,2nd,regular,\r\nārētur,1st,passive,subjunctive,imperfect,singular,3rd,regular,\r\nārēmur,1st,passive,subjunctive,imperfect,plural,1st,regular,\r\nārēminī,1st,passive,subjunctive,imperfect,plural,2nd,regular,\r\nārentur,1st,passive,subjunctive,imperfect,plural,3rd,regular,\r\nēbar,2nd,passive,indicative,imperfect,singular,1st,regular,\r\nēbāris,2nd,passive,indicative,imperfect,singular,2nd,regular,\r\nēbāre,2nd,passive,indicative,imperfect,singular,2nd,regular,\r\nēbātur,2nd,passive,indicative,imperfect,singular,3rd,regular,\r\nēbāmur,2nd,passive,indicative,imperfect,plural,1st,regular,\r\nēbāmini,2nd,passive,indicative,imperfect,plural,2nd,regular,\r\nēbantur,2nd,passive,indicative,imperfect,plural,3rd,regular,\r\nērer,2nd,passive,subjunctive,imperfect,singular,1st,regular,\r\nērēris,2nd,passive,subjunctive,imperfect,singular,2nd,regular,\r\nērēre,2nd,passive,subjunctive,imperfect,singular,2nd,regular,\r\nērētur,2nd,passive,subjunctive,imperfect,singular,3rd,regular,\r\nērēmur,2nd,passive,subjunctive,imperfect,plural,1st,regular,\r\nērēminī,2nd,passive,subjunctive,imperfect,plural,2nd,regular,\r\nērentur,2nd,passive,subjunctive,imperfect,plural,3rd,regular,\r\nēbar,3rd,passive,indicative,imperfect,singular,1st,regular,\r\nēbāris,3rd,passive,indicative,imperfect,singular,2nd,regular,\r\nēbāre,3rd,passive,indicative,imperfect,singular,2nd,regular,\r\nēbatur,3rd,passive,indicative,imperfect,singular,3rd,regular,\r\nēbāmur,3rd,passive,indicative,imperfect,plural,1st,regular,\r\nēbāminī,3rd,passive,indicative,imperfect,plural,2nd,regular,\r\nēbantur,3rd,passive,indicative,imperfect,plural,3rd,regular,\r\nerer,3rd,passive,subjunctive,imperfect,singular,1st,regular,\r\nerēris,3rd,passive,subjunctive,imperfect,singular,2nd,regular,\r\nerēre,3rd,passive,subjunctive,imperfect,singular,2nd,regular,\r\nerētur,3rd,passive,subjunctive,imperfect,singular,3rd,regular,\r\nerēmur,3rd,passive,subjunctive,imperfect,plural,1st,regular,\r\nerēminī,3rd,passive,subjunctive,imperfect,plural,2nd,regular,\r\nerentur,3rd,passive,subjunctive,imperfect,plural,3rd,regular,\r\niēbar,4th,passive,indicative,imperfect,singular,1st,regular,\r\niēbāris,4th,passive,indicative,imperfect,singular,2nd,regular,\r\niēbāre,4th,passive,indicative,imperfect,singular,2nd,regular,\r\niēbātur,4th,passive,indicative,imperfect,singular,3rd,regular,\r\niēbāmur,4th,passive,indicative,imperfect,plural,1st,regular,\r\niēbāminī,4th,passive,indicative,imperfect,plural,2nd,regular,\r\niēbantur,4th,passive,indicative,imperfect,plural,3rd,regular,\r\nīrer,4th,passive,subjunctive,imperfect,singular,1st,regular,\r\nīrēris,4th,passive,subjunctive,imperfect,singular,2nd,regular,\r\nīrēre,4th,passive,subjunctive,imperfect,singular,2nd,regular,\r\nīrētur,4th,passive,subjunctive,imperfect,singular,3rd,regular,\r\nīrēmur,4th,passive,subjunctive,imperfect,plural,1st,regular,\r\nīrēminī,4th,passive,subjunctive,imperfect,plural,2nd,regular,\r\nīrentur,4th,passive,subjunctive,imperfect,plural,3rd,regular,\r\nābor,1st,passive,indicative,future,singular,1st,regular,\r\nāberis,1st,passive,indicative,future,singular,2nd,regular,\r\nābere,1st,passive,indicative,future,singular,2nd,irregular,\r\nābitur,1st,passive,indicative,future,singular,3rd,regular,\r\nābimur,1st,passive,indicative,future,plural,1st,regular,\r\nābiminī,1st,passive,indicative,future,plural,2nd,regular,\r\nābuntur,1st,passive,indicative,future,plural,3rd,regular,\r\n,1st,passive,subjunctive,future,singular,1st,,\r\n,1st,passive,subjunctive,future,singular,2nd,,\r\n,1st,passive,subjunctive,future,singular,3rd,,\r\n,1st,passive,subjunctive,future,plural,1st,,\r\n,1st,passive,subjunctive,future,plural,2nd,,\r\n,1st,passive,subjunctive,future,plural,3rd,,\r\nēbor,2nd,passive,indicative,future,singular,1st,regular,\r\nēberis,2nd,passive,indicative,future,singular,2nd,regular,\r\nēbere,2nd,passive,indicative,future,singular,2nd,regular,\r\nēbitur,2nd,passive,indicative,future,singular,3rd,regular,\r\nēbimur,2nd,passive,indicative,future,plural,1st,regular,\r\nēbiminī,2nd,passive,indicative,future,plural,2nd,regular,\r\nēbuntur,2nd,passive,indicative,future,plural,3rd,regular,\r\n,2nd,passive,subjunctive,future,singular,1st,,\r\n,2nd,passive,subjunctive,future,singular,2nd,,\r\n,2nd,passive,subjunctive,future,singular,3rd,,\r\n,2nd,passive,subjunctive,future,plural,1st,,\r\n,2nd,passive,subjunctive,future,plural,2nd,,\r\n,2nd,passive,subjunctive,future,plural,3rd,,\r\nar,3rd,passive,indicative,future,singular,1st,regular,\r\nēris,3rd,passive,indicative,future,singular,2nd,regular,\r\nēre,3rd,passive,indicative,future,singular,2nd,irregular,\r\nētur,3rd,passive,indicative,future,singular,3rd,regular,\r\nēmur,3rd,passive,indicative,future,plural,1st,regular,\r\nēminī,3rd,passive,indicative,future,plural,2nd,regular,\r\nentur,3rd,passive,indicative,future,plural,3rd,regular,\r\n,3rd,passive,subjunctive,future,singular,1st,,\r\n,3rd,passive,subjunctive,future,singular,2nd,,\r\n,3rd,passive,subjunctive,future,singular,3rd,,\r\n,3rd,passive,subjunctive,future,plural,1st,,\r\n,3rd,passive,subjunctive,future,plural,2nd,,\r\n,3rd,passive,subjunctive,future,plural,3rd,,\r\niar,4th,passive,indicative,future,singular,1st,regular,\r\niēris,4th,passive,indicative,future,singular,2nd,regular,\r\nīēre,4th,passive,indicative,future,singular,2nd,irregular,\r\niētur,4th,passive,indicative,future,singular,3rd,regular,\r\niēmur,4th,passive,indicative,future,plural,1st,regular,\r\niēminī,4th,passive,indicative,future,plural,2nd,regular,\r\nientur,4th,passive,indicative,future,plural,3rd,regular,\r\n,4th,passive,subjunctive,future,singular,1st,,\r\n,4th,passive,subjunctive,future,singular,2nd,,\r\n,4th,passive,subjunctive,future,singular,3rd,,\r\n,4th,passive,subjunctive,future,plural,1st,,\r\n,4th,passive,subjunctive,future,plural,2nd,,\r\n,4th,passive,subjunctive,future,plural,3rd,,\r\nātus sum,1st,passive,indicative,perfect,singular,1st,regular,\r\nātus fui,1st,passive,indicative,perfect,singular,1st,regular,\r\nātus es,1st,passive,indicative,perfect,singular,2nd,regular,\r\nātus fuisti,1st,passive,indicative,perfect,singular,2nd,regular,\r\nātus est,1st,passive,indicative,perfect,singular,3rd,regular,\r\nātus fuit,1st,passive,indicative,perfect,singular,3rd,regular,\r\nāti sumus,1st,passive,indicative,perfect,plural,1st,regular,\r\nāti fuimus,1st,passive,indicative,perfect,plural,1st,irregular,\r\nāti estis,1st,passive,indicative,perfect,plural,2nd,regular,\r\nāti fuistis,1st,passive,indicative,perfect,plural,2nd,irregular,\r\nāti sunt,1st,passive,indicative,perfect,plural,3rd,regular,\r\nāti fuerunt,1st,passive,indicative,perfect,plural,3rd,irregular,\r\nātus sim,1st,passive,subjunctive,perfect,singular,1st,regular,\r\nātus fuerim,1st,passive,subjunctive,perfect,singular,1st,irregular,\r\nātus sis,1st,passive,subjunctive,perfect,singular,2nd,regular,\r\nātus fueris,1st,passive,subjunctive,perfect,singular,2nd,irregular,\r\nātus sit,1st,passive,subjunctive,perfect,singular,3rd,regular,\r\nātus fuerit,1st,passive,subjunctive,perfect,singular,3rd,regular,\r\nāti sīmus,1st,passive,subjunctive,perfect,plural,1st,regular,\r\nāti fuerimus,1st,passive,subjunctive,perfect,plural,1st,irregular,\r\nāti sītis,1st,passive,subjunctive,perfect,plural,2nd,regular,\r\nāti fueritis,1st,passive,subjunctive,perfect,plural,2nd,irregular,\r\nāti sint,1st,passive,subjunctive,perfect,plural,3rd,regular,\r\nāti fuerint,1st,passive,subjunctive,perfect,plural,3rd,irregular,\r\nitus sum,2nd,passive,indicative,perfect,singular,1st,regular,\r\nitus es,2nd,passive,indicative,perfect,singular,2nd,regular,\r\nitus est,2nd,passive,indicative,perfect,singular,3rd,regular,\r\nitī sumus,2nd,passive,indicative,perfect,plural,1st,regular,\r\nitī estis,2nd,passive,indicative,perfect,plural,2nd,regular,\r\nitī sunt,2nd,passive,indicative,perfect,plural,3rd,regular,\r\nitus sim,2nd,passive,subjunctive,perfect,singular,1st,regular,\r\nitus sīs,2nd,passive,subjunctive,perfect,singular,2nd,regular,\r\nitus sit,2nd,passive,subjunctive,perfect,singular,3rd,regular,\r\nitī sīmus,2nd,passive,subjunctive,perfect,plural,1st,regular,\r\nitī sītis,2nd,passive,subjunctive,perfect,plural,2nd,regular,\r\nitī sint,2nd,passive,subjunctive,perfect,plural,3rd,regular,\r\nus sum,3rd,passive,indicative,perfect,singular,1st,regular,\r\nus es,3rd,passive,indicative,perfect,singular,2nd,regular,\r\nus est,3rd,passive,indicative,perfect,singular,3rd,regular,\r\nī sumus,3rd,passive,indicative,perfect,plural,1st,regular,\r\nī estis,3rd,passive,indicative,perfect,plural,2nd,regular,\r\nī sunt,3rd,passive,indicative,perfect,plural,3rd,regular,\r\nus sim,3rd,passive,subjunctive,perfect,singular,1st,regular,\r\nus sīs,3rd,passive,subjunctive,perfect,singular,2nd,regular,\r\nus sit,3rd,passive,subjunctive,perfect,singular,3rd,regular,\r\nus sīmus,3rd,passive,subjunctive,perfect,plural,1st,regular,\r\nus sītis,3rd,passive,subjunctive,perfect,plural,2nd,regular,\r\nus sint,3rd,passive,subjunctive,perfect,plural,3rd,regular,\r\nītus sum,4th,passive,indicative,perfect,singular,1st,regular,\r\nītus es,4th,passive,indicative,perfect,singular,2nd,regular,\r\nītus est,4th,passive,indicative,perfect,singular,3rd,regular,\r\nītī sumus,4th,passive,indicative,perfect,plural,1st,regular,\r\nīti estis,4th,passive,indicative,perfect,plural,2nd,regular,\r\nīti sunt,4th,passive,indicative,perfect,plural,3rd,regular,\r\nītus sim,4th,passive,subjunctive,perfect,singular,1st,regular,\r\nītus sīs,4th,passive,subjunctive,perfect,singular,2nd,regular,\r\nītus sit,4th,passive,subjunctive,perfect,singular,3rd,regular,\r\nītī sīmus,4th,passive,subjunctive,perfect,plural,1st,regular,\r\nīti sītis,4th,passive,subjunctive,perfect,plural,2nd,regular,\r\nīti sint,4th,passive,subjunctive,perfect,plural,3rd,regular,\r\nātus eram,1st,passive,indicative,pluperfect,singular,1st,regular,\r\nātus fueram,1st,passive,indicative,pluperfect,singular,1st,irregular,\r\nātus eras,1st,passive,indicative,pluperfect,singular,2nd,regular,\r\nātus fueras,1st,passive,indicative,pluperfect,singular,2nd,irregular,\r\nātus erat,1st,passive,indicative,pluperfect,singular,3rd,regular,\r\nātus fuerat,1st,passive,indicative,pluperfect,singular,3rd,irregular,\r\nātī erāmus,1st,passive,indicative,pluperfect,plural,1st,regular,\r\nātī fueramus,1st,passive,indicative,pluperfect,plural,1st,irregular,\r\nātī erātis,1st,passive,indicative,pluperfect,plural,2nd,regular,\r\nātī fueratis,1st,passive,indicative,pluperfect,plural,2nd,irregular,\r\nātī erant,1st,passive,indicative,pluperfect,plural,3rd,regular,\r\nātī fuerant,1st,passive,indicative,pluperfect,plural,3rd,irregular,\r\nātus essem,1st,passive,subjunctive,pluperfect,singular,1st,regular,\r\nātus fuissem,1st,passive,subjunctive,pluperfect,singular,1st,irregular,\r\nātus esses,1st,passive,subjunctive,pluperfect,singular,2nd,regular,\r\nātus fuissēs,1st,passive,subjunctive,pluperfect,singular,2nd,irregular,\r\nātus esset,1st,passive,subjunctive,pluperfect,singular,3rd,regular,\r\nātus fuisset,1st,passive,subjunctive,pluperfect,singular,3rd,irregular,\r\nāti essēmus,1st,passive,subjunctive,pluperfect,plural,1st,regular,\r\nāti fuissēmus,1st,passive,subjunctive,pluperfect,plural,1st,irregular,\r\nāti essētis,1st,passive,subjunctive,pluperfect,plural,2nd,regular,\r\nāti fuissētis,1st,passive,subjunctive,pluperfect,plural,2nd,regular,\r\nāti essent,1st,passive,subjunctive,pluperfect,plural,3rd,regular,\r\nāti fuissent,1st,passive,subjunctive,pluperfect,plural,3rd,regular,\r\nitus eram,2nd,passive,indicative,pluperfect,singular,1st,regular,\r\nitus erās,2nd,passive,indicative,pluperfect,singular,2nd,regular,\r\nitus erat,2nd,passive,indicative,pluperfect,singular,3rd,regular,\r\nitī erāmus,2nd,passive,indicative,pluperfect,plural,1st,regular,\r\nitī erātis,2nd,passive,indicative,pluperfect,plural,2nd,regular,\r\nitī erant,2nd,passive,indicative,pluperfect,plural,3rd,regular,\r\nitus essem,2nd,passive,subjunctive,pluperfect,singular,1st,regular,\r\nitus essēs,2nd,passive,subjunctive,pluperfect,singular,2nd,regular,\r\nitus esset,2nd,passive,subjunctive,pluperfect,singular,3rd,regular,\r\nitī essēmus,2nd,passive,subjunctive,pluperfect,plural,1st,regular,\r\nīti essētis,2nd,passive,subjunctive,pluperfect,plural,2nd,regular,\r\nīti essent,2nd,passive,subjunctive,pluperfect,plural,3rd,regular,\r\nus eram,3rd,passive,indicative,pluperfect,singular,1st,regular,\r\nus erās,3rd,passive,indicative,pluperfect,singular,2nd,regular,\r\nus erat,3rd,passive,indicative,pluperfect,singular,3rd,regular,\r\nī erāmus,3rd,passive,indicative,pluperfect,plural,1st,regular,\r\nī erātis,3rd,passive,indicative,pluperfect,plural,2nd,regular,\r\nī erant,3rd,passive,indicative,pluperfect,plural,3rd,regular,\r\nus essem,3rd,passive,subjunctive,pluperfect,singular,1st,regular,\r\nus essēs,3rd,passive,subjunctive,pluperfect,singular,2nd,regular,\r\nus esset,3rd,passive,subjunctive,pluperfect,singular,3rd,regular,\r\nī essēmus,3rd,passive,subjunctive,pluperfect,plural,1st,regular,\r\nī essētis,3rd,passive,subjunctive,pluperfect,plural,2nd,regular,\r\nī essent,3rd,passive,subjunctive,pluperfect,plural,3rd,regular,\r\nītus eram,4th,passive,indicative,pluperfect,singular,1st,regular,\r\nītus erās,4th,passive,indicative,pluperfect,singular,2nd,regular,\r\nītus erat,4th,passive,indicative,pluperfect,singular,3rd,regular,\r\nītī erāmus,4th,passive,indicative,pluperfect,plural,1st,regular,\r\nīti erātis,4th,passive,indicative,pluperfect,plural,2nd,regular,\r\nītī erant,4th,passive,indicative,pluperfect,plural,3rd,regular,\r\nītus essem,4th,passive,subjunctive,pluperfect,singular,1st,regular,\r\nītus essēs,4th,passive,subjunctive,pluperfect,singular,2nd,regular,\r\nītus esset,4th,passive,subjunctive,pluperfect,singular,3rd,regular,\r\nītī essēmus,4th,passive,subjunctive,pluperfect,plural,1st,regular,\r\nīti essētis,4th,passive,subjunctive,pluperfect,plural,2nd,regular,\r\nīti essent,4th,passive,subjunctive,pluperfect,plural,3rd,regular,\r\nātus erō,1st,passive,indicative,future_perfect,singular,1st,regular,\r\nātus eris,1st,passive,indicative,future_perfect,singular,2nd,regular,\r\nātus erit,1st,passive,indicative,future_perfect,singular,3rd,regular,\r\nāti erimus,1st,passive,indicative,future_perfect,plural,1st,regular,\r\nāti eritis,1st,passive,indicative,future_perfect,plural,2nd,regular,\r\nāti erunt,1st,passive,indicative,future_perfect,plural,3rd,regular,\r\n,1st,passive,subjunctive,future_perfect,singular,1st,,\r\n,1st,passive,subjunctive,future_perfect,singular,2nd,,\r\n,1st,passive,subjunctive,future_perfect,singular,3rd,,\r\n,1st,passive,subjunctive,future_perfect,plural,1st,,\r\n,1st,passive,subjunctive,future_perfect,plural,2nd,,\r\n,1st,passive,subjunctive,future_perfect,plural,3rd,,\r\nitus erō,2nd,passive,indicative,future_perfect,singular,1st,regular,\r\nitus eris,2nd,passive,indicative,future_perfect,singular,2nd,regular,\r\nitus erit,2nd,passive,indicative,future_perfect,singular,3rd,regular,\r\nitī erimus,2nd,passive,indicative,future_perfect,plural,1st,regular,\r\nitī eritis,2nd,passive,indicative,future_perfect,plural,2nd,regular,\r\nitī erunt,2nd,passive,indicative,future_perfect,plural,3rd,regular,\r\n,2nd,passive,subjunctive,future_perfect,singular,1st,,\r\n,2nd,passive,subjunctive,future_perfect,singular,2nd,,\r\n,2nd,passive,subjunctive,future_perfect,singular,3rd,,\r\n,2nd,passive,subjunctive,future_perfect,plural,1st,,\r\n,2nd,passive,subjunctive,future_perfect,plural,2nd,,\r\n,2nd,passive,subjunctive,future_perfect,plural,3rd,,\r\nus erō,3rd,passive,indicative,future_perfect,singular,1st,regular,\r\nus eris,3rd,passive,indicative,future_perfect,singular,2nd,regular,\r\nus erit,3rd,passive,indicative,future_perfect,singular,3rd,regular,\r\nī erimus,3rd,passive,indicative,future_perfect,plural,1st,regular,\r\nī eritis,3rd,passive,indicative,future_perfect,plural,2nd,regular,\r\nī erunt,3rd,passive,indicative,future_perfect,plural,3rd,regular,\r\n,3rd,passive,subjunctive,future_perfect,singular,1st,,\r\n,3rd,passive,subjunctive,future_perfect,singular,2nd,,\r\n,3rd,passive,subjunctive,future_perfect,singular,3rd,,\r\n,3rd,passive,subjunctive,future_perfect,plural,1st,,\r\n,3rd,passive,subjunctive,future_perfect,plural,2nd,,\r\n,3rd,passive,subjunctive,future_perfect,plural,3rd,,\r\nītus erō,4th,passive,indicative,future_perfect,singular,1st,regular,\r\nītus eris,4th,passive,indicative,future_perfect,singular,2nd,regular,\r\nītus erit,4th,passive,indicative,future_perfect,singular,3rd,regular,\r\nītī erimus,4th,passive,indicative,future_perfect,plural,1st,regular,\r\nītī eritis,4th,passive,indicative,future_perfect,plural,2nd,regular,\r\nītī erunt,4th,passive,indicative,future_perfect,plural,3rd,regular,\r\n,4th,passive,subjunctive,future_perfect,singular,1st,,\r\n,4th,passive,subjunctive,future_perfect,singular,2nd,,\r\n,4th,passive,subjunctive,future_perfect,singular,3rd,,\r\n,4th,passive,subjunctive,future_perfect,plural,1st,,\r\n,4th,passive,subjunctive,future_perfect,plural,2nd,,\r\n,4th,passive,subjunctive,future_perfect,plural,3rd,,";
+
+var verbFootnotesCSV = "Index,Text\r\n2,Chiefly in poetry.\r\n3,\"In tenses based on the perfect stem (the perfect, pluperfect and future perfect of the Active voice) a v between two vowels is often lost with contraction of the two vowels, thus āvī to ā, ēvī to ē, ōvi to ō. Perfects in īvī often omit the v but rarely contract the vowels, except before ss or st, and sometimes in the third person. In addition to the use of v or u, the Active perfect stem can also be formed in a number of other ways, such as the addition of s to the root (eg carpsi), reduplication of the root (eg cecidi from cado), and simple lengthening of the vowel (eg vidī from video or legī from lego).\"\r\n4,\"Dic, duc, fac, and fer lack a final vowel in the imperative in classical Latin. The singular imperative of the verb sciō is always scītō, and the plural is usually scītōte.\"\r\n5,Common in epic poetry.\r\n6,Present in early Latin but chiefly confined to popular use until Livy and later writers.\r\n7,The verb fīō is a 4th conjugation verb that is irregular in only two forms: the present infinitive fierī and the imperfect subjunctive fierem.";
+
+function createCommonjsModule(fn, module) {
+	return module = { exports: {} }, fn(module, module.exports), module.exports;
+}
+
+var papaparse = createCommonjsModule(function (module, exports) {
+/*!
+	Papa Parse
+	v4.3.6
+	https://github.com/mholt/PapaParse
+	License: MIT
+*/
+(function(root, factory)
+{
+	if (typeof undefined === 'function' && undefined.amd)
+	{
+		// AMD. Register as an anonymous module.
+		undefined([], factory);
+	}
+	else {
+		// Node. Does not work with strict CommonJS, but
+		// only CommonJS-like environments that support module.exports,
+		// like Node.
+		module.exports = factory();
+	}
+}(this, function()
+{
+	'use strict';
+
+	var global = (function () {
+		// alternative method, similar to `Function('return this')()`
+		// but without using `eval` (which is disabled when
+		// using Content Security Policy).
+
+		if (typeof self !== 'undefined') { return self; }
+		if (typeof window !== 'undefined') { return window; }
+		if (typeof global !== 'undefined') { return global; }
+
+		// When running tests none of the above have been defined
+		return {};
+	})();
+
+
+	var IS_WORKER = !global.document && !!global.postMessage,
+		IS_PAPA_WORKER = IS_WORKER && /(\?|&)papaworker(=|&|$)/.test(global.location.search),
+		LOADED_SYNC = false, AUTO_SCRIPT_PATH;
+	var workers = {}, workerIdCounter = 0;
+
+	var Papa = {};
+
+	Papa.parse = CsvToJson;
+	Papa.unparse = JsonToCsv;
+
+	Papa.RECORD_SEP = String.fromCharCode(30);
+	Papa.UNIT_SEP = String.fromCharCode(31);
+	Papa.BYTE_ORDER_MARK = '\ufeff';
+	Papa.BAD_DELIMITERS = ['\r', '\n', '"', Papa.BYTE_ORDER_MARK];
+	Papa.WORKERS_SUPPORTED = !IS_WORKER && !!global.Worker;
+	Papa.SCRIPT_PATH = null;	// Must be set by your code if you use workers and this lib is loaded asynchronously
+
+	// Configurable chunk sizes for local and remote files, respectively
+	Papa.LocalChunkSize = 1024 * 1024 * 10;	// 10 MB
+	Papa.RemoteChunkSize = 1024 * 1024 * 5;	// 5 MB
+	Papa.DefaultDelimiter = ',';			// Used if not specified and detection fails
+
+	// Exposed for testing and development only
+	Papa.Parser = Parser;
+	Papa.ParserHandle = ParserHandle;
+	Papa.NetworkStreamer = NetworkStreamer;
+	Papa.FileStreamer = FileStreamer;
+	Papa.StringStreamer = StringStreamer;
+	Papa.ReadableStreamStreamer = ReadableStreamStreamer;
+
+	if (global.jQuery)
+	{
+		var $ = global.jQuery;
+		$.fn.parse = function(options)
+		{
+			var config = options.config || {};
+			var queue = [];
+
+			this.each(function(idx)
+			{
+				var supported = $(this).prop('tagName').toUpperCase() === 'INPUT'
+								&& $(this).attr('type').toLowerCase() === 'file'
+								&& global.FileReader;
+
+				if (!supported || !this.files || this.files.length === 0)
+					return true;	// continue to next input element
+
+				for (var i = 0; i < this.files.length; i++)
+				{
+					queue.push({
+						file: this.files[i],
+						inputElem: this,
+						instanceConfig: $.extend({}, config)
+					});
+				}
+			});
+
+			parseNextFile();	// begin parsing
+			return this;		// maintains chainability
+
+
+			function parseNextFile()
+			{
+				if (queue.length === 0)
+				{
+					if (isFunction(options.complete))
+						options.complete();
+					return;
+				}
+
+				var f = queue[0];
+
+				if (isFunction(options.before))
+				{
+					var returned = options.before(f.file, f.inputElem);
+
+					if (typeof returned === 'object')
+					{
+						if (returned.action === 'abort')
+						{
+							error('AbortError', f.file, f.inputElem, returned.reason);
+							return;	// Aborts all queued files immediately
+						}
+						else if (returned.action === 'skip')
+						{
+							fileComplete();	// parse the next file in the queue, if any
+							return;
+						}
+						else if (typeof returned.config === 'object')
+							f.instanceConfig = $.extend(f.instanceConfig, returned.config);
+					}
+					else if (returned === 'skip')
+					{
+						fileComplete();	// parse the next file in the queue, if any
+						return;
+					}
+				}
+
+				// Wrap up the user's complete callback, if any, so that ours also gets executed
+				var userCompleteFunc = f.instanceConfig.complete;
+				f.instanceConfig.complete = function(results)
+				{
+					if (isFunction(userCompleteFunc))
+						userCompleteFunc(results, f.file, f.inputElem);
+					fileComplete();
+				};
+
+				Papa.parse(f.file, f.instanceConfig);
+			}
+
+			function error(name, file, elem, reason)
+			{
+				if (isFunction(options.error))
+					options.error({name: name}, file, elem, reason);
+			}
+
+			function fileComplete()
+			{
+				queue.splice(0, 1);
+				parseNextFile();
+			}
+		};
+	}
+
+
+	if (IS_PAPA_WORKER)
+	{
+		global.onmessage = workerThreadReceivedMessage;
+	}
+	else if (Papa.WORKERS_SUPPORTED)
+	{
+		AUTO_SCRIPT_PATH = getScriptPath();
+
+		// Check if the script was loaded synchronously
+		if (!document.body)
+		{
+			// Body doesn't exist yet, must be synchronous
+			LOADED_SYNC = true;
+		}
+		else
+		{
+			document.addEventListener('DOMContentLoaded', function () {
+				LOADED_SYNC = true;
+			}, true);
+		}
+	}
+
+
+
+
+	function CsvToJson(_input, _config)
+	{
+		_config = _config || {};
+		var dynamicTyping = _config.dynamicTyping || false;
+		if (isFunction(dynamicTyping)) {
+			_config.dynamicTypingFunction = dynamicTyping;
+			// Will be filled on first row call
+			dynamicTyping = {};
+		}
+		_config.dynamicTyping = dynamicTyping;
+
+		if (_config.worker && Papa.WORKERS_SUPPORTED)
+		{
+			var w = newWorker();
+
+			w.userStep = _config.step;
+			w.userChunk = _config.chunk;
+			w.userComplete = _config.complete;
+			w.userError = _config.error;
+
+			_config.step = isFunction(_config.step);
+			_config.chunk = isFunction(_config.chunk);
+			_config.complete = isFunction(_config.complete);
+			_config.error = isFunction(_config.error);
+			delete _config.worker;	// prevent infinite loop
+
+			w.postMessage({
+				input: _input,
+				config: _config,
+				workerId: w.id
+			});
+
+			return;
+		}
+
+		var streamer = null;
+		if (typeof _input === 'string')
+		{
+			if (_config.download)
+				streamer = new NetworkStreamer(_config);
+			else
+				streamer = new StringStreamer(_config);
+		}
+		else if (_input.readable === true && isFunction(_input.read) && isFunction(_input.on))
+		{
+			streamer = new ReadableStreamStreamer(_config);
+		}
+		else if ((global.File && _input instanceof File) || _input instanceof Object)	// ...Safari. (see issue #106)
+			streamer = new FileStreamer(_config);
+
+		return streamer.stream(_input);
+	}
+
+
+
+
+
+
+	function JsonToCsv(_input, _config)
+	{
+		var _output = '';
+		var _fields = [];
+
+		// Default configuration
+
+		/** whether to surround every datum with quotes */
+		var _quotes = false;
+
+		/** whether to write headers */
+		var _writeHeader = true;
+
+		/** delimiting character */
+		var _delimiter = ',';
+
+		/** newline character(s) */
+		var _newline = '\r\n';
+
+		/** quote character */
+		var _quoteChar = '"';
+
+		unpackConfig();
+
+		var quoteCharRegex = new RegExp(_quoteChar, 'g');
+
+		if (typeof _input === 'string')
+			_input = JSON.parse(_input);
+
+		if (_input instanceof Array)
+		{
+			if (!_input.length || _input[0] instanceof Array)
+				return serialize(null, _input);
+			else if (typeof _input[0] === 'object')
+				return serialize(objectKeys(_input[0]), _input);
+		}
+		else if (typeof _input === 'object')
+		{
+			if (typeof _input.data === 'string')
+				_input.data = JSON.parse(_input.data);
+
+			if (_input.data instanceof Array)
+			{
+				if (!_input.fields)
+					_input.fields =  _input.meta && _input.meta.fields;
+
+				if (!_input.fields)
+					_input.fields =  _input.data[0] instanceof Array
+									? _input.fields
+									: objectKeys(_input.data[0]);
+
+				if (!(_input.data[0] instanceof Array) && typeof _input.data[0] !== 'object')
+					_input.data = [_input.data];	// handles input like [1,2,3] or ['asdf']
+			}
+
+			return serialize(_input.fields || [], _input.data || []);
+		}
+
+		// Default (any valid paths should return before this)
+		throw 'exception: Unable to serialize unrecognized input';
+
+
+		function unpackConfig()
+		{
+			if (typeof _config !== 'object')
+				return;
+
+			if (typeof _config.delimiter === 'string'
+				&& _config.delimiter.length === 1
+				&& Papa.BAD_DELIMITERS.indexOf(_config.delimiter) === -1)
+			{
+				_delimiter = _config.delimiter;
+			}
+
+			if (typeof _config.quotes === 'boolean'
+				|| _config.quotes instanceof Array)
+				_quotes = _config.quotes;
+
+			if (typeof _config.newline === 'string')
+				_newline = _config.newline;
+
+			if (typeof _config.quoteChar === 'string')
+				_quoteChar = _config.quoteChar;
+
+			if (typeof _config.header === 'boolean')
+				_writeHeader = _config.header;
+		}
+
+
+		/** Turns an object's keys into an array */
+		function objectKeys(obj)
+		{
+			if (typeof obj !== 'object')
+				return [];
+			var keys = [];
+			for (var key in obj)
+				keys.push(key);
+			return keys;
+		}
+
+		/** The double for loop that iterates the data and writes out a CSV string including header row */
+		function serialize(fields, data)
+		{
+			var csv = '';
+
+			if (typeof fields === 'string')
+				fields = JSON.parse(fields);
+			if (typeof data === 'string')
+				data = JSON.parse(data);
+
+			var hasHeader = fields instanceof Array && fields.length > 0;
+			var dataKeyedByField = !(data[0] instanceof Array);
+
+			// If there a header row, write it first
+			if (hasHeader && _writeHeader)
+			{
+				for (var i = 0; i < fields.length; i++)
+				{
+					if (i > 0)
+						csv += _delimiter;
+					csv += safe(fields[i], i);
+				}
+				if (data.length > 0)
+					csv += _newline;
+			}
+
+			// Then write out the data
+			for (var row = 0; row < data.length; row++)
+			{
+				var maxCol = hasHeader ? fields.length : data[row].length;
+
+				for (var col = 0; col < maxCol; col++)
+				{
+					if (col > 0)
+						csv += _delimiter;
+					var colIdx = hasHeader && dataKeyedByField ? fields[col] : col;
+					csv += safe(data[row][colIdx], col);
+				}
+
+				if (row < data.length - 1)
+					csv += _newline;
+			}
+
+			return csv;
+		}
+
+		/** Encloses a value around quotes if needed (makes a value safe for CSV insertion) */
+		function safe(str, col)
+		{
+			if (typeof str === 'undefined' || str === null)
+				return '';
+
+			str = str.toString().replace(quoteCharRegex, _quoteChar+_quoteChar);
+
+			var needsQuotes = (typeof _quotes === 'boolean' && _quotes)
+							|| (_quotes instanceof Array && _quotes[col])
+							|| hasAny(str, Papa.BAD_DELIMITERS)
+							|| str.indexOf(_delimiter) > -1
+							|| str.charAt(0) === ' '
+							|| str.charAt(str.length - 1) === ' ';
+
+			return needsQuotes ? _quoteChar + str + _quoteChar : str;
+		}
+
+		function hasAny(str, substrings)
+		{
+			for (var i = 0; i < substrings.length; i++)
+				if (str.indexOf(substrings[i]) > -1)
+					return true;
+			return false;
+		}
+	}
+
+	/** ChunkStreamer is the base prototype for various streamer implementations. */
+	function ChunkStreamer(config)
+	{
+		this._handle = null;
+		this._paused = false;
+		this._finished = false;
+		this._input = null;
+		this._baseIndex = 0;
+		this._partialLine = '';
+		this._rowCount = 0;
+		this._start = 0;
+		this._nextChunk = null;
+		this.isFirstChunk = true;
+		this._completeResults = {
+			data: [],
+			errors: [],
+			meta: {}
+		};
+		replaceConfig.call(this, config);
+
+		this.parseChunk = function(chunk)
+		{
+			// First chunk pre-processing
+			if (this.isFirstChunk && isFunction(this._config.beforeFirstChunk))
+			{
+				var modifiedChunk = this._config.beforeFirstChunk(chunk);
+				if (modifiedChunk !== undefined)
+					chunk = modifiedChunk;
+			}
+			this.isFirstChunk = false;
+
+			// Rejoin the line we likely just split in two by chunking the file
+			var aggregate = this._partialLine + chunk;
+			this._partialLine = '';
+
+			var results = this._handle.parse(aggregate, this._baseIndex, !this._finished);
+
+			if (this._handle.paused() || this._handle.aborted())
+				return;
+
+			var lastIndex = results.meta.cursor;
+
+			if (!this._finished)
+			{
+				this._partialLine = aggregate.substring(lastIndex - this._baseIndex);
+				this._baseIndex = lastIndex;
+			}
+
+			if (results && results.data)
+				this._rowCount += results.data.length;
+
+			var finishedIncludingPreview = this._finished || (this._config.preview && this._rowCount >= this._config.preview);
+
+			if (IS_PAPA_WORKER)
+			{
+				global.postMessage({
+					results: results,
+					workerId: Papa.WORKER_ID,
+					finished: finishedIncludingPreview
+				});
+			}
+			else if (isFunction(this._config.chunk))
+			{
+				this._config.chunk(results, this._handle);
+				if (this._paused)
+					return;
+				results = undefined;
+				this._completeResults = undefined;
+			}
+
+			if (!this._config.step && !this._config.chunk) {
+				this._completeResults.data = this._completeResults.data.concat(results.data);
+				this._completeResults.errors = this._completeResults.errors.concat(results.errors);
+				this._completeResults.meta = results.meta;
+			}
+
+			if (finishedIncludingPreview && isFunction(this._config.complete) && (!results || !results.meta.aborted))
+				this._config.complete(this._completeResults, this._input);
+
+			if (!finishedIncludingPreview && (!results || !results.meta.paused))
+				this._nextChunk();
+
+			return results;
+		};
+
+		this._sendError = function(error)
+		{
+			if (isFunction(this._config.error))
+				this._config.error(error);
+			else if (IS_PAPA_WORKER && this._config.error)
+			{
+				global.postMessage({
+					workerId: Papa.WORKER_ID,
+					error: error,
+					finished: false
+				});
+			}
+		};
+
+		function replaceConfig(config)
+		{
+			// Deep-copy the config so we can edit it
+			var configCopy = copy(config);
+			configCopy.chunkSize = parseInt(configCopy.chunkSize);	// parseInt VERY important so we don't concatenate strings!
+			if (!config.step && !config.chunk)
+				configCopy.chunkSize = null;  // disable Range header if not streaming; bad values break IIS - see issue #196
+			this._handle = new ParserHandle(configCopy);
+			this._handle.streamer = this;
+			this._config = configCopy;	// persist the copy to the caller
+		}
+	}
+
+
+	function NetworkStreamer(config)
+	{
+		config = config || {};
+		if (!config.chunkSize)
+			config.chunkSize = Papa.RemoteChunkSize;
+		ChunkStreamer.call(this, config);
+
+		var xhr;
+
+		if (IS_WORKER)
+		{
+			this._nextChunk = function()
+			{
+				this._readChunk();
+				this._chunkLoaded();
+			};
+		}
+		else
+		{
+			this._nextChunk = function()
+			{
+				this._readChunk();
+			};
+		}
+
+		this.stream = function(url)
+		{
+			this._input = url;
+			this._nextChunk();	// Starts streaming
+		};
+
+		this._readChunk = function()
+		{
+			if (this._finished)
+			{
+				this._chunkLoaded();
+				return;
+			}
+
+			xhr = new XMLHttpRequest();
+
+			if (this._config.withCredentials)
+			{
+				xhr.withCredentials = this._config.withCredentials;
+			}
+
+			if (!IS_WORKER)
+			{
+				xhr.onload = bindFunction(this._chunkLoaded, this);
+				xhr.onerror = bindFunction(this._chunkError, this);
+			}
+
+			xhr.open('GET', this._input, !IS_WORKER);
+			// Headers can only be set when once the request state is OPENED
+			if (this._config.downloadRequestHeaders)
+			{
+				var headers = this._config.downloadRequestHeaders;
+
+				for (var headerName in headers)
+				{
+					xhr.setRequestHeader(headerName, headers[headerName]);
+				}
+			}
+
+			if (this._config.chunkSize)
+			{
+				var end = this._start + this._config.chunkSize - 1;	// minus one because byte range is inclusive
+				xhr.setRequestHeader('Range', 'bytes='+this._start+'-'+end);
+				xhr.setRequestHeader('If-None-Match', 'webkit-no-cache'); // https://bugs.webkit.org/show_bug.cgi?id=82672
+			}
+
+			try {
+				xhr.send();
+			}
+			catch (err) {
+				this._chunkError(err.message);
+			}
+
+			if (IS_WORKER && xhr.status === 0)
+				this._chunkError();
+			else
+				this._start += this._config.chunkSize;
+		};
+
+		this._chunkLoaded = function()
+		{
+			if (xhr.readyState != 4)
+				return;
+
+			if (xhr.status < 200 || xhr.status >= 400)
+			{
+				this._chunkError();
+				return;
+			}
+
+			this._finished = !this._config.chunkSize || this._start > getFileSize(xhr);
+			this.parseChunk(xhr.responseText);
+		};
+
+		this._chunkError = function(errorMessage)
+		{
+			var errorText = xhr.statusText || errorMessage;
+			this._sendError(errorText);
+		};
+
+		function getFileSize(xhr)
+		{
+			var contentRange = xhr.getResponseHeader('Content-Range');
+			if (contentRange === null) { // no content range, then finish!
+					return -1;
+					}
+			return parseInt(contentRange.substr(contentRange.lastIndexOf('/') + 1));
+		}
+	}
+	NetworkStreamer.prototype = Object.create(ChunkStreamer.prototype);
+	NetworkStreamer.prototype.constructor = NetworkStreamer;
+
+
+	function FileStreamer(config)
+	{
+		config = config || {};
+		if (!config.chunkSize)
+			config.chunkSize = Papa.LocalChunkSize;
+		ChunkStreamer.call(this, config);
+
+		var reader, slice;
+
+		// FileReader is better than FileReaderSync (even in worker) - see http://stackoverflow.com/q/24708649/1048862
+		// But Firefox is a pill, too - see issue #76: https://github.com/mholt/PapaParse/issues/76
+		var usingAsyncReader = typeof FileReader !== 'undefined';	// Safari doesn't consider it a function - see issue #105
+
+		this.stream = function(file)
+		{
+			this._input = file;
+			slice = file.slice || file.webkitSlice || file.mozSlice;
+
+			if (usingAsyncReader)
+			{
+				reader = new FileReader();		// Preferred method of reading files, even in workers
+				reader.onload = bindFunction(this._chunkLoaded, this);
+				reader.onerror = bindFunction(this._chunkError, this);
+			}
+			else
+				reader = new FileReaderSync();	// Hack for running in a web worker in Firefox
+
+			this._nextChunk();	// Starts streaming
+		};
+
+		this._nextChunk = function()
+		{
+			if (!this._finished && (!this._config.preview || this._rowCount < this._config.preview))
+				this._readChunk();
+		};
+
+		this._readChunk = function()
+		{
+			var input = this._input;
+			if (this._config.chunkSize)
+			{
+				var end = Math.min(this._start + this._config.chunkSize, this._input.size);
+				input = slice.call(input, this._start, end);
+			}
+			var txt = reader.readAsText(input, this._config.encoding);
+			if (!usingAsyncReader)
+				this._chunkLoaded({ target: { result: txt } });	// mimic the async signature
+		};
+
+		this._chunkLoaded = function(event)
+		{
+			// Very important to increment start each time before handling results
+			this._start += this._config.chunkSize;
+			this._finished = !this._config.chunkSize || this._start >= this._input.size;
+			this.parseChunk(event.target.result);
+		};
+
+		this._chunkError = function()
+		{
+			this._sendError(reader.error);
+		};
+
+	}
+	FileStreamer.prototype = Object.create(ChunkStreamer.prototype);
+	FileStreamer.prototype.constructor = FileStreamer;
+
+
+	function StringStreamer(config)
+	{
+		config = config || {};
+		ChunkStreamer.call(this, config);
+
+		var string;
+		var remaining;
+		this.stream = function(s)
+		{
+			string = s;
+			remaining = s;
+			return this._nextChunk();
+		};
+		this._nextChunk = function()
+		{
+			if (this._finished) return;
+			var size = this._config.chunkSize;
+			var chunk = size ? remaining.substr(0, size) : remaining;
+			remaining = size ? remaining.substr(size) : '';
+			this._finished = !remaining;
+			return this.parseChunk(chunk);
+		};
+	}
+	StringStreamer.prototype = Object.create(StringStreamer.prototype);
+	StringStreamer.prototype.constructor = StringStreamer;
+
+
+	function ReadableStreamStreamer(config)
+	{
+		config = config || {};
+
+		ChunkStreamer.call(this, config);
+
+		var queue = [];
+		var parseOnData = true;
+
+		this.stream = function(stream)
+		{
+			this._input = stream;
+
+			this._input.on('data', this._streamData);
+			this._input.on('end', this._streamEnd);
+			this._input.on('error', this._streamError);
+		};
+
+		this._nextChunk = function()
+		{
+			if (queue.length)
+			{
+				this.parseChunk(queue.shift());
+			}
+			else
+			{
+				parseOnData = true;
+			}
+		};
+
+		this._streamData = bindFunction(function(chunk)
+		{
+			try
+			{
+				queue.push(typeof chunk === 'string' ? chunk : chunk.toString(this._config.encoding));
+
+				if (parseOnData)
+				{
+					parseOnData = false;
+					this.parseChunk(queue.shift());
+				}
+			}
+			catch (error)
+			{
+				this._streamError(error);
+			}
+		}, this);
+
+		this._streamError = bindFunction(function(error)
+		{
+			this._streamCleanUp();
+			this._sendError(error.message);
+		}, this);
+
+		this._streamEnd = bindFunction(function()
+		{
+			this._streamCleanUp();
+			this._finished = true;
+			this._streamData('');
+		}, this);
+
+		this._streamCleanUp = bindFunction(function()
+		{
+			this._input.removeListener('data', this._streamData);
+			this._input.removeListener('end', this._streamEnd);
+			this._input.removeListener('error', this._streamError);
+		}, this);
+	}
+	ReadableStreamStreamer.prototype = Object.create(ChunkStreamer.prototype);
+	ReadableStreamStreamer.prototype.constructor = ReadableStreamStreamer;
+
+
+	// Use one ParserHandle per entire CSV file or string
+	function ParserHandle(_config)
+	{
+		// One goal is to minimize the use of regular expressions...
+		var FLOAT = /^\s*-?(\d*\.?\d+|\d+\.?\d*)(e[-+]?\d+)?\s*$/i;
+
+		var self = this;
+		var _stepCounter = 0;	// Number of times step was called (number of rows parsed)
+		var _input;				// The input being parsed
+		var _parser;			// The core parser being used
+		var _paused = false;	// Whether we are paused or not
+		var _aborted = false;	// Whether the parser has aborted or not
+		var _delimiterError;	// Temporary state between delimiter detection and processing results
+		var _fields = [];		// Fields are from the header row of the input, if there is one
+		var _results = {		// The last results returned from the parser
+			data: [],
+			errors: [],
+			meta: {}
+		};
+
+		if (isFunction(_config.step))
+		{
+			var userStep = _config.step;
+			_config.step = function(results)
+			{
+				_results = results;
+
+				if (needsHeaderRow())
+					processResults();
+				else	// only call user's step function after header row
+				{
+					processResults();
+
+					// It's possbile that this line was empty and there's no row here after all
+					if (_results.data.length === 0)
+						return;
+
+					_stepCounter += results.data.length;
+					if (_config.preview && _stepCounter > _config.preview)
+						_parser.abort();
+					else
+						userStep(_results, self);
+				}
+			};
+		}
+
+		/**
+		 * Parses input. Most users won't need, and shouldn't mess with, the baseIndex
+		 * and ignoreLastRow parameters. They are used by streamers (wrapper functions)
+		 * when an input comes in multiple chunks, like from a file.
+		 */
+		this.parse = function(input, baseIndex, ignoreLastRow)
+		{
+			if (!_config.newline)
+				_config.newline = guessLineEndings(input);
+
+			_delimiterError = false;
+			if (!_config.delimiter)
+			{
+				var delimGuess = guessDelimiter(input, _config.newline, _config.skipEmptyLines);
+				if (delimGuess.successful)
+					_config.delimiter = delimGuess.bestDelimiter;
+				else
+				{
+					_delimiterError = true;	// add error after parsing (otherwise it would be overwritten)
+					_config.delimiter = Papa.DefaultDelimiter;
+				}
+				_results.meta.delimiter = _config.delimiter;
+			}
+			else if(isFunction(_config.delimiter))
+			{
+				_config.delimiter = _config.delimiter(input);
+				_results.meta.delimiter = _config.delimiter;
+			}
+
+			var parserConfig = copy(_config);
+			if (_config.preview && _config.header)
+				parserConfig.preview++;	// to compensate for header row
+
+			_input = input;
+			_parser = new Parser(parserConfig);
+			_results = _parser.parse(_input, baseIndex, ignoreLastRow);
+			processResults();
+			return _paused ? { meta: { paused: true } } : (_results || { meta: { paused: false } });
+		};
+
+		this.paused = function()
+		{
+			return _paused;
+		};
+
+		this.pause = function()
+		{
+			_paused = true;
+			_parser.abort();
+			_input = _input.substr(_parser.getCharIndex());
+		};
+
+		this.resume = function()
+		{
+			_paused = false;
+			self.streamer.parseChunk(_input);
+		};
+
+		this.aborted = function ()
+		{
+			return _aborted;
+		};
+
+		this.abort = function()
+		{
+			_aborted = true;
+			_parser.abort();
+			_results.meta.aborted = true;
+			if (isFunction(_config.complete))
+				_config.complete(_results);
+			_input = '';
+		};
+
+		function processResults()
+		{
+			if (_results && _delimiterError)
+			{
+				addError('Delimiter', 'UndetectableDelimiter', 'Unable to auto-detect delimiting character; defaulted to \''+Papa.DefaultDelimiter+'\'');
+				_delimiterError = false;
+			}
+
+			if (_config.skipEmptyLines)
+			{
+				for (var i = 0; i < _results.data.length; i++)
+					if (_results.data[i].length === 1 && _results.data[i][0] === '')
+						_results.data.splice(i--, 1);
+			}
+
+			if (needsHeaderRow())
+				fillHeaderFields();
+
+			return applyHeaderAndDynamicTyping();
+		}
+
+		function needsHeaderRow()
+		{
+			return _config.header && _fields.length === 0;
+		}
+
+		function fillHeaderFields()
+		{
+			if (!_results)
+				return;
+			for (var i = 0; needsHeaderRow() && i < _results.data.length; i++)
+				for (var j = 0; j < _results.data[i].length; j++)
+					_fields.push(_results.data[i][j]);
+			_results.data.splice(0, 1);
+		}
+
+		function shouldApplyDynamicTyping(field) {
+			// Cache function values to avoid calling it for each row
+			if (_config.dynamicTypingFunction && _config.dynamicTyping[field] === undefined) {
+				_config.dynamicTyping[field] = _config.dynamicTypingFunction(field);
+			}
+			return (_config.dynamicTyping[field] || _config.dynamicTyping) === true
+		}
+
+		function parseDynamic(field, value)
+		{
+			if (shouldApplyDynamicTyping(field))
+			{
+				if (value === 'true' || value === 'TRUE')
+					return true;
+				else if (value === 'false' || value === 'FALSE')
+					return false;
+				else
+					return tryParseFloat(value);
+			}
+			return value;
+		}
+
+		function applyHeaderAndDynamicTyping()
+		{
+			if (!_results || (!_config.header && !_config.dynamicTyping))
+				return _results;
+
+			for (var i = 0; i < _results.data.length; i++)
+			{
+				var row = _config.header ? {} : [];
+
+				for (var j = 0; j < _results.data[i].length; j++)
+				{
+					var field = j;
+					var value = _results.data[i][j];
+
+					if (_config.header)
+						field = j >= _fields.length ? '__parsed_extra' : _fields[j];
+
+					value = parseDynamic(field, value);
+
+					if (field === '__parsed_extra')
+					{
+						row[field] = row[field] || [];
+						row[field].push(value);
+					}
+					else
+						row[field] = value;
+				}
+
+				_results.data[i] = row;
+
+				if (_config.header)
+				{
+					if (j > _fields.length)
+						addError('FieldMismatch', 'TooManyFields', 'Too many fields: expected ' + _fields.length + ' fields but parsed ' + j, i);
+					else if (j < _fields.length)
+						addError('FieldMismatch', 'TooFewFields', 'Too few fields: expected ' + _fields.length + ' fields but parsed ' + j, i);
+				}
+			}
+
+			if (_config.header && _results.meta)
+				_results.meta.fields = _fields;
+			return _results;
+		}
+
+		function guessDelimiter(input, newline, skipEmptyLines)
+		{
+			var delimChoices = [',', '\t', '|', ';', Papa.RECORD_SEP, Papa.UNIT_SEP];
+			var bestDelim, bestDelta, fieldCountPrevRow;
+
+			for (var i = 0; i < delimChoices.length; i++)
+			{
+				var delim = delimChoices[i];
+				var delta = 0, avgFieldCount = 0, emptyLinesCount = 0;
+				fieldCountPrevRow = undefined;
+
+				var preview = new Parser({
+					delimiter: delim,
+					newline: newline,
+					preview: 10
+				}).parse(input);
+
+				for (var j = 0; j < preview.data.length; j++)
+				{
+					if (skipEmptyLines && preview.data[j].length === 1 && preview.data[j][0].length === 0) {
+						emptyLinesCount++;
+						continue
+					}
+					var fieldCount = preview.data[j].length;
+					avgFieldCount += fieldCount;
+
+					if (typeof fieldCountPrevRow === 'undefined')
+					{
+						fieldCountPrevRow = fieldCount;
+						continue;
+					}
+					else if (fieldCount > 1)
+					{
+						delta += Math.abs(fieldCount - fieldCountPrevRow);
+						fieldCountPrevRow = fieldCount;
+					}
+				}
+
+				if (preview.data.length > 0)
+					avgFieldCount /= (preview.data.length - emptyLinesCount);
+
+				if ((typeof bestDelta === 'undefined' || delta < bestDelta)
+					&& avgFieldCount > 1.99)
+				{
+					bestDelta = delta;
+					bestDelim = delim;
+				}
+			}
+
+			_config.delimiter = bestDelim;
+
+			return {
+				successful: !!bestDelim,
+				bestDelimiter: bestDelim
+			}
+		}
+
+		function guessLineEndings(input)
+		{
+			input = input.substr(0, 1024*1024);	// max length 1 MB
+
+			var r = input.split('\r');
+
+			var n = input.split('\n');
+
+			var nAppearsFirst = (n.length > 1 && n[0].length < r[0].length);
+
+			if (r.length === 1 || nAppearsFirst)
+				return '\n';
+
+			var numWithN = 0;
+			for (var i = 0; i < r.length; i++)
+			{
+				if (r[i][0] === '\n')
+					numWithN++;
+			}
+
+			return numWithN >= r.length / 2 ? '\r\n' : '\r';
+		}
+
+		function tryParseFloat(val)
+		{
+			var isNumber = FLOAT.test(val);
+			return isNumber ? parseFloat(val) : val;
+		}
+
+		function addError(type, code, msg, row)
+		{
+			_results.errors.push({
+				type: type,
+				code: code,
+				message: msg,
+				row: row
+			});
+		}
+	}
+
+
+
+
+
+	/** The core parser implements speedy and correct CSV parsing */
+	function Parser(config)
+	{
+		// Unpack the config object
+		config = config || {};
+		var delim = config.delimiter;
+		var newline = config.newline;
+		var comments = config.comments;
+		var step = config.step;
+		var preview = config.preview;
+		var fastMode = config.fastMode;
+		var quoteChar = config.quoteChar || '"';
+
+		// Delimiter must be valid
+		if (typeof delim !== 'string'
+			|| Papa.BAD_DELIMITERS.indexOf(delim) > -1)
+			delim = ',';
+
+		// Comment character must be valid
+		if (comments === delim)
+			throw 'Comment character same as delimiter';
+		else if (comments === true)
+			comments = '#';
+		else if (typeof comments !== 'string'
+			|| Papa.BAD_DELIMITERS.indexOf(comments) > -1)
+			comments = false;
+
+		// Newline must be valid: \r, \n, or \r\n
+		if (newline != '\n' && newline != '\r' && newline != '\r\n')
+			newline = '\n';
+
+		// We're gonna need these at the Parser scope
+		var cursor = 0;
+		var aborted = false;
+
+		this.parse = function(input, baseIndex, ignoreLastRow)
+		{
+			// For some reason, in Chrome, this speeds things up (!?)
+			if (typeof input !== 'string')
+				throw 'Input must be a string';
+
+			// We don't need to compute some of these every time parse() is called,
+			// but having them in a more local scope seems to perform better
+			var inputLen = input.length,
+				delimLen = delim.length,
+				newlineLen = newline.length,
+				commentsLen = comments.length;
+			var stepIsFunction = isFunction(step);
+
+			// Establish starting state
+			cursor = 0;
+			var data = [], errors = [], row = [], lastCursor = 0;
+
+			if (!input)
+				return returnable();
+
+			if (fastMode || (fastMode !== false && input.indexOf(quoteChar) === -1))
+			{
+				var rows = input.split(newline);
+				for (var i = 0; i < rows.length; i++)
+				{
+					var row = rows[i];
+					cursor += row.length;
+					if (i !== rows.length - 1)
+						cursor += newline.length;
+					else if (ignoreLastRow)
+						return returnable();
+					if (comments && row.substr(0, commentsLen) === comments)
+						continue;
+					if (stepIsFunction)
+					{
+						data = [];
+						pushRow(row.split(delim));
+						doStep();
+						if (aborted)
+							return returnable();
+					}
+					else
+						pushRow(row.split(delim));
+					if (preview && i >= preview)
+					{
+						data = data.slice(0, preview);
+						return returnable(true);
+					}
+				}
+				return returnable();
+			}
+
+			var nextDelim = input.indexOf(delim, cursor);
+			var nextNewline = input.indexOf(newline, cursor);
+			var quoteCharRegex = new RegExp(quoteChar+quoteChar, 'g');
+
+			// Parser loop
+			for (;;)
+			{
+				// Field has opening quote
+				if (input[cursor] === quoteChar)
+				{
+					// Start our search for the closing quote where the cursor is
+					var quoteSearch = cursor;
+
+					// Skip the opening quote
+					cursor++;
+
+					for (;;)
+					{
+						// Find closing quote
+						var quoteSearch = input.indexOf(quoteChar, quoteSearch+1);
+
+						//No other quotes are found - no other delimiters
+						if (quoteSearch === -1)
+						{
+							if (!ignoreLastRow) {
+								// No closing quote... what a pity
+								errors.push({
+									type: 'Quotes',
+									code: 'MissingQuotes',
+									message: 'Quoted field unterminated',
+									row: data.length,	// row has yet to be inserted
+									index: cursor
+								});
+							}
+							return finish();
+						}
+
+						// Closing quote at EOF
+						if (quoteSearch === inputLen-1)
+						{
+							var value = input.substring(cursor, quoteSearch).replace(quoteCharRegex, quoteChar);
+							return finish(value);
+						}
+
+						// If this quote is escaped, it's part of the data; skip it
+						if (input[quoteSearch+1] === quoteChar)
+						{
+							quoteSearch++;
+							continue;
+						}
+
+						// Closing quote followed by delimiter
+						if (input[quoteSearch+1] === delim)
+						{
+							row.push(input.substring(cursor, quoteSearch).replace(quoteCharRegex, quoteChar));
+							cursor = quoteSearch + 1 + delimLen;
+							nextDelim = input.indexOf(delim, cursor);
+							nextNewline = input.indexOf(newline, cursor);
+							break;
+						}
+
+						// Closing quote followed by newline
+						if (input.substr(quoteSearch+1, newlineLen) === newline)
+						{
+							row.push(input.substring(cursor, quoteSearch).replace(quoteCharRegex, quoteChar));
+							saveRow(quoteSearch + 1 + newlineLen);
+							nextDelim = input.indexOf(delim, cursor);	// because we may have skipped the nextDelim in the quoted field
+
+							if (stepIsFunction)
+							{
+								doStep();
+								if (aborted)
+									return returnable();
+							}
+
+							if (preview && data.length >= preview)
+								return returnable(true);
+
+							break;
+						}
+
+
+						// Checks for valid closing quotes are complete (escaped quotes or quote followed by EOF/delimiter/newline) -- assume these quotes are part of an invalid text string
+						errors.push({
+							type: 'Quotes',
+							code: 'InvalidQuotes',
+							message: 'Trailing quote on quoted field is malformed',
+							row: data.length,	// row has yet to be inserted
+							index: cursor
+						});
+
+						quoteSearch++;
+						continue;
+
+					}
+
+					continue;
+				}
+
+				// Comment found at start of new line
+				if (comments && row.length === 0 && input.substr(cursor, commentsLen) === comments)
+				{
+					if (nextNewline === -1)	// Comment ends at EOF
+						return returnable();
+					cursor = nextNewline + newlineLen;
+					nextNewline = input.indexOf(newline, cursor);
+					nextDelim = input.indexOf(delim, cursor);
+					continue;
+				}
+
+				// Next delimiter comes before next newline, so we've reached end of field
+				if (nextDelim !== -1 && (nextDelim < nextNewline || nextNewline === -1))
+				{
+					row.push(input.substring(cursor, nextDelim));
+					cursor = nextDelim + delimLen;
+					nextDelim = input.indexOf(delim, cursor);
+					continue;
+				}
+
+				// End of row
+				if (nextNewline !== -1)
+				{
+					row.push(input.substring(cursor, nextNewline));
+					saveRow(nextNewline + newlineLen);
+
+					if (stepIsFunction)
+					{
+						doStep();
+						if (aborted)
+							return returnable();
+					}
+
+					if (preview && data.length >= preview)
+						return returnable(true);
+
+					continue;
+				}
+
+				break;
+			}
+
+
+			return finish();
+
+
+			function pushRow(row)
+			{
+				data.push(row);
+				lastCursor = cursor;
+			}
+
+			/**
+			 * Appends the remaining input from cursor to the end into
+			 * row, saves the row, calls step, and returns the results.
+			 */
+			function finish(value)
+			{
+				if (ignoreLastRow)
+					return returnable();
+				if (typeof value === 'undefined')
+					value = input.substr(cursor);
+				row.push(value);
+				cursor = inputLen;	// important in case parsing is paused
+				pushRow(row);
+				if (stepIsFunction)
+					doStep();
+				return returnable();
+			}
+
+			/**
+			 * Appends the current row to the results. It sets the cursor
+			 * to newCursor and finds the nextNewline. The caller should
+			 * take care to execute user's step function and check for
+			 * preview and end parsing if necessary.
+			 */
+			function saveRow(newCursor)
+			{
+				cursor = newCursor;
+				pushRow(row);
+				row = [];
+				nextNewline = input.indexOf(newline, cursor);
+			}
+
+			/** Returns an object with the results, errors, and meta. */
+			function returnable(stopped)
+			{
+				return {
+					data: data,
+					errors: errors,
+					meta: {
+						delimiter: delim,
+						linebreak: newline,
+						aborted: aborted,
+						truncated: !!stopped,
+						cursor: lastCursor + (baseIndex || 0)
+					}
+				};
+			}
+
+			/** Executes the user's step function and resets data & errors. */
+			function doStep()
+			{
+				step(returnable());
+				data = [], errors = [];
+			}
+		};
+
+		/** Sets the abort flag */
+		this.abort = function()
+		{
+			aborted = true;
+		};
+
+		/** Gets the cursor position */
+		this.getCharIndex = function()
+		{
+			return cursor;
+		};
+	}
+
+
+	// If you need to load Papa Parse asynchronously and you also need worker threads, hard-code
+	// the script path here. See: https://github.com/mholt/PapaParse/issues/87#issuecomment-57885358
+	function getScriptPath()
+	{
+		var scripts = document.getElementsByTagName('script');
+		return scripts.length ? scripts[scripts.length - 1].src : '';
+	}
+
+	function newWorker()
+	{
+		if (!Papa.WORKERS_SUPPORTED)
+			return false;
+		if (!LOADED_SYNC && Papa.SCRIPT_PATH === null)
+			throw new Error(
+				'Script path cannot be determined automatically when Papa Parse is loaded asynchronously. ' +
+				'You need to set Papa.SCRIPT_PATH manually.'
+			);
+		var workerUrl = Papa.SCRIPT_PATH || AUTO_SCRIPT_PATH;
+		// Append 'papaworker' to the search string to tell papaparse that this is our worker.
+		workerUrl += (workerUrl.indexOf('?') !== -1 ? '&' : '?') + 'papaworker';
+		var w = new global.Worker(workerUrl);
+		w.onmessage = mainThreadReceivedMessage;
+		w.id = workerIdCounter++;
+		workers[w.id] = w;
+		return w;
+	}
+
+	/** Callback when main thread receives a message */
+	function mainThreadReceivedMessage(e)
+	{
+		var msg = e.data;
+		var worker = workers[msg.workerId];
+		var aborted = false;
+
+		if (msg.error)
+			worker.userError(msg.error, msg.file);
+		else if (msg.results && msg.results.data)
+		{
+			var abort = function() {
+				aborted = true;
+				completeWorker(msg.workerId, { data: [], errors: [], meta: { aborted: true } });
+			};
+
+			var handle = {
+				abort: abort,
+				pause: notImplemented,
+				resume: notImplemented
+			};
+
+			if (isFunction(worker.userStep))
+			{
+				for (var i = 0; i < msg.results.data.length; i++)
+				{
+					worker.userStep({
+						data: [msg.results.data[i]],
+						errors: msg.results.errors,
+						meta: msg.results.meta
+					}, handle);
+					if (aborted)
+						break;
+				}
+				delete msg.results;	// free memory ASAP
+			}
+			else if (isFunction(worker.userChunk))
+			{
+				worker.userChunk(msg.results, handle, msg.file);
+				delete msg.results;
+			}
+		}
+
+		if (msg.finished && !aborted)
+			completeWorker(msg.workerId, msg.results);
+	}
+
+	function completeWorker(workerId, results) {
+		var worker = workers[workerId];
+		if (isFunction(worker.userComplete))
+			worker.userComplete(results);
+		worker.terminate();
+		delete workers[workerId];
+	}
+
+	function notImplemented() {
+		throw 'Not implemented.';
+	}
+
+	/** Callback when worker thread receives a message */
+	function workerThreadReceivedMessage(e)
+	{
+		var msg = e.data;
+
+		if (typeof Papa.WORKER_ID === 'undefined' && msg)
+			Papa.WORKER_ID = msg.workerId;
+
+		if (typeof msg.input === 'string')
+		{
+			global.postMessage({
+				workerId: Papa.WORKER_ID,
+				results: Papa.parse(msg.input, msg.config),
+				finished: true
+			});
+		}
+		else if ((global.File && msg.input instanceof File) || msg.input instanceof Object)	// thank you, Safari (see issue #106)
+		{
+			var results = Papa.parse(msg.input, msg.config);
+			if (results)
+				global.postMessage({
+					workerId: Papa.WORKER_ID,
+					results: results,
+					finished: true
+				});
+		}
+	}
+
+	/** Makes a deep copy of an array or object (mostly) */
+	function copy(obj)
+	{
+		if (typeof obj !== 'object')
+			return obj;
+		var cpy = obj instanceof Array ? [] : {};
+		for (var key in obj)
+			cpy[key] = copy(obj[key]);
+		return cpy;
+	}
+
+	function bindFunction(f, self)
+	{
+		return function() { f.apply(self, arguments); };
+	}
+
+	function isFunction(func)
+	{
+		return typeof func === 'function';
+	}
+
+	return Papa;
+}));
+});
+
+/*
+ * Latin language data module
+ */
+let languageModel = new LatinLanguageModel();
+let types = Feature.types;
+// A language of this module
+const language = languages.latin;
+// Create a language data set that will keep all language-related information
+let dataSet = new LanguageDataset(language);
+
+// region Definition of grammatical features
+/*
+ Define grammatical features of a language. Those grammatical features definitions will also be used by morphological
+ analyzer's language modules as well.
+ */
+const importerName = 'csv';
+languageModel.features[types.declension].addImporter(importerName)
+    .map('1st 2nd',
+  [ languageModel.features[types.declension][constants.ORD_1ST],
+    languageModel.features[types.declension][constants.ORD_2ND]
+  ]);
+languageModel.features[types.gender].addImporter(importerName)
+    .map('masculine feminine',
+  [ languageModel.features[types.gender][constants.GEND_MASCULINE],
+    languageModel.features[types.gender][constants.GEND_FEMININE]
+  ]);
+languageModel.features[types.tense].addImporter(importerName)
+    .map('future_perfect', languageModel.features[types.tense][constants.TENSE_FUTURE_PERFECT]);
+const footnotes = new FeatureType(types.footnote, [], language);
+
+// endregion Definition of grammatical features
+
+// For noun and adjectives
+dataSet.addSuffixes = function (partOfSpeech, data) {
+    // Some suffix values will mean a lack of suffix, they will be mapped to a null
+  let noSuffixValue = '-';
+
+    // First row are headers
+  for (let i = 1; i < data.length; i++) {
+    let suffix = data[i][0];
+        // Handle special suffix values
+    if (suffix === noSuffixValue) {
+      suffix = null;
+    }
+
+    let features = [partOfSpeech,
+      languageModel.features[types.number].getFromImporter('csv', data[i][1]),
+      languageModel.features[types.grmCase].getFromImporter('csv', data[i][2]),
+      languageModel.features[types.declension].getFromImporter('csv', data[i][3]),
+      languageModel.features[types.gender].getFromImporter('csv', data[i][4]),
+      languageModel.features[types.type].getFromImporter('csv', data[i][5])];
+    if (data[i][6]) {
+            // There can be multiple footnote indexes separated by spaces
+      let indexes = data[i][6].split(' ').map(function (index) {
+        return footnotes.get(index)
+      });
+      features.push(...indexes);
+    }
+    this.addSuffix(suffix, features);
+  }
+};
+
+// For verbs
+dataSet.addVerbSuffixes = function (partOfSpeech, data) {
+    // Some suffix values will mean a lack of suffix, they will be mapped to a null
+  let noSuffixValue = '-';
+
+    // First row are headers
+  for (let i = 1; i < data.length; i++) {
+    let suffix = data[i][0];
+        // Handle special suffix values
+    if (suffix === noSuffixValue) {
+      suffix = null;
+    }
+
+    let features = [partOfSpeech,
+      languageModel.features[types.conjugation].getFromImporter('csv', data[i][1]),
+      languageModel.features[types.voice].getFromImporter('csv', data[i][2]),
+      languageModel.features[types.mood].getFromImporter('csv', data[i][3]),
+      languageModel.features[types.tense].getFromImporter('csv', data[i][4]),
+      languageModel.features[types.number].getFromImporter('csv', data[i][5]),
+      languageModel.features[types.person].getFromImporter('csv', data[i][6])];
+
+    let grammartype = data[i][7];
+        // Type information can be empty if no ending is provided
+    if (grammartype) {
+      features.push(languageModel.features[types.type].getFromImporter('csv', grammartype));
+    }
+        // Footnotes
+    if (data[i][8]) {
+            // There can be multiple footnote indexes separated by spaces
+      let indexes = data[i][8].split(' ').map(function (index) {
+        return footnotes.get(index)
+      });
+      features.push(...indexes);
+    }
+    this.addSuffix(suffix, features);
+  }
+};
+
+dataSet.addFootnotes = function (partOfSpeech, data) {
+    // First row are headers
+  for (let i = 1; i < data.length; i++) {
+    this.addFootnote(partOfSpeech, data[i][0], data[i][1]);
+  }
+};
+
+dataSet.loadData = function () {
+    // Nouns
+  let partOfSpeech = languageModel.features[types.part][constants.POFS_NOUN];
+  let suffixes = papaparse.parse(nounSuffixesCSV, {});
+  this.addSuffixes(partOfSpeech, suffixes.data);
+  let footnotes = papaparse.parse(nounFootnotesCSV, {});
+  this.addFootnotes(partOfSpeech, footnotes.data);
+
+    // Adjectives
+  partOfSpeech = languageModel.features[types.part][constants.POFS_ADJECTIVE];
+  suffixes = papaparse.parse(adjectiveSuffixesCSV, {});
+  this.addSuffixes(partOfSpeech, suffixes.data);
+  footnotes = papaparse.parse(adjectiveFootnotesCSV, {});
+  this.addFootnotes(partOfSpeech, footnotes.data);
+
+    // Verbs
+  partOfSpeech = languageModel.features[types.part][constants.POFS_VERB];
+  suffixes = papaparse.parse(verbSuffixesCSV, {});
+  this.addVerbSuffixes(partOfSpeech, suffixes.data);
+  footnotes = papaparse.parse(verbFootnotesCSV, {});
+  this.addFootnotes(partOfSpeech, footnotes.data);
+};
+
+/**
+ * Decides whether a suffix is a match to any of inflections, and if it is, what type of match it is.
+ * @param {Inflection[]} inflections - an array of inflection objects to be matched against a suffix.
+ * @param {Suffix} suffix - a suffix to be matched with inflections.
+ * @returns {Suffix | null} if a match is found, returns a suffix object modified with some
+ * additional information about a match. if no matches found, returns null.
+ */
+dataSet.matcher = function (inflections, suffix) {
+  'use strict';
+    // All of those features must match between an inflection and an ending
+  let obligatoryMatches = [types.part];
+
+    // Any of those features must match between an inflection and an ending
+  let optionalMatches = [types.grmCase, types.declension, types.gender, types.number];
+  let bestMatchData = null; // information about the best match we would be able to find
+
+    /*
+     There can be only one full match between an inflection and a suffix (except when suffix has multiple values?)
+     But there could be multiple partial matches. So we should try to find the best match possible and return it.
+     a fullFeature match is when one of inflections has all grammatical features fully matching those of a suffix
+     */
+  for (let inflection of inflections) {
+    let matchData = new MatchData(); // Create a match profile
+
+    if (inflection.suffix === suffix.value) {
+      matchData.suffixMatch = true;
+    }
+
+        // Check obligatory matches
+    for (let feature of obligatoryMatches) {
+      let featureMatch = suffix.featureMatch(feature, inflection[feature]);
+            // matchFound = matchFound && featureMatch;
+
+      if (!featureMatch) {
+                // If an obligatory match is not found, there is no reason to check other items
+        break
+      }
+            // Inflection's value of this feature is matching the one of the suffix
+      matchData.matchedFeatures.push(feature);
+    }
+
+    if (matchData.matchedFeatures.length < obligatoryMatches.length) {
+            // Not all obligatory matches are found, this is not a match
+      break
+    }
+
+        // Check optional matches now
+    for (let feature of optionalMatches) {
+      let matchedValue = suffix.featureMatch(feature, inflection[feature]);
+      if (matchedValue) {
+        matchData.matchedFeatures.push(feature);
+      }
+    }
+
+    if (matchData.suffixMatch && (matchData.matchedFeatures.length === obligatoryMatches.length + optionalMatches.length)) {
+            // This is a full match
+      matchData.fullMatch = true;
+
+            // There can be only one full match, no need to search any further
+      suffix.match = matchData;
+      return suffix
+    }
+    bestMatchData = this.bestMatch(bestMatchData, matchData);
+  }
+  if (bestMatchData) {
+        // There is some match found
+    suffix.match = bestMatchData;
+    return suffix
+  }
+  return null
+};
+
+/**
+ * Decides whether matchA is 'better' (i.e. has more items matched) than matchB or not
+ * @param {MatchData} matchA
+ * @param {MatchData} matchB
+ * @returns {MatchData} A best of two matches
+ */
+dataSet.bestMatch = function (matchA, matchB) {
+    // If one of the arguments is not set, return the other one
+  if (!matchA && matchB) {
+    return matchB
+  }
+
+  if (!matchB && matchA) {
+    return matchA
+  }
+
+    // Suffix match has a priority
+  if (matchA.suffixMatch !== matchB.suffixMatch) {
+    if (matchA.suffixMatch > matchB.suffixMatch) {
+      return matchA
+    } else {
+      return matchB
+    }
+  }
+
+    // If same on suffix matche, compare by how many features matched
+  if (matchA.matchedFeatures.length >= matchB.matchedFeatures.length) {
+        // Arbitrarily return matchA if matches are the same
+    return matchA
+  } else {
+    return matchB
+  }
+};
+
 let classNames = {
   cell: 'infl-cell',
   widthPrefix: 'infl-cell--sp',
@@ -4515,7 +6375,7 @@ let narrowView = {
   }
 };
 
-let footnotes = {
+let footnotes$1 = {
   id: 'inlection-table-footer'
 };
 
@@ -6043,13 +7903,13 @@ class Footnotes {
      * Initialises a Footnotes object.
      * @param {Footnote[]} footnotes - An array of footnote objects.
      */
-  constructor (footnotes$$1) {
-    this.footnotes = footnotes$$1;
+  constructor (footnotes) {
+    this.footnotes = footnotes;
 
     this.nodes = document.createElement('dl');
-    this.nodes.id = footnotes.id;
+    this.nodes.id = footnotes$1.id;
     this.nodes.classList.add(classNames.footnotesContainer);
-    for (let footnote of footnotes$$1) {
+    for (let footnote of footnotes) {
       let index = document.createElement('dt');
       index.innerHTML = footnote.index;
       this.nodes.appendChild(index);
@@ -6197,57 +8057,762 @@ class View {
   }
 }
 
-// Import shared language data
-// Reexport items for Jest
-// Library
-exports.languages = languages;
-exports.Feature = Feature;
-exports.FeatureType = FeatureType;
-exports.FeatureImporter = FeatureImporter;
-exports.Inflection = Inflection;
-exports.Lemma = Lemma;
-exports.Lexeme = Lexeme;
-exports.Homonym = Homonym;
-exports.Suffix = Suffix;
-exports.LanguageDataset = LanguageDataset;
-exports.LanguageData = LanguageData;
-exports.MatchData = MatchData;
-exports.Footnote = Footnote;
-exports.ResultSet = LexicalData;
+class LatinView extends View {
+  constructor () {
+    super();
+    this.language = languages.latin;
+    this.language_features = languageModel.features;
 
-// L10n
-exports.LatinLanguageModel = LatinLanguageModel;
+        /*
+        Default grammatical features of a view. It child views need to have different feature values, redefine
+        those values in child objects.
+         */
+    this.features = {
+      numbers: new GroupFeatureType(this.language_features[Feature.types.number], 'Number'),
+      cases: new GroupFeatureType(this.language_features[Feature.types.grmCase], 'Case'),
+      declensions: new GroupFeatureType(this.language_features[Feature.types.declension], 'Declension'),
+      genders: new GroupFeatureType(this.language_features[Feature.types.gender], 'Gender'),
+      types: new GroupFeatureType(this.language_features[Feature.types.type], 'Type')
+    };
+  }
 
-// L10n
-exports.L10n = {
-  MessageBundle: MessageBundle,
-  L10n: L10n
+    /*
+    Creates and initializes an inflection table. Redefine this method in child objects in order to create
+    an inflection table differently
+     */
+  createTable () {
+    this.table = new Table([this.features.declensions, this.features.genders,
+      this.features.types, this.features.numbers, this.features.cases]);
+    let features = this.table.features;
+    features.columns = [this.language_features[Feature.types.declension], this.language_features[Feature.types.gender], this.language_features[Feature.types.type]];
+    features.rows = [this.language_features[Feature.types.number], this.language_features[Feature.types.grmCase]];
+    features.columnRowTitles = [this.language_features[Feature.types.grmCase]];
+    features.fullWidthRowTitles = [this.language_features[Feature.types.number]];
+  }
+}
+
+class NounView extends LatinView {
+  constructor () {
+    super();
+    this.id = 'nounDeclension';
+    this.name = 'noun declension';
+    this.title = 'Noun declension';
+    this.partOfSpeech = this.language_features[Feature.types.part][constants.POFS_NOUN].value;
+
+        // Models.Feature that are different from base class values
+    this.features.genders = new GroupFeatureType(this.language_features[Feature.types.gender], 'Gender',
+      [ this.language_features[Feature.types.gender][constants.GEND_MASCULINE],
+        this.language_features[Feature.types.gender][constants.GEND_FEMININE],
+        this.language_features[Feature.types.gender][constants.GEND_NEUTER]
+      ]);
+    this.createTable();
+  }
+}
+
+class AdjectiveView extends LatinView {
+  constructor () {
+    super();
+    this.id = 'adjectiveDeclension';
+    this.name = 'adjective declension';
+    this.title = 'Adjective declension';
+    this.partOfSpeech = this.language_features[Feature.types.part].adjective.value;
+
+        // Models.Feature that are different from base class values
+    this.features.declensions = new GroupFeatureType(this.language_features[Feature.types.declension], 'Declension',
+      [ this.language_features[Feature.types.declension][constants.ORD_1ST],
+        this.language_features[Feature.types.declension][constants.ORD_2ND],
+        this.language_features[Feature.types.declension][constants.ORD_3RD]
+      ]);
+    this.createTable();
+  }
+}
+
+class VerbView extends LatinView {
+  constructor () {
+    super();
+    this.partOfSpeech = this.language_features[Feature.types.part][constants.POFS_VERB].value;
+
+    this.features = {
+      tenses: new GroupFeatureType(this.language_features[Feature.types.tense], 'Tenses'),
+      numbers: new GroupFeatureType(this.language_features[Feature.types.number], 'Number'),
+      persons: new GroupFeatureType(this.language_features[Feature.types.person], 'Person'),
+      voices: new GroupFeatureType(this.language_features[Feature.types.voice], 'Voice'),
+      conjugations: new GroupFeatureType(this.language_features[Feature.types.conjugation], 'Conjugation Stem'),
+      moods: new GroupFeatureType(this.language_features[Feature.types.mood], 'Mood')
+    };
+  }
+}
+
+class VoiceConjugationMoodView extends VerbView {
+  constructor () {
+    super();
+    this.id = 'verbVoiceConjugationMood';
+    this.name = 'verb voice-conjugation-mood';
+    this.title = 'Voice-Conjugation-Mood';
+
+    this.createTable();
+  }
+
+  createTable () {
+    this.table = new Table([this.features.voices, this.features.conjugations, this.features.moods,
+      this.features.tenses, this.features.numbers, this.features.persons]);
+    let features = this.table.features;
+    features.columns = [
+      this.language_features[Feature.types.voice],
+      this.language_features[Feature.types.conjugation],
+      this.language_features[Feature.types.mood]];
+    features.rows = [
+      this.language_features[Feature.types.tense],
+      this.language_features[Feature.types.number],
+      this.language_features[Feature.types.person]];
+    features.columnRowTitles = [
+      this.language_features[Feature.types.number],
+      this.language_features[Feature.types.person]];
+    features.fullWidthRowTitles = [this.language_features[Feature.types.tense]];
+  }
+}
+
+class VoiceMoodConjugationView extends VerbView {
+  constructor () {
+    super();
+    this.id = 'verbVoiceMoodConjugation';
+    this.name = 'verb voice-mood-conjugation';
+    this.title = 'Voice-Mood-Conjugation';
+
+    this.createTable();
+  }
+
+  createTable () {
+    this.table = new Table([this.features.voices, this.features.moods, this.features.conjugations,
+      this.features.tenses, this.features.numbers, this.features.persons]);
+    let features = this.table.features;
+    features.columns = [
+      this.language_features[Feature.types.voice],
+      this.language_features[Feature.types.mood],
+      this.language_features[Feature.types.conjugation]];
+    features.rows = [
+      this.language_features[Feature.types.tense],
+      this.language_features[Feature.types.number],
+      this.language_features[Feature.types.person]];
+    features.columnRowTitles = [
+      this.language_features[Feature.types.number],
+      this.language_features[Feature.types.person]];
+    features.fullWidthRowTitles = [this.language_features[Feature.types.tense]];
+  }
+}
+
+class ConjugationVoiceMoodView extends VerbView {
+  constructor () {
+    super();
+    this.id = 'verbConjugationVoiceMood';
+    this.name = 'verb conjugation-voice-mood';
+    this.title = 'Conjugation-Voice-Mood';
+
+    this.createTable();
+  }
+
+  createTable () {
+    this.table = new Table([this.features.conjugations, this.features.voices, this.features.moods,
+      this.features.tenses, this.features.numbers, this.features.persons]);
+    let features = this.table.features;
+    features.columns = [
+      this.language_features[Feature.types.conjugation],
+      this.language_features[Feature.types.voice], this.language_features[Feature.types.mood]];
+    features.rows = [
+      this.language_features[Feature.types.tense],
+      this.language_features[Feature.types.number],
+      this.language_features[Feature.types.person]];
+    features.columnRowTitles = [
+      this.language_features[Feature.types.number],
+      this.language_features[Feature.types.person]];
+    features.fullWidthRowTitles = [this.language_features[Feature.types.tense]];
+  }
+}
+
+class ConjugationMoodVoiceView extends VerbView {
+  constructor () {
+    super();
+    this.id = 'verbConjugationMoodVoice';
+    this.name = 'verb conjugation-mood-voice';
+    this.title = 'Conjugation-Mood-Voice';
+
+    this.createTable();
+  }
+
+  createTable () {
+    this.table = new Table([this.features.conjugations, this.features.moods, this.features.voices,
+      this.features.tenses, this.features.numbers, this.features.persons]);
+    let features = this.table.features;
+    features.columns = [
+      this.language_features[Feature.types.conjugation],
+      this.language_features[Feature.types.mood],
+      this.language_features[Feature.types.voice]];
+    features.rows = [
+      this.language_features[Feature.types.tense],
+      this.language_features[Feature.types.number],
+      this.language_features[Feature.types.person]];
+    features.columnRowTitles = [
+      this.language_features[Feature.types.number],
+      this.language_features[Feature.types.person]];
+    features.fullWidthRowTitles = [this.language_features[Feature.types.tense]];
+  }
+}
+
+class MoodVoiceConjugationView extends VerbView {
+  constructor () {
+    super();
+    this.id = 'verbMoodVoiceConjugation';
+    this.name = 'verb mood-voice-conjugation';
+    this.title = 'Mood-Voice-Conjugation';
+
+    this.createTable();
+  }
+
+  createTable () {
+    this.table = new Table([this.features.moods, this.features.voices, this.features.conjugations,
+      this.features.tenses, this.features.numbers, this.features.persons]);
+    let features = this.table.features;
+    features.columns = [this.language_features[Feature.types.mood], this.language_features[Feature.types.voice], this.language_features[Feature.types.conjugation]];
+    features.rows = [this.language_features[Feature.types.tense], this.language_features[Feature.types.number], this.language_features[Feature.types.person]];
+    features.columnRowTitles = [this.language_features[Feature.types.number], this.language_features[Feature.types.person]];
+    features.fullWidthRowTitles = [this.language_features[Feature.types.tense]];
+  }
+}
+
+class MoodConjugationVoiceView extends VerbView {
+  constructor () {
+    super();
+    this.id = 'verbMoodConjugationVoice';
+    this.name = 'verb mood-conjugation-voice';
+    this.title = 'Mood-Conjugation-Voice';
+
+    this.createTable();
+  }
+
+  createTable () {
+    this.table = new Table([this.features.moods, this.features.conjugations, this.features.voices,
+      this.features.tenses, this.features.numbers, this.features.persons]);
+    let features = this.table.features;
+    features.columns = [this.language_features[Feature.types.mood], this.language_features[Feature.types.conjugation], this.language_features[Feature.types.voice]];
+    features.rows = [this.language_features[Feature.types.tense], this.language_features[Feature.types.number], this.language_features[Feature.types.person]];
+    features.columnRowTitles = [this.language_features[Feature.types.number], this.language_features[Feature.types.person]];
+    features.fullWidthRowTitles = [this.language_features[Feature.types.tense]];
+  }
+}
+
+var viewsLatin = [new NounView(), new AdjectiveView(),
+    // Verbs
+  new VoiceConjugationMoodView(), new VoiceMoodConjugationView(), new ConjugationVoiceMoodView(),
+  new ConjugationMoodVoiceView(), new MoodVoiceConjugationView(), new MoodConjugationVoiceView()];
+
+var nounSuffixesCSV$1 = "Ending,Number,Case,Declension,Gender,Type,Primary,Footnote\r\nα,dual,accusative,1st,feminine,regular,primary,\r\nά,dual,accusative,1st,feminine,regular,,\r\nᾶ,dual,accusative,1st,feminine,regular,,2\r\nαιν,dual,dative,1st,feminine,regular,primary,\r\nαῖν,dual,dative,1st,feminine,regular,,\r\nαιιν,dual,dative,1st,feminine,irregular,,\r\nαιν,dual,genitive,1st,feminine,regular,primary,\r\nαῖν,dual,genitive,1st,feminine,regular,,\r\nαιιν,dual,genitive,1st,feminine,irregular,,\r\nα,dual,nominative,1st,feminine,regular,primary,\r\nά,dual,nominative,1st,feminine,regular,,\r\nᾶ,dual,nominative,1st,feminine,regular,,2\r\nα,dual,vocative,1st,feminine,regular,primary,\r\nά,dual,vocative,1st,feminine,regular,,\r\nᾶ,dual,vocative,1st,feminine,regular,,2\r\nα,dual,accusative,1st,masculine,regular,primary,\r\nά,dual,accusative,1st,masculine,regular,,\r\nᾶ,dual,accusative,1st,masculine,regular,,2\r\nαιν,dual,dative,1st,masculine,regular,primary,\r\nαῖν,dual,dative,1st,masculine,regular,,\r\nαιιν,dual,dative,1st,masculine,irregular,,\r\nαιν,dual,genitive,1st,masculine,regular,primary,\r\nαῖν,dual,genitive,1st,masculine,regular,,\r\nαιιν,dual,genitive,1st,masculine,irregular,,\r\nα,dual,nominative,1st,masculine,regular,primary,\r\nά,dual,nominative,1st,masculine,regular,,\r\nᾶ,dual,nominative,1st,masculine,regular,,2\r\nα,dual,vocative,1st,masculine,regular,primary,\r\nά,dual,vocative,1st,masculine,regular,,\r\nᾶ,dual,vocative,1st,masculine,regular,,2\r\nας,plural,accusative,1st,feminine,regular,primary,\r\nάς,plural,accusative,1st,feminine,regular,,\r\nᾶς,plural,accusative,1st,feminine,regular,,2\r\nανς,plural,accusative,1st,feminine,irregular,,\r\nαις,plural,accusative,1st,feminine,irregular,,\r\nαις,plural,dative,1st,feminine,regular,primary,\r\nαῖς,plural,dative,1st,feminine,regular,,\r\nῃσι,plural,dative,1st,feminine,irregular,,44\r\nῃσιν,plural,dative,1st,feminine,irregular,,4 44\r\nῃς,plural,dative,1st,feminine,irregular,,44\r\nαισι,plural,dative,1st,feminine,irregular,,44\r\nαισιν,plural,dative,1st,feminine,irregular,,4 44\r\nῶν,plural,genitive,1st,feminine,regular,primary,\r\nάων,plural,genitive,1st,feminine,irregular,,\r\nέων,plural,genitive,1st,feminine,irregular,,\r\nήων,plural,genitive,1st,feminine,irregular,,\r\nᾶν,plural,genitive,1st,feminine,irregular,,\r\nαι,plural,nominative,1st,feminine,regular,primary,\r\nαί,plural,nominative,1st,feminine,regular,,\r\nαῖ,plural,nominative,1st,feminine,regular,,2\r\nαι,plural,vocative,1st,feminine,regular,primary,\r\nαί,plural,vocative,1st,feminine,regular,,\r\nαῖ,plural,vocative,1st,feminine,regular,,2\r\nας,plural,accusative,1st,masculine,regular,primary,\r\nάς,plural,accusative,1st,masculine,regular,,\r\nᾶς,plural,accusative,1st,masculine,regular,,3\r\nανς,plural,accusative,1st,masculine,irregular,,\r\nαις,plural,accusative,1st,masculine,irregular,,\r\nαις,plural,dative,1st,masculine,regular,primary,\r\nαῖς,plural,dative,1st,masculine,regular,,\r\nῃσι,plural,dative,1st,masculine,irregular,,44\r\nῃσιν,plural,dative,1st,masculine,irregular,,4 44\r\nῃς,plural,dative,1st,masculine,irregular,,44\r\nαισι,plural,dative,1st,masculine,irregular,,44\r\nαισιν,plural,dative,1st,masculine,irregular,,4 44\r\nῶν,plural,genitive,1st,masculine,regular,primary,\r\nάων,plural,genitive,1st,masculine,irregular,,\r\nέων,plural,genitive,1st,masculine,irregular,,\r\nήων,plural,genitive,1st,masculine,irregular,,\r\nᾶν,plural,genitive,1st,masculine,irregular,,\r\nαι,plural,nominative,1st,masculine,regular,primary,\r\nαί,plural,nominative,1st,masculine,regular,,\r\nαῖ,plural,nominative,1st,masculine,regular,,3\r\nαι,plural,vocative,1st,masculine,regular,primary,\r\nαί,plural,vocative,1st,masculine,regular,,\r\nαῖ,plural,vocative,1st,masculine,regular,,3\r\nαν,singular,accusative,1st,feminine,regular,primary,\r\nην,singular,accusative,1st,feminine,regular,primary,\r\nήν,singular,accusative,1st,feminine,regular,,\r\nᾶν,singular,accusative,1st,feminine,regular,,2\r\nῆν,singular,accusative,1st,feminine,regular,,2\r\nάν,singular,accusative,1st,feminine,irregular,,63\r\nᾳ,singular,dative,1st,feminine,regular,primary,\r\nῃ,singular,dative,1st,feminine,regular,primary,\r\nῇ,singular,dative,1st,feminine,regular,,2\r\nᾷ,singular,dative,1st,feminine,regular,,2\r\nηφι,singular,dative,1st,feminine,irregular,,45\r\nηφιν,singular,dative,1st,feminine,irregular,,4 45\r\nῆφι,singular,dative,1st,feminine,irregular,,45\r\nῆφιv,singular,dative,1st,feminine,irregular,,4 45\r\nας,singular,genitive,1st,feminine,regular,primary,\r\nης,singular,genitive,1st,feminine,regular,primary,\r\nῆs,singular,genitive,1st,feminine,regular,,\r\nᾶs,singular,genitive,1st,feminine,regular,,2\r\nηφι,singular,genitive,1st,feminine,irregular,,45\r\nηφιν,singular,genitive,1st,feminine,irregular,,4 45\r\nῆφι,singular,genitive,1st,feminine,irregular,,45\r\nῆφιv,singular,genitive,1st,feminine,irregular,,4 45\r\nα,singular,nominative,1st,feminine,regular,primary,\r\nη,singular,nominative,1st,feminine,regular,primary,1\r\nή,singular,nominative,1st,feminine,regular,,\r\nᾶ,singular,nominative,1st,feminine,regular,,2\r\nῆ,singular,nominative,1st,feminine,regular,,2\r\nά,singular,nominative,1st,feminine,irregular,,63\r\nα,singular,vocative,1st,feminine,regular,primary,\r\nη,singular,vocative,1st,feminine,regular,primary,\r\nή,singular,vocative,1st,feminine,regular,,\r\nᾶ,singular,vocative,1st,feminine,regular,,2\r\nῆ,singular,vocative,1st,feminine,regular,,2\r\nά,singular,vocative,1st,feminine,irregular,,63\r\nαν,singular,accusative,1st,masculine,regular,primary,\r\nην,singular,accusative,1st,masculine,regular,primary,3\r\nήν,singular,accusative,1st,masculine,regular,,\r\nᾶν,singular,accusative,1st,masculine,regular,,3\r\nῆν,singular,accusative,1st,masculine,regular,,3\r\nεα,singular,accusative,1st,masculine,irregular,,\r\nᾳ,singular,dative,1st,masculine,regular,primary,\r\nῃ,singular,dative,1st,masculine,regular,primary,\r\nῇ,singular,dative,1st,masculine,regular,,\r\nᾷ,singular,dative,1st,masculine,regular,,3\r\nῆ,singular,dative,1st,masculine,regular,,3\r\nηφι,singular,dative,1st,masculine,irregular,,45\r\nηφιν,singular,dative,1st,masculine,irregular,,4 45\r\nῆφι,singular,dative,1st,masculine,irregular,,45\r\nῆφιv,singular,dative,1st,masculine,irregular,,4 45\r\nου,singular,genitive,1st,masculine,regular,primary,\r\nοῦ,singular,genitive,1st,masculine,regular,,\r\nαο,singular,genitive,1st,masculine,irregular,,\r\nεω,singular,genitive,1st,masculine,irregular,,\r\nηφι,singular,genitive,1st,masculine,irregular,,45\r\nηφιν,singular,genitive,1st,masculine,irregular,,4 45\r\nῆφι,singular,genitive,1st,masculine,irregular,,45\r\nῆφιv,singular,genitive,1st,masculine,irregular,,4 45\r\nω,singular,genitive,1st,masculine,irregular,,\r\nα,singular,genitive,1st,masculine,irregular,,\r\nας,singular,nominative,1st,masculine,regular,primary,\r\nης,singular,nominative,1st,masculine,regular,primary,\r\nής,singular,nominative,1st,masculine,regular,,\r\nᾶs,singular,nominative,1st,masculine,regular,,3\r\nῆs,singular,nominative,1st,masculine,regular,,3\r\nα,singular,vocative,1st,masculine,regular,primary,\r\nη,singular,vocative,1st,masculine,regular,primary,\r\nά,singular,vocative,1st,masculine,regular,,\r\nᾶ,singular,vocative,1st,masculine,regular,,3\r\nῆ,singular,vocative,1st,masculine,regular,,3\r\nω,dual,accusative,2nd,masculine feminine,regular,primary,\r\nώ,dual,accusative,2nd,masculine feminine,regular,,5\r\nοιν,dual,dative,2nd,masculine feminine,regular,primary,\r\nοῖν,dual,dative,2nd,masculine feminine,regular,,5\r\nοιιν,dual,dative,2nd,masculine feminine,irregular,,\r\nῴν,dual,dative,2nd,masculine feminine,irregular,,7\r\nοιν,dual,genitive,2nd,masculine feminine,regular,primary,\r\nοῖν,dual,genitive,2nd,masculine feminine,regular,,5\r\nοιιν,dual,genitive,2nd,masculine feminine,irregular,,\r\nῴν,dual,genitive,2nd,masculine feminine,irregular,,7\r\nω,dual,nominative,2nd,masculine feminine,regular,primary,60\r\nώ,dual,nominative,2nd,masculine feminine,regular,,60\r\nω,dual,vocative,2nd,masculine feminine,regular,primary,\r\nώ,dual,vocative,2nd,masculine feminine,regular,,5\r\nω,dual,accusative,2nd,neuter,regular,primary,\r\nώ,dual,accusative,2nd,neuter,regular,,6\r\nοιν,dual,dative,2nd,neuter,regular,primary,\r\nοῖν,dual,dative,2nd,neuter,regular,,6\r\nοιιν,dual,dative,2nd,neuter,irregular,,\r\nοιν,dual,genitive,2nd,neuter,regular,primary,\r\nοῖν,dual,genitive,2nd,neuter,regular,,6\r\nοιιν,dual,genitive,2nd,neuter,irregular,,\r\nω,dual,nominative,2nd,neuter,regular,primary,\r\nώ,dual,nominative,2nd,neuter,regular,,6\r\nω,dual,vocative,2nd,neuter,regular,primary,\r\nώ,dual,vocative,2nd,neuter,regular,,6\r\nους,plural,accusative,2nd,masculine feminine,regular,primary,\r\nούς,plural,accusative,2nd,masculine feminine,regular,,41\r\nοῦς,plural,accusative,2nd,masculine feminine,regular,,5\r\nονς,plural,accusative,2nd,masculine feminine,irregular,,\r\nος,plural,accusative,2nd,masculine feminine,irregular,,\r\nως,plural,accusative,2nd,masculine feminine,irregular,,\r\nοις,plural,accusative,2nd,masculine feminine,irregular,,\r\nώς,plural,accusative,2nd,masculine feminine,irregular,,7\r\nοις,plural,dative,2nd,masculine feminine,regular,primary,\r\nοῖς,plural,dative,2nd,masculine feminine,regular,,5\r\nοισι,plural,dative,2nd,masculine feminine,irregular,,\r\nοισιν,plural,dative,2nd,masculine feminine,irregular,,4\r\nῴς,plural,dative,2nd,masculine feminine,irregular,,7\r\nόφι,plural,dative,2nd,masculine feminine,irregular,,45\r\nόφιv,plural,dative,2nd,masculine feminine,irregular,,4 45\r\nων,plural,genitive,2nd,masculine feminine,regular,primary,\r\nῶν,plural,genitive,2nd,masculine feminine,regular,,5\r\nών,plural,genitive,2nd,masculine feminine,irregular,,7\r\nόφι,plural,genitive,2nd,masculine feminine,irregular,,45\r\nόφιv,plural,genitive,2nd,masculine feminine,irregular,,4 45\r\nοι,plural,nominative,2nd,masculine feminine,regular,primary,\r\nοί,plural,nominative,2nd,masculine feminine,regular,,41\r\nοῖ,plural,nominative,2nd,masculine feminine,regular,,5\r\nῴ,plural,nominative,2nd,masculine feminine,irregular,,7\r\nοι,plural,vocative,2nd,masculine feminine,regular,primary,\r\nοί,plural,vocative,2nd,masculine feminine,regular,,41\r\nοῖ,plural,vocative,2nd,masculine feminine,regular,,5\r\nα,plural,accusative,2nd,neuter,regular,primary,\r\nᾶ,plural,accusative,2nd,neuter,regular,,6\r\nοις,plural,dative,2nd,neuter,regular,primary,\r\nοῖς,plural,dative,2nd,neuter,regular,,6\r\nοισι,plural,dative,2nd,neuter,irregular,,\r\nοισιν,plural,dative,2nd,neuter,irregular,,4\r\nόφι,plural,dative,2nd,neuter,irregular,,45\r\nόφιv,plural,dative,2nd,neuter,irregular,,4 45\r\nων,plural,genitive,2nd,neuter,regular,primary,\r\nῶν,plural,genitive,2nd,neuter,regular,,6\r\nόφι,plural,genitive,2nd,neuter,irregular,,45\r\nόφιv,plural,genitive,2nd,neuter,irregular,,4 45\r\nα,plural,nominative,2nd,neuter,regular,primary,\r\nᾶ,plural,nominative,2nd,neuter,regular,,6\r\nα,plural,vocative,2nd,neuter,regular,primary,\r\nᾶ,plural,vocative,2nd,neuter,regular,,6\r\nον,singular,accusative,2nd,masculine feminine,regular,primary,\r\nόν,singular,accusative,2nd,masculine feminine,regular,primary,41\r\nουν,singular,accusative,2nd,masculine feminine,regular,,5\r\nοῦν,singular,accusative,2nd,masculine feminine,regular,,5\r\nω,singular,accusative,2nd,masculine feminine,irregular,,7 5\r\nωv,singular,accusative,2nd,masculine feminine,irregular,,7 59\r\nώ,singular,accusative,2nd,masculine feminine,irregular,,7 42 59\r\nών,singular,accusative,2nd,masculine feminine,irregular,,7 59\r\nῳ,singular,dative,2nd,masculine feminine,regular,primary,\r\nῷ,singular,dative,2nd,masculine feminine,regular,,5\r\nῴ,singular,dative,2nd,masculine feminine,irregular,,7\r\nόφι,singular,dative,2nd,masculine feminine,irregular,,45\r\nόφιv,singular,dative,2nd,masculine feminine,irregular,,4 45\r\nου,singular,genitive,2nd,masculine feminine,regular,primary,\r\nοῦ,singular,genitive,2nd,masculine feminine,regular,,5\r\nοιο,singular,genitive,2nd,masculine feminine,irregular,,\r\nοο,singular,genitive,2nd,masculine feminine,irregular,,\r\nω,singular,genitive,2nd,masculine feminine,irregular,,\r\nώ,singular,genitive,2nd,masculine feminine,irregular,,7\r\nόφι,singular,genitive,2nd,masculine feminine,irregular,,45\r\nόφιv,singular,genitive,2nd,masculine feminine,irregular,,4 45\r\nος,singular,nominative,2nd,masculine feminine,regular,primary,\r\nους,singular,nominative,2nd,masculine feminine,regular,,5\r\noῦς,singular,nominative,2nd,masculine feminine,regular,,5\r\nός,singular,nominative,2nd,masculine feminine,regular,,\r\nώς,singular,nominative,2nd,masculine feminine,irregular,,7 42\r\nως,singular,nominative,2nd,masculine feminine,irregular,,\r\nε,singular,vocative,2nd,masculine feminine,regular,primary,\r\nέ,singular,vocative,2nd,masculine feminine,regular,,\r\nοu,singular,vocative,2nd,masculine feminine,regular,,5\r\nοῦ,singular,vocative,2nd,masculine feminine,regular,,42\r\nός,singular,vocative,2nd,masculine feminine,irregular,,57\r\nον,singular,accusative,2nd,neuter,regular,primary,\r\nοῦν,singular,accusative,2nd,neuter,regular,,6\r\nῳ,singular,dative,2nd,neuter,regular,primary,\r\nῷ,singular,dative,2nd,neuter,regular,,6\r\nόφι,singular,dative,2nd,neuter,irregular,,45\r\nόφιv,singular,dative,2nd,neuter,irregular,,4 45\r\nου,singular,genitive,2nd,neuter,regular,primary,\r\nοῦ,singular,genitive,2nd,neuter,regular,,6\r\nοο,singular,genitive,2nd,neuter,irregular,,\r\nοιο,singular,genitive,2nd,neuter,irregular,,\r\nω,singular,genitive,2nd,neuter,irregular,,\r\nόφι,singular,genitive,2nd,neuter,irregular,,45\r\nόφιv,singular,genitive,2nd,neuter,irregular,,4 45\r\nον,singular,nominative,2nd,neuter,regular,primary,\r\nοῦν,singular,nominative,2nd,neuter,regular,,6\r\nον,singular,vocative,2nd,neuter,regular,primary,\r\nοῦν,singular,vocative,2nd,neuter,regular,,6\r\nε,dual,accusative,3rd,masculine feminine,regular,primary,\r\nει,dual,accusative,3rd,masculine feminine,regular,,\r\nῆ,dual,accusative,3rd,masculine feminine,regular,,18\r\nω,dual,accusative,3rd,masculine feminine,irregular,,32\r\nῖ,dual,accusative,3rd,masculine feminine,irregular,,33\r\nεε,dual,accusative,3rd,masculine feminine,irregular,,16 55 61\r\nοιν,dual,dative,3rd,masculine feminine,regular,primary,\r\nοῖν,dual,dative,3rd,masculine feminine,regular,,\r\nοιιν,dual,dative,3rd,masculine feminine,irregular,,54\r\nσι,dual,dative,3rd,masculine feminine,irregular,,33 37\r\nεσσι,dual,dative,3rd,masculine feminine,irregular,,33\r\nεσι,dual,dative,3rd,masculine feminine,irregular,,33\r\nέοιν,dual,dative,3rd,masculine feminine,irregular,,16 61\r\nῳν,dual,dative,3rd,masculine feminine,irregular,,49\r\nοιν,dual,genitive,3rd,masculine feminine,regular,primary,\r\nοῖν,dual,genitive,3rd,masculine feminine,regular,,\r\nοιιν,dual,genitive,3rd,masculine feminine,irregular,,54\r\nέοιν,dual,genitive,3rd,masculine feminine,irregular,,16 61\r\nῳν,dual,genitive,3rd,masculine feminine,irregular,,49\r\nε,dual,nominative,3rd,masculine feminine,regular,primary,\r\nει,dual,nominative,3rd,masculine feminine,regular,,\r\nῆ,dual,nominative,3rd,masculine feminine,regular,,18\r\nω,dual,nominative,3rd,masculine feminine,irregular,,32\r\nῖ,dual,nominative,3rd,masculine feminine,irregular,,33\r\nεε,dual,nominative,3rd,masculine feminine,irregular,,16 55 61\r\nε,dual,vocative,3rd,masculine feminine,regular,primary,\r\nει,dual,vocative,3rd,masculine feminine,regular,,\r\nῆ,dual,vocative,3rd,masculine feminine,regular,,18\r\nω,dual,vocative,3rd,masculine feminine,irregular,,32\r\nῖ,dual,vocative,3rd,masculine feminine,irregular,,33\r\nεε,dual,vocative,3rd,masculine feminine,irregular,,16 55 61\r\nε,dual,accusative,3rd,neuter,regular,primary,\r\nει,dual,accusative,3rd,neuter,regular,,\r\nα,dual,accusative,3rd,neuter,regular,,\r\nεε,dual,accusative,3rd,neuter,irregular,,16 61\r\nαε,dual,accusative,3rd,neuter,irregular,,16 61\r\nοιν,dual,dative,3rd,neuter,regular,primary,\r\nῷν,dual,dative,3rd,neuter,regular,,\r\nοις,dual,dative,3rd,neuter,irregular,,33 38\r\nοισι,dual,dative,3rd,neuter,irregular,,33 38\r\nοισι(ν),dual,dative,3rd,neuter,irregular,,4 33 38\r\nοιιν,dual,dative,3rd,neuter,irregular,,\r\nέοιν,dual,dative,3rd,neuter,irregular,,16 61\r\nάοιν,dual,dative,3rd,neuter,irregular,,16 61\r\nοιν,dual,genitive,3rd,neuter,regular,primary,\r\nῷν,dual,genitive,3rd,neuter,regular,,\r\nων,dual,genitive,3rd,neuter,irregular,,33 38\r\nοιιν,dual,genitive,3rd,neuter,irregular,,\r\nέοιν,dual,genitive,3rd,neuter,irregular,,16 61\r\nάοιν,dual,genitive,3rd,neuter,irregular,,16 61\r\nε,dual,nominative,3rd,neuter,regular,primary,\r\nει,dual,nominative,3rd,neuter,regular,,\r\nα,dual,nominative,3rd,neuter,regular,,\r\nεε,dual,nominative,3rd,neuter,irregular,,16 61\r\nαε,dual,nominative,3rd,neuter,irregular,,16 61\r\nε,dual,vocative,3rd,neuter,regular,primary,\r\nει,dual,vocative,3rd,neuter,regular,,\r\nα,dual,vocative,3rd,neuter,regular,,\r\nεε,dual,vocative,3rd,neuter,irregular,,16 61\r\nαε,dual,vocative,3rd,neuter,irregular,,16 61\r\nας,plural,accusative,3rd,masculine feminine,regular,primary,\r\nεις,plural,accusative,3rd,masculine feminine,regular,,17 41\r\nες,plural,accusative,3rd,masculine feminine,regular,,\r\nς,plural,accusative,3rd,masculine feminine,regular,,\r\nῦς,plural,accusative,3rd,masculine feminine,regular,,17 18 48\r\nως,plural,accusative,3rd,masculine feminine,regular,,30\r\nῆς,plural,accusative,3rd,masculine feminine,irregular,,56\r\nέας,plural,accusative,3rd,masculine feminine,irregular,,\r\nέος,plural,accusative,3rd,masculine feminine,irregular,,\r\nῆος,plural,accusative,3rd,masculine feminine,irregular,,\r\nῆες,plural,accusative,3rd,masculine feminine,irregular,,\r\nῆας,plural,accusative,3rd,masculine feminine,irregular,,\r\nους,plural,accusative,3rd,masculine feminine,irregular,,32\r\nούς,plural,accusative,3rd,masculine feminine,irregular,,32\r\nεῖς,plural,accusative,3rd,masculine feminine,irregular,,31 41\r\nεες,plural,accusative,3rd,masculine feminine,irregular,,55 61\r\nις,plural,accusative,3rd,masculine feminine,irregular,,\r\nινς,plural,accusative,3rd,masculine feminine,irregular,,\r\nῶς,plural,accusative,3rd,masculine feminine,irregular,,48\r\nσι,plural,dative,3rd,masculine feminine,regular,primary,\r\nσιν,plural,dative,3rd,masculine feminine,regular,primary,4\r\nσί,plural,dative,3rd,masculine feminine,regular,,41\r\nσίν,plural,dative,3rd,masculine feminine,regular,,4 41\r\nεσι,plural,dative,3rd,masculine feminine,regular,,41\r\nεσιν,plural,dative,3rd,masculine feminine,regular,,4 41\r\nέσι,plural,dative,3rd,masculine feminine,regular,,\r\nέσιν,plural,dative,3rd,masculine feminine,regular,,4\r\nψι,plural,dative,3rd,masculine feminine,regular,,\r\nψιν,plural,dative,3rd,masculine feminine,regular,,4\r\nψί,plural,dative,3rd,masculine feminine,regular,,\r\nψίν,plural,dative,3rd,masculine feminine,regular,,4\r\nξι,plural,dative,3rd,masculine feminine,regular,,\r\nξιν,plural,dative,3rd,masculine feminine,regular,,4\r\nξί,plural,dative,3rd,masculine feminine,regular,,\r\nξίν,plural,dative,3rd,masculine feminine,regular,,4\r\nφι,plural,dative,3rd,masculine feminine,irregular,,45\r\nφιν,plural,dative,3rd,masculine feminine,irregular,,4 45\r\nηφι,plural,dative,3rd,masculine feminine,irregular,,45\r\nηφιv,plural,dative,3rd,masculine feminine,irregular,,4 45\r\nῆφι,plural,dative,3rd,masculine feminine,irregular,,45\r\nῆφιν,plural,dative,3rd,masculine feminine,irregular,,4 45\r\nόφι,plural,dative,3rd,masculine feminine,irregular,,45\r\nόφιν,plural,dative,3rd,masculine feminine,irregular,,4 45\r\nαις,plural,dative,3rd,masculine feminine,irregular,,33 41\r\nοῖσι,plural,dative,3rd,masculine feminine,irregular,,33\r\nοῖσιv,plural,dative,3rd,masculine feminine,irregular,,4 33\r\nεσσι,plural,dative,3rd,masculine feminine,irregular,,16 61\r\nεσσιv,plural,dative,3rd,masculine feminine,irregular,,4 16 61\r\nυσσι,plural,dative,3rd,masculine feminine,irregular,,54\r\nυσσιv,plural,dative,3rd,masculine feminine,irregular,,4 54\r\nσσί,plural,dative,3rd,masculine feminine,irregular,,54\r\nσσίv,plural,dative,3rd,masculine feminine,irregular,,4 54\r\nων,plural,genitive,3rd,masculine feminine,regular,primary,\r\nῶν,plural,genitive,3rd,masculine feminine,regular,,\r\n-,plural,genitive,3rd,masculine feminine,irregular,,41\r\nφι,plural,genitive,3rd,masculine feminine,irregular,,45\r\nφιν,plural,genitive,3rd,masculine feminine,irregular,,4 45\r\nηφι,plural,genitive,3rd,masculine feminine,irregular,,45\r\nηφιv,plural,genitive,3rd,masculine feminine,irregular,,4 45\r\nῆφι,plural,genitive,3rd,masculine feminine,irregular,,45\r\nῆφιν,plural,genitive,3rd,masculine feminine,irregular,,4 45\r\nόφι,plural,genitive,3rd,masculine feminine,irregular,,45\r\nόφιν,plural,genitive,3rd,masculine feminine,irregular,,4 45\r\nέων,plural,genitive,3rd,masculine feminine,irregular,,16 61\r\nες,plural,nominative,3rd,masculine feminine,regular,primary,\r\nως,plural,nominative,3rd,masculine feminine,regular,,30\r\nεις,plural,nominative,3rd,masculine feminine,regular,,17\r\nεῖς,plural,nominative,3rd,masculine feminine,regular,,18\r\nοί,plural,nominative,3rd,masculine feminine,irregular,,32\r\nαί,plural,nominative,3rd,masculine feminine,irregular,,33\r\nῆς,plural,nominative,3rd,masculine feminine,irregular,,18\r\nῄς,plural,nominative,3rd,masculine feminine,irregular,,31 41\r\nεες,plural,nominative,3rd,masculine feminine,irregular,,16 55 61\r\nοι,plural,nominative,3rd,masculine feminine,irregular,,33\r\nες,plural,vocative,3rd,masculine feminine,regular,primary,\r\nεις,plural,vocative,3rd,masculine feminine,regular,,17\r\nεῖς,plural,vocative,3rd,masculine feminine,regular,,18\r\nῆς,plural,vocative,3rd,masculine feminine,regular,,18\r\nως,plural,vocative,3rd,masculine feminine,regular,,30\r\nεες,plural,vocative,3rd,masculine feminine,irregular,,16 55 61\r\nα,plural,accusative,3rd,neuter,regular,primary,\r\nη,plural,accusative,3rd,neuter,regular,,\r\nς,plural,accusative,3rd,neuter,regular,,\r\nά,plural,accusative,3rd,neuter,irregular,,33\r\nαα,plural,accusative,3rd,neuter,irregular,,16 61\r\nεα,plural,accusative,3rd,neuter,irregular,,16 61\r\nσι,plural,dative,3rd,neuter,regular,primary,\r\nσιν,plural,dative,3rd,neuter,regular,primary,4\r\nσί,plural,dative,3rd,neuter,regular,,\r\nσίv,plural,dative,3rd,neuter,regular,,4\r\nασι,plural,dative,3rd,neuter,regular,,\r\nασιν,plural,dative,3rd,neuter,regular,,4\r\nεσι,plural,dative,3rd,neuter,regular,,\r\nεσιν,plural,dative,3rd,neuter,regular,,4\r\nέσι,plural,dative,3rd,neuter,regular,,\r\nέσιv,plural,dative,3rd,neuter,regular,,4\r\nεσσι,plural,dative,3rd,neuter,irregular,,54\r\nεσσιν,plural,dative,3rd,neuter,irregular,,4 54\r\nσσί,plural,dative,3rd,neuter,irregular,,54\r\nσσίv,plural,dative,3rd,neuter,irregular,,4 54\r\nασσι,plural,dative,3rd,neuter,irregular,,54\r\nασσιν,plural,dative,3rd,neuter,irregular,,4 54\r\nφι,plural,dative,3rd,neuter,irregular,,45\r\nφιν,plural,dative,3rd,neuter,irregular,,4 45\r\nηφι,plural,dative,3rd,neuter,irregular,,45\r\nηφιv,plural,dative,3rd,neuter,irregular,,4 45\r\nῆφι,plural,dative,3rd,neuter,irregular,,45\r\nῆφιν,plural,dative,3rd,neuter,irregular,,4 45\r\nόφι,plural,dative,3rd,neuter,irregular,,45\r\nόφιν,plural,dative,3rd,neuter,irregular,,4 45\r\nων,plural,genitive,3rd,neuter,regular,primary,\r\nῶν,plural,genitive,3rd,neuter,regular,primary,\r\nφι,plural,genitive,3rd,neuter,irregular,,\r\nφιν,plural,genitive,3rd,neuter,irregular,,4 45\r\nηφι,plural,genitive,3rd,neuter,irregular,,45\r\nηφιv,plural,genitive,3rd,neuter,irregular,,4 45\r\nῆφι,plural,genitive,3rd,neuter,irregular,,45\r\nῆφιν,plural,genitive,3rd,neuter,irregular,,4 45\r\nόφι,plural,genitive,3rd,neuter,irregular,,45\r\nόφιν,plural,genitive,3rd,neuter,irregular,,4 45\r\nέων,plural,genitive,3rd,neuter,irregular,,16 61\r\nάων,plural,genitive,3rd,neuter,irregular,,16 61\r\nα,plural,nominative,3rd,neuter,regular,primary,\r\nη,plural,nominative,3rd,neuter,regular,,\r\nες,plural,nominative,3rd,neuter,regular,,\r\nά,plural,nominative,3rd,neuter,irregular,,33\r\nεα,plural,nominative,3rd,neuter,irregular,,16 61\r\nαα,plural,nominative,3rd,neuter,irregular,,16 61\r\nα,plural,vocative,3rd,neuter,regular,primary,\r\nη,plural,vocative,3rd,neuter,regular,,\r\nες,plural,vocative,3rd,neuter,regular,,\r\nαα,plural,vocative,3rd,neuter,irregular,,16 61\r\nεα,plural,vocative,3rd,neuter,irregular,,16 61\r\nα,singular,accusative,3rd,masculine feminine,regular,primary,\r\nη,singular,accusative,3rd,masculine feminine,regular,,16\r\nν,singular,accusative,3rd,masculine feminine,regular,,\r\nιν,singular,accusative,3rd,masculine feminine,regular,,41\r\nῦν,singular,accusative,3rd,masculine feminine,regular,,18\r\nῶ,singular,accusative,3rd,masculine feminine,regular,,23\r\nυν,singular,accusative,3rd,masculine feminine,regular,,\r\nῦν,singular,accusative,3rd,masculine feminine,regular,,17\r\nύν,singular,accusative,3rd,masculine feminine,regular,,17\r\nέα,singular,accusative,3rd,masculine feminine,regular,,20\r\nην,singular,accusative,3rd,masculine feminine,regular,,24\r\nώ,singular,accusative,3rd,masculine feminine,regular,,19 41\r\nω,singular,accusative,3rd,masculine feminine,regular,,23\r\nεῖν,singular,accusative,3rd,masculine feminine,irregular,,31 41\r\nων,singular,accusative,3rd,masculine feminine,irregular,,33 41 49\r\nαν,singular,accusative,3rd,masculine feminine,irregular,,33 41\r\nον,singular,accusative,3rd,masculine feminine,irregular,,39\r\nῖς,singular,accusative,3rd,masculine feminine,irregular,,33\r\nεα,singular,accusative,3rd,masculine feminine,irregular,,61\r\nι,singular,dative,3rd,masculine feminine,regular,primary,\r\nί,singular,dative,3rd,masculine feminine,regular,,\r\nϊ,singular,dative,3rd,masculine feminine,regular,,17\r\nΐ,singular,dative,3rd,masculine feminine,regular,,40\r\nει,singular,dative,3rd,masculine feminine,regular,,16 17\r\nεῖ,singular,dative,3rd,masculine feminine,regular,,18\r\nαι,singular,dative,3rd,masculine feminine,regular,,\r\noῖ,singular,dative,3rd,masculine feminine,regular,,28 41\r\nῖ,singular,dative,3rd,masculine feminine,irregular,,33 46\r\nῆι,singular,dative,3rd,masculine feminine,irregular,,18\r\nᾳ,singular,dative,3rd,masculine feminine,irregular,,25\r\nῳ,singular,dative,3rd,masculine feminine,irregular,,33 34\r\nῷ,singular,dative,3rd,masculine feminine,irregular,,33\r\nιί,singular,dative,3rd,masculine feminine,irregular,,62\r\nυί,singular,dative,3rd,masculine feminine,irregular,,62\r\nέϊ,singular,dative,3rd,masculine feminine,irregular,,18 61\r\nος,singular,genitive,3rd,masculine feminine,regular,primary,\r\nός,singular,genitive,3rd,masculine feminine,regular,,\r\nους,singular,genitive,3rd,masculine feminine,regular,,16\r\nοῦς,singular,genitive,3rd,masculine feminine,regular,,19 46\r\nως,singular,genitive,3rd,masculine feminine,regular,,17 18\r\nώς,singular,genitive,3rd,masculine feminine,regular,,17 18 41\r\nῶς,singular,genitive,3rd,masculine feminine,regular,,47\r\nεως,singular,genitive,3rd,masculine feminine,regular,,17\r\nέως,singular,genitive,3rd,masculine feminine,regular,,\r\nεώς,singular,genitive,3rd,masculine feminine,regular,,\r\nέους,singular,genitive,3rd,masculine feminine,regular,,20\r\nω,singular,genitive,3rd,masculine feminine,irregular,,\r\nεος,singular,genitive,3rd,masculine feminine,irregular,,61\r\nΰς,singular,genitive,3rd,masculine feminine,irregular,,41 48\r\nῦς,singular,genitive,3rd,masculine feminine,irregular,,48\r\nνος,singular,genitive,3rd,masculine feminine,irregular,,22\r\nοῦ,singular,genitive,3rd,masculine feminine,irregular,,33\r\nηος,singular,genitive,3rd,masculine feminine,irregular,,55\r\nιός,singular,genitive,3rd,masculine feminine,irregular,,62\r\nuός,singular,genitive,3rd,masculine feminine,irregular,,62\r\nς,singular,nominative,3rd,masculine feminine,regular,primary,\r\n-,singular,nominative,3rd,masculine feminine,regular,primary,\r\nηρ,singular,nominative,3rd,masculine feminine,regular,,41\r\nις,singular,nominative,3rd,masculine feminine,regular,,\r\nϊς,singular,nominative,3rd,masculine feminine,regular,,\r\nώ,singular,nominative,3rd,masculine feminine,regular,,41\r\nψ,singular,nominative,3rd,masculine feminine,regular,,\r\nξ,singular,nominative,3rd,masculine feminine,regular,,\r\nρ,singular,nominative,3rd,masculine feminine,regular,,\r\nήρ,singular,nominative,3rd,masculine feminine,regular,,\r\nήν,singular,nominative,3rd,masculine feminine,regular,,50\r\nν,singular,nominative,3rd,masculine feminine,regular,,\r\nωρ,singular,nominative,3rd,masculine feminine,regular,,\r\nων,singular,nominative,3rd,masculine feminine,regular,,\r\nών,singular,nominative,3rd,masculine feminine,regular,,\r\nης,singular,nominative,3rd,masculine feminine,regular,,\r\nῆς,singular,nominative,3rd,masculine feminine,regular,,\r\nυς,singular,nominative,3rd,masculine feminine,regular,,\r\nῦς,singular,nominative,3rd,masculine feminine,regular,,\r\nεῦς,singular,nominative,3rd,masculine feminine,regular,,\r\nύς,singular,nominative,3rd,masculine feminine,regular,,\r\nής,singular,nominative,3rd,masculine feminine,regular,,33\r\nας,singular,nominative,3rd,masculine feminine,irregular,,\r\nῴ,singular,nominative,3rd,masculine feminine,irregular,,29 41\r\nώς,singular,nominative,3rd,masculine feminine,irregular,,27 41\r\nϋς,singular,nominative,3rd,masculine feminine,irregular,,41\r\nῄς,singular,nominative,3rd,masculine feminine,irregular,,31 41\r\nῖς,singular,nominative,3rd,masculine feminine,irregular,,\r\nεῖς,singular,nominative,3rd,masculine feminine,irregular,,31 41\r\nῶς,singular,nominative,3rd,masculine feminine,irregular,,48\r\nος,singular,nominative,3rd,masculine feminine,irregular,,33\r\n-,singular,vocative,3rd,masculine feminine,regular,primary,52\r\nς,singular,vocative,3rd,masculine feminine,regular,,30\r\nι,singular,vocative,3rd,masculine feminine,regular,,41\r\nῦ,singular,vocative,3rd,masculine feminine,regular,,15 17 18\r\nοῖ,singular,vocative,3rd,masculine feminine,regular,,19 41\r\nψ,singular,vocative,3rd,masculine feminine,regular,,\r\nξ,singular,vocative,3rd,masculine feminine,regular,,\r\nν,singular,vocative,3rd,masculine feminine,regular,,\r\nρ,singular,vocative,3rd,masculine feminine,regular,,\r\nων,singular,vocative,3rd,masculine feminine,regular,,50\r\nών,singular,vocative,3rd,masculine feminine,regular,,\r\nήν,singular,vocative,3rd,masculine feminine,regular,,\r\nερ,singular,vocative,3rd,masculine feminine,regular,,\r\nες,singular,vocative,3rd,masculine feminine,regular,,\r\nί,singular,vocative,3rd,masculine feminine,regular,,\r\nως,singular,vocative,3rd,masculine feminine,regular,,\r\nἶ,singular,vocative,3rd,masculine feminine,regular,,\r\nούς,singular,vocative,3rd,masculine feminine,regular,,51\r\nύ,singular,vocative,3rd,masculine feminine,regular,,15\r\nυ,singular,vocative,3rd,masculine feminine,regular,,51\r\nεις,singular,vocative,3rd,masculine feminine,regular,,20\r\nαν,singular,vocative,3rd,masculine feminine,regular,,\r\nώς,singular,vocative,3rd,masculine feminine,irregular,,27 41 46\r\nον,singular,vocative,3rd,masculine feminine,irregular,,\r\nυς,singular,vocative,3rd,masculine feminine,irregular,,33\r\nα,singular,accusative,3rd,neuter,regular,primary,15\r\n-,singular,accusative,3rd,neuter,regular,,33\r\nος,singular,accusative,3rd,neuter,regular,,\r\nας,singular,accusative,3rd,neuter,regular,,\r\nαρ,singular,accusative,3rd,neuter,regular,,21\r\nυ,singular,accusative,3rd,neuter,regular,,\r\nι,singular,dative,3rd,neuter,regular,primary,\r\nει,singular,dative,3rd,neuter,regular,,16\r\nαι,singular,dative,3rd,neuter,regular,,16 21\r\nϊ,singular,dative,3rd,neuter,irregular,,17\r\nᾳ,singular,dative,3rd,neuter,irregular,,25 33\r\nυϊ,singular,dative,3rd,neuter,irregular,,17\r\nαϊ,singular,dative,3rd,neuter,irregular,,21 61\r\nος,singular,genitive,3rd,neuter,regular,primary,\r\nους,singular,genitive,3rd,neuter,regular,,16\r\nως,singular,genitive,3rd,neuter,regular,,16\r\nεως,singular,genitive,3rd,neuter,regular,,17\r\nυς,singular,genitive,3rd,neuter,irregular,,26\r\nου,singular,genitive,3rd,neuter,irregular,,33\r\nαος,singular,genitive,3rd,neuter,irregular,,21 61\r\nα,singular,nominative,3rd,neuter,regular,primary,\r\n-,singular,nominative,3rd,neuter,regular,,33\r\nος,singular,nominative,3rd,neuter,regular,,\r\nαρ,singular,nominative,3rd,neuter,regular,,\r\nας,singular,nominative,3rd,neuter,regular,,16 21\r\nυ,singular,nominative,3rd,neuter,regular,,\r\nον,singular,nominative,3rd,neuter,irregular,,33\r\nα,singular,vocative,3rd,neuter,regular,primary,15\r\n-,singular,vocative,3rd,neuter,regular,,\r\nος,singular,vocative,3rd,neuter,regular,,\r\nας,singular,vocative,3rd,neuter,regular,,\r\nαρ,singular,vocative,3rd,neuter,regular,,21\r\nυ,singular,vocative,3rd,neuter,regular,,";
+
+var nounFootnotesCSV$1 = "Index,Text\r\n1,See  for Rules of variance within regular endings\r\n2,See  for Table of α- and ε- stem feminine 1st declension contracts\r\n3,See  for Table of α- and ε- stem masculine 1st declension contracts\r\n4,\"Previous, with (ν)\"\r\n5,See  for Table of o- and ε- stem masculine  2nd declension contracts\r\n6,See  for Table of o- and ε- stem neuter 2nd declension contracts\r\n7,(Attic) contracts of o-stems preceded by a long vowel\r\n15,\"This is not actually an “ending,” but the last letter of the “pure stem”. See\"\r\n16,\"See  &  for Table of Sigma (ες,ας,ος) stem contracts\"\r\n17,See  for Table of  ι and υ - stem contracts\r\n18,\"See  for Table of  ευ,αυ,and ου - stem contracts\"\r\n19,See  for stems in οι feminine 3rd declension contracts\r\n20,See  for Table of 3rd declension contracts of stems in -εσ- preceded by ε\r\n21,See  for Table of stems in τ and ατ neuter 3rd declension contracts\r\n22,\"On stem ending in ν, ν doubled in gen. Sing Aeolic (e.g. μῆνς,μῆννος...)\"\r\n23,Also in inscriptions and expressions of swearing\r\n24,(Borrowed from 1st decl) Sometimes in proper names whose nominative ends in -ης\r\n25,From -ας-stems (properly αι)\r\n26,(ε)υς instead of (ε)ος or ους (gen) for (3rd decl) words whose nominative ends in -ος\r\n27,In 3rd decl. Only in the words αἰδώς (Attic) and ἠώς (Homer and Ionic)\r\n28,Contraction of a stem in οι  and an ι-ending\r\n29,Stronger form of Ionic contractions of οι-stems (in the nominative)\r\n30,See  for Table of ω - stem contracts (masculine only)\r\n31,Nominative plural contraction of  -ειδ+ες  after dropping the δ (used for accusative too). See .a\r\n32,\"Plurals & duals occur rarely (and w/ 2nd decl endings) for 3rd decl οι-stem nouns. See .D.a,b,c\"\r\n33,See  for description and examples of Irreg. Decl involving 3rd decl endings\r\n34,(Homer)  for Attic  (ῳτ)ι\r\n35,(Homer) for Cretan ινς\r\n36,Also an irregular ending for other stem(s)\r\n37,In inscriptions\r\n38,\"Plural endings for otherwise dual noun,οσσε (eyes)\"\r\n39,\"“Poetical” (acc for ἔρως). See ,11\"\r\n40,\"Poetic for χρωτι,dat. of ὁ χρως\"\r\n41,No Masculine of this Form\r\n42,No Feminine of this Form\r\n44,See  D.9 and #215 regarding dialectic alternate forms of the Dative Plural\r\n45,\"Surviving in Homer (See ) Not truly genitive or dative, but instrumental/locative/ablative, associated with the remaining oblique cases (genitive & dative) only after being lost as cases themselves in Greek\"\r\n46,See Smyth # 266 for only surviving ος-stem in Attic (fem. singular of αἰδως)\r\n47,See  for Substantives in -εύς preceded by a vowel.\r\n48,\"See Smyth,  #275 D.1,2,3\"\r\n49,\"See , List of Principal Irregular Substantives\"\r\n50,\"See  for Table of stems in a Liquid (λ,ρ) or a Nasal (ν), and Note #259D for variants including Κρονίων...\"\r\n51,\"See  for Table of stems in a Dental (τ,δ,θ) or a Nasal (ν), and its notes including Ν.κόρυς (Voc. Κόρυ) & ὀδούς\"\r\n52,See  for general rule re 3rd Declension Masc/Fem Singular Vocative\r\n54,See  D\r\n55,See\r\n56,\"See  for other forms of endings for contracts of ευ,αυ,and ου - stems\"\r\n57,Nominative form used as Vocative. See\r\n58,\"See ,b\"\r\n59,\"See ,d\"\r\n60,This (Feminine or Masculine) Form only Masculine when derived from ε- or ο- contraction\r\n61,See Smyth Note 264 D.1 regarding Homer's use of Open Forms\r\n62,See Smyth Note 269 for alternate i-stem and u-stem endings\r\n63,See  D.2\r\n64,See  D.1";
+
+/*
+ * Latin language data module
+ */
+/* import adjectiveSuffixesCSV from './data/adjective/suffixes.csv';
+import adjectiveFootnotesCSV from './data/adjective/footnotes.csv';
+import verbSuffixesCSV from './data/verb/suffixes.csv';
+import verbFootnotesCSV from './data/verb/footnotes.csv'; */
+// A language of this module
+const language$1 = languages.greek;
+// Create a language data set that will keep all language-related information
+let dataSet$1 = new LanguageDataset(language$1);
+
+// region Definition of grammatical features
+/*
+ Define grammatical features of a language. Those grammatical features definitions will also be used by morphological
+ analyzer's language modules as well.
+ */
+const importerName$1 = 'csv';
+const parts = new FeatureType(Feature.types.part, ['noun', 'adjective', 'verb'], language$1);
+const numbers = new FeatureType(Feature.types.number, ['singular', 'dual', 'plural'], language$1);
+numbers.addImporter(importerName$1)
+    .map('singular', numbers.singular)
+    .map('dual', numbers.dual)
+    .map('plural', numbers.plural);
+const cases = new FeatureType(Feature.types.grmCase, ['nominative', 'genitive', 'dative', 'accusative', 'vocative'], language$1);
+cases.addImporter(importerName$1)
+    .map('nominative', cases.nominative)
+    .map('genitive', cases.genitive)
+    .map('dative', cases.dative)
+    .map('accusative', cases.accusative)
+    .map('vocative', cases.vocative);
+const declensions = new FeatureType(Feature.types.declension, ['first', 'second', 'third'], language$1);
+declensions.addImporter(importerName$1)
+    .map('1st', declensions.first)
+    .map('2nd', declensions.second)
+    .map('3rd', declensions.third);
+const genders = new FeatureType(Feature.types.gender, ['masculine', 'feminine', 'neuter'], language$1);
+genders.addImporter(importerName$1)
+    .map('masculine', genders.masculine)
+    .map('feminine', genders.feminine)
+    .map('neuter', genders.neuter)
+    .map('masculine feminine', [genders.masculine, genders.feminine]);
+const types$1 = new FeatureType(Feature.types.type, ['regular', 'irregular'], language$1);
+types$1.addImporter(importerName$1)
+    .map('regular', types$1.regular)
+    .map('irregular', types$1.irregular);
+/*
+const conjugations = new Models.FeatureType(Lib.types.conjugation, ['first', 'second', 'third', 'fourth']);
+conjugations.addImporter(importerName)
+    .map('1st', conjugations.first)
+    .map('2nd', conjugations.second)
+    .map('3rd', conjugations.third)
+    .map('4th', conjugations.fourth);
+const tenses = new Models.FeatureType(Lib.types.tense, ['present', 'imperfect', 'future', 'perfect', 'pluperfect', 'future perfect']);
+tenses.addImporter(importerName)
+    .map('present', tenses.present)
+    .map('imperfect', tenses.imperfect)
+    .map('future', tenses.future)
+    .map('perfect', tenses.perfect)
+    .map('pluperfect', tenses.pluperfect)
+    .map('future_perfect', tenses['future perfect']);
+const voices = new Models.FeatureType(Lib.types.voice, ['passive', 'active'],language);
+voices.addImporter(importerName)
+    .map('passive', voices.passive)
+    .map('active', voices.active);
+const moods = new Models.FeatureType(Lib.types.mood, ['indicative', 'subjunctive']);
+moods.addImporter(importerName)
+    .map('indicative', moods.indicative)
+    .map('subjunctive', moods.subjunctive);
+const persons = new Models.FeatureType(Lib.types.person, ['first', 'second', 'third']);
+persons.addImporter(importerName)
+    .map('1st', persons.first)
+    .map('2nd', persons.second)
+    .map('3rd', persons.third); */
+const footnotes$2 = new FeatureType(Feature.types.footnote, [], {});
+
+// endregion Definition of grammatical features
+
+// For noun and adjectives
+dataSet$1.addSuffixes = function (partOfSpeech, data) {
+  // Some suffix values will mean a lack of suffix, they will be mapped to a null
+  let noSuffixValue = '-';
+
+  // First row are headers
+  for (let i = 1; i < data.length; i++) {
+    let dataItem = data[i];
+    let suffixValue = dataItem[0];
+    // Handle special suffix values
+    if (suffixValue === noSuffixValue) {
+      suffixValue = null;
+    }
+
+    let primary = false;
+    let features = [partOfSpeech,
+      numbers.importer.csv.get(dataItem[1]),
+      cases.importer.csv.get(dataItem[2]),
+      declensions.importer.csv.get(dataItem[3]),
+      genders.importer.csv.get(dataItem[4]),
+      types$1.importer.csv.get(dataItem[5])];
+    if (dataItem[6] === 'primary') {
+      primary = true;
+    }
+    if (dataItem[7]) {
+      // There can be multiple footnote indexes separated by spaces
+      let indexes = dataItem[7].split(' ').map(function (index) {
+        return footnotes$2.get(index)
+      });
+      features.push(...indexes);
+    }
+    let extendedGreekData = new ExtendedGreekData();
+    extendedGreekData.primary = primary;
+    let extendedLangData = {
+      [languages.greek]: extendedGreekData
+    };
+    this.addSuffix(suffixValue, features, extendedLangData);
+  }
 };
 
-// Styles
-exports.Styles = {
-  classNames: classNames,
-  wideView: wideView,
-  narrowView: narrowView,
-  footnotes: footnotes,
-  pageHeader: pageHeader
+// For verbs
+dataSet$1.addVerbSuffixes = function (partOfSpeech, data) {
+  // Some suffix values will mean a lack of suffix, they will be mapped to a null
+  let noSuffixValue = '-';
+
+  // First row are headers
+  for (let i = 1; i < data.length; i++) {
+    let suffix = data[i][0];
+    // Handle special suffix values
+    if (suffix === noSuffixValue) {
+      suffix = null;
+    }
+
+    let features = [partOfSpeech
+      /*
+      conjugations.importer.csv.get(data[i][1]),
+      voices.importer.csv.get(data[i][2]),
+      moods.importer.csv.get(data[i][3]),
+      tenses.importer.csv.get(data[i][4]),
+      numbers.importer.csv.get(data[i][5]),
+      persons.importer.csv.get(data[i][6]) */
+    ];
+
+    let grammarType = data[i][7];
+    // Type information can be empty if no ending is provided
+    if (grammarType) {
+      features.push(types$1.importer.csv.get(grammarType));
+    }
+    // Footnotes
+    if (data[i][8]) {
+      // There can be multiple footnote indexes separated by spaces
+      let indexes = data[i][8].split(' ').map(function (index) {
+        return footnotes$2.get(index)
+      });
+      features.push(...indexes);
+    }
+    this.addSuffix(suffix, features);
+  }
 };
 
-// View
-exports.View = {
-  Cell: Cell,
-  RowTitleCell: RowTitleCell,
-  HeaderCell: HeaderCell,
-  Column: Column,
-  Row: Row,
-  GroupingFeature: GroupFeatureType,
-  GroupingFeatureList: GroupFeatureList,
-  WideView: WideView,
-  NarrowView: NarrowView,
-  NarrowViewGroup: NarrowViewGroup,
-  Table: Table,
-  Footnotes: Footnotes,
-  View: View
+dataSet$1.addFootnotes = function (partOfSpeech, data) {
+  // First row are headers
+  for (let i = 1; i < data.length; i++) {
+    this.addFootnote(partOfSpeech, data[i][0], data[i][1]);
+  }
 };
 
-})));
+dataSet$1.loadData = function () {
+  // Nouns
+  let partOfSpeech = parts.noun;
+  let suffixes = papaparse.parse(nounSuffixesCSV$1, {});
+  this.addSuffixes(partOfSpeech, suffixes.data);
+  let footnotes = papaparse.parse(nounFootnotesCSV$1, {});
+  this.addFootnotes(partOfSpeech, footnotes.data);
+
+  // Adjectives
+  /* partOfSpeech = parts.adjective;
+  suffixes = papaparse.parse(adjectiveSuffixesCSV, {});
+  this.addSuffixes(partOfSpeech, suffixes.data);
+  footnotes = papaparse.parse(adjectiveFootnotesCSV, {});
+  this.addFootnotes(partOfSpeech, footnotes.data); */
+
+  // Verbs
+  /* partOfSpeech = parts.verb;
+  suffixes = papaparse.parse(verbSuffixesCSV, {});
+  this.addVerbSuffixes(partOfSpeech, suffixes.data);
+  footnotes = papaparse.parse(verbFootnotesCSV, {});
+  this.addFootnotes(partOfSpeech, footnotes.data); */
+};
+
+/**
+ * Decides whether a suffix is a match to any of inflections, and if it is, what type of match it is.
+ * @param {Inflection[]} inflections - An array of Inflection objects to be matched against a suffix.
+ * @param {Suffix} suffix - A suffix to be matched with inflections.
+ * @returns {Suffix | null} If a match is found, returns a Suffix object modified with some
+ * additional information about a match. If no matches found, returns null.
+ */
+dataSet$1.matcher = function (inflections, suffix) {
+  'use strict';
+    // All of those features must match between an inflection and an ending
+  let obligatoryMatches = [Feature.types.part];
+
+    // Any of those features must match between an inflection and an ending
+  let optionalMatches = [Feature.types.grmCase, Feature.types.declension, Feature.types.gender, Feature.types.number];
+  let bestMatchData = null; // Information about the best match we would be able to find
+
+  /*
+   There can be only one full match between an inflection and a suffix (except when suffix has multiple values?)
+   But there could be multiple partial matches. So we should try to find the best match possible and return it.
+   A fullFeature match is when one of inflections has all grammatical features fully matching those of a suffix
+   */
+  for (let inflection of inflections) {
+    let matchData = new MatchData(); // Create a match profile
+
+    if (inflection.suffix === suffix.value) {
+      matchData.suffixMatch = true;
+    }
+
+    // Check obligatory matches
+    for (let feature of obligatoryMatches) {
+      let featureMatch = suffix.featureMatch(feature, inflection[feature]);
+      // matchFound = matchFound && featureMatch;
+
+      if (!featureMatch) {
+        // If an obligatory match is not found, there is no reason to check other items
+        break
+      }
+      // Inflection's value of this feature is matching the one of the suffix
+      matchData.matchedFeatures.push(feature);
+    }
+
+    if (matchData.matchedFeatures.length < obligatoryMatches.length) {
+      // Not all obligatory matches are found, this is not a match
+      break
+    }
+
+    // Check optional matches now
+    for (let feature of optionalMatches) {
+      let matchedValue = suffix.featureMatch(feature, inflection[feature]);
+      if (matchedValue) {
+        matchData.matchedFeatures.push(feature);
+      }
+    }
+
+    if (matchData.suffixMatch && (matchData.matchedFeatures.length === obligatoryMatches.length + optionalMatches.length)) {
+      // This is a full match
+      matchData.fullMatch = true;
+
+      // There can be only one full match, no need to search any further
+      suffix.match = matchData;
+      return suffix
+    }
+    bestMatchData = this.bestMatch(bestMatchData, matchData);
+  }
+  if (bestMatchData) {
+    // There is some match found
+    suffix.match = bestMatchData;
+    return suffix
+  }
+  return null
+};
+
+/**
+ * Decides whether matchA is 'better' (i.e. has more items matched) than matchB or not
+ * @param {MatchData} matchA
+ * @param {MatchData} matchB
+ * @returns {MatchData} A best of two matches
+ */
+dataSet$1.bestMatch = function (matchA, matchB) {
+  // If one of the arguments is not set, return the other one
+  if (!matchA && matchB) {
+    return matchB
+  }
+
+  if (!matchB && matchA) {
+    return matchA
+  }
+
+  // Suffix match has a priority
+  if (matchA.suffixMatch !== matchB.suffixMatch) {
+    if (matchA.suffixMatch > matchB.suffixMatch) {
+      return matchA
+    } else {
+      return matchB
+    }
+  }
+
+  // If same on suffix matche, compare by how many features matched
+  if (matchA.matchedFeatures.length >= matchB.matchedFeatures.length) {
+    // Arbitrarily return matchA if matches are the same
+    return matchA
+  } else {
+    return matchB
+  }
+};
+
+class GreekView extends View {
+  constructor () {
+    super();
+    this.language = languages.greek;
+
+    /*
+    Default grammatical features of a view. It child views need to have different feature values, redefine
+    those values in child objects.
+     */
+    this.features = {
+      numbers: new GroupFeatureType(numbers, 'Number'),
+      cases: new GroupFeatureType(cases, 'Case'),
+      declensions: new GroupFeatureType(declensions, 'Declension'),
+      genders: new GroupFeatureType(genders, 'Gender'),
+      types: new GroupFeatureType(types$1, 'Type')
+    };
+  }
+
+  /**
+   * Creates and initializes an inflection table. Redefine this method in child objects in order to create
+   * an inflection table differently.
+   */
+  createTable () {
+    this.table = new Table([this.features.declensions, this.features.genders,
+      this.features.types, this.features.numbers, this.features.cases]);
+    let features = this.table.features;
+    features.columns = [declensions, genders, types$1];
+    features.rows = [numbers, cases];
+    features.columnRowTitles = [cases];
+    features.fullWidthRowTitles = [numbers];
+  }
+}
+
+class NounView$1 extends GreekView {
+  constructor () {
+    super();
+    this.id = 'nounDeclension';
+    this.name = 'noun declension';
+    this.title = 'Noun declension';
+    this.partOfSpeech = parts.noun.value;
+
+    this.features.genders.getOrderedValues = function getOrderedValues (ancestorFeatures) {
+      if (ancestorFeatures) {
+        if (ancestorFeatures[0].value === declensions.second.value ||
+          ancestorFeatures[0].value === declensions.third.value) {
+          return [[genders.masculine.value, genders.feminine.value], genders.neuter.value]
+        }
+      }
+      return [genders.masculine.value, genders.feminine.value, genders.neuter.value]
+    };
+
+    this.createTable();
+  }
+}
+
+class NounViewSimplified extends NounView$1 {
+  constructor () {
+    super();
+    this.id = 'nounDeclensionSimplified';
+    this.name = 'noun declension simplified';
+    this.title = 'Noun declension (simplified)';
+    this.partOfSpeech = parts.noun.value;
+
+    this.features.genders.getOrderedValues = function getOrderedValues (ancestorFeatures) {
+      if (ancestorFeatures) {
+        if (ancestorFeatures[0].value === declensions.second.value) {
+          return [[genders.masculine.value, genders.feminine.value], genders.neuter.value]
+        }
+        if (ancestorFeatures[0].value === declensions.third.value) {
+          return [[genders.masculine.value, genders.feminine.value, genders.neuter.value]]
+        }
+      }
+      return [genders.masculine.value, genders.feminine.value, genders.neuter.value]
+    };
+
+    this.createTable();
+
+    this.table.suffixCellFilter = NounViewSimplified.suffixCellFilter;
+  }
+
+  static suffixCellFilter (suffix) {
+    return suffix.extendedLangData[languages.greek].primary
+  }
+}
+
+var viewsGreek = [new NounView$1(), new NounViewSimplified()];
+
+/**
+ * This module is responsible for displaying different views of an inflection table. Each view is located in a separate
+ * directory under /presenter/views/view-name
+ */
+class Presenter {
+  constructor (viewContainer, viewSelectorContainer, localeSelectorContainer, wordData, locale = 'en-US') {
+    this.viewContainer = viewContainer;
+    this.viewSelectorContainer = viewSelectorContainer;
+    this.localeSelectorContainer = localeSelectorContainer;
+    this.wordData = wordData;
+
+        // All views registered by the Presenter
+    this.views = [];
+    this.viewIndex = {};
+
+    for (let view of viewsLatin) {
+      this.addView(view);
+    }
+    for (let view of viewsGreek) {
+      this.addView(view);
+    }
+
+        // Views available for parts of speech that are present in a Result Set
+    this.availableViews = this.getViews(this.wordData);
+
+    this.defaultView = this.availableViews[0];
+    this.activeView = undefined;
+
+    this.locale = locale; // This is a default locale
+    this.l10n = new L10n(messages);
+
+    return this
+  }
+
+  addView (view) {
+       // let view =  new View.View(viewOptions);
+    this.views.push(view);
+    this.viewIndex[view.id] = view;
+  }
+
+  setLocale (locale) {
+    this.locale = locale;
+    this.activeView.render(this.viewContainer, this.wordData, this.l10n.messages(this.locale));
+  }
+
+  render () {
+        // Show a default view
+    if (this.defaultView) {
+      this.defaultView.render(this.viewContainer, this.wordData, this.l10n.messages(this.locale));
+      this.activeView = this.defaultView;
+
+      this.appendViewSelector(this.viewSelectorContainer);
+            // this.appendLocaleSelector(this.localeSelectorContainer);
+    }
+    return this
+  }
+
+  appendViewSelector (targetContainer) {
+    targetContainer.innerHTML = '';
+    if (this.availableViews.length > 1) {
+      let id = 'view-selector-list';
+      let viewLabel = document.createElement('label');
+      viewLabel.setAttribute('for', id);
+      viewLabel.innerHTML = 'View:&nbsp;';
+      let viewList = document.createElement('select');
+      viewList.classList.add('alpheios-ui-form-control');
+      for (const view of this.availableViews) {
+        let option = document.createElement('option');
+        option.value = view.id;
+        option.text = view.name;
+        viewList.appendChild(option);
+      }
+      viewList.addEventListener('change', this.viewSelectorEventListener.bind(this));
+      targetContainer.appendChild(viewLabel);
+      targetContainer.appendChild(viewList);
+    }
+    return this
+  }
+
+  viewSelectorEventListener (event) {
+    let viewID = event.target.value;
+    let view = this.viewIndex[viewID];
+    view.render(this.viewContainer, this.wordData, this.l10n.messages(this.locale));
+    this.activeView = view;
+  }
+
+  appendLocaleSelector (targetContainer) {
+    let id = 'locale-selector-list';
+    targetContainer.innerHTML = ''; // Erase whatever was there
+    let localeLabel = document.createElement('label');
+    localeLabel.setAttribute('for', id);
+    localeLabel.innerHTML = 'Locale:&nbsp;';
+    let localeList = document.createElement('select');
+    localeList.classList.add('alpheios-ui-form-control');
+    localeList.id = id;
+    for (let locale of this.l10n.locales) {
+      let option = document.createElement('option');
+      option.value = locale;
+      option.text = locale;
+      localeList.appendChild(option);
+    }
+    localeList.addEventListener('change', this.localeSelectorEventListener.bind(this));
+    targetContainer.appendChild(localeLabel);
+    targetContainer.appendChild(localeList);
+    return this
+  }
+
+  localeSelectorEventListener () {
+    let locale = window.event.target.value;
+    this.setLocale(locale);
+  }
+
+  getViews (wordData) {
+        // First view in a returned array will be a default one
+    let views = [];
+    for (let view of this.views) {
+      if (wordData.language === view.language && wordData[Feature.types.part].includes(view.partOfSpeech)) {
+        views.push(view);
+      }
+    }
+    return views
+  }
+}
+
+export { dataSet as LatinDataSet, dataSet$1 as GreekDataSet, languages, LanguageDataset, LanguageData, Suffix, Footnote, MatchData, ExtendedLanguageData, ExtendedGreekData, LexicalData, loadData, SelectedWord, Presenter };
+//# sourceMappingURL=inflection-tables.standalone.js.map

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -119,7 +119,7 @@ class LanguageDataset {
 
   getSuffixes (homonym) {
         // Add support for languages
-    let result = new WordData(homonym)
+    let result = new LexicalData(homonym)
     let inflections = {}
 
         // Find partial matches first, and then full among them
@@ -226,7 +226,7 @@ class LanguageData {
     /**
      * Finds matching suffixes for a homonym.
      * @param {Homonym} homonym - A homonym for which matching suffixes must be found.
-     * @return {WordData} A return value of an inflection query.
+     * @return {LexicalData} A return value of an inflection query.
      */
   getSuffixes (homonym) {
     let language = homonym.language
@@ -603,40 +603,38 @@ class SelectedWord {
 /**
  * A return value for inflection queries
  */
-class WordData {
+class LexicalData {
   constructor (homonym) {
     this.homonym = homonym
-    this.definition = undefined
     this[Models.Feature.types.part] = [] // What parts of speech are represented by this object.
   }
 
   static readObject (jsonObject) {
     let homonym = Models.Homonym.readObject(jsonObject.homonym)
 
-    let wordData = new WordData(homonym)
-    wordData.definition = jsonObject.definition
-    wordData[Models.Feature.types.part] = jsonObject[Models.Feature.types.part]
+    let lexicalData = new LexicalData(homonym)
+    lexicalData[Models.Feature.types.part] = jsonObject[Models.Feature.types.part]
 
-    for (let part of wordData[Models.Feature.types.part]) {
+    for (let part of lexicalData[Models.Feature.types.part]) {
       let partData = jsonObject[part]
-      wordData[part] = {}
+      lexicalData[part] = {}
 
       if (partData.suffixes) {
-        wordData[part].suffixes = []
+        lexicalData[part].suffixes = []
         for (let suffix of partData.suffixes) {
-          wordData[part].suffixes.push(Suffix.readObject(suffix))
+          lexicalData[part].suffixes.push(Suffix.readObject(suffix))
         }
       }
 
       if (partData.footnotes) {
-        wordData[part].footnotes = []
+        lexicalData[part].footnotes = []
         for (let footnote of partData.footnotes) {
-          wordData[part].footnotes.push(Footnote.readObject(footnote))
+          lexicalData[part].footnotes.push(Footnote.readObject(footnote))
         }
       }
     }
 
-    return wordData
+    return lexicalData
   }
 
   get word () {
@@ -669,4 +667,4 @@ let loadData = function loadData (filePath) {
   })
 }
 
-export {languages, LanguageDataset, LanguageData, Suffix, Footnote, MatchData, ExtendedLanguageData, ExtendedGreekData, WordData, loadData, SelectedWord}
+export {languages, LanguageDataset, LanguageData, Suffix, Footnote, MatchData, ExtendedLanguageData, ExtendedGreekData, LexicalData, loadData, SelectedWord}

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,12104 @@
       }
     },
     "alpheios-data-models": {
-      "version": "git://github.com/alpheios-project/data-models.git#8a9ee931ac931c7f13e243ee8898dadb4e9b856a"
+      "version": "file:../data-models",
+      "dependencies": {
+        "@types/node": {
+          "version": "6.0.90",
+          "bundled": true
+        },
+        "abab": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "acorn": {
+          "version": "4.0.13",
+          "bundled": true
+        },
+        "acorn-globals": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "4.0.13"
+          }
+        },
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "acorn": "3.3.0"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "3.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "ajv": {
+          "version": "5.3.0",
+          "bundled": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "ajv-keywords": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "kind-of": "3.2.2",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "alpheios-lexicon-client": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dependencies": {
+            "@types/node": {
+              "version": "8.0.50",
+              "bundled": true
+            },
+            "abab": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "acorn": {
+              "version": "4.0.13",
+              "bundled": true
+            },
+            "acorn-globals": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "acorn": "4.0.13"
+              }
+            },
+            "acorn-jsx": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "acorn": "3.3.0"
+              },
+              "dependencies": {
+                "acorn": {
+                  "version": "3.3.0",
+                  "bundled": true
+                }
+              }
+            },
+            "ajv": {
+              "version": "5.3.0",
+              "bundled": true,
+              "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+              }
+            },
+            "ajv-keywords": {
+              "version": "1.5.1",
+              "bundled": true
+            },
+            "align-text": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
+              }
+            },
+            "alpheios-data-models": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dependencies": {
+                "@types/node": {
+                  "version": "6.0.90",
+                  "bundled": true
+                },
+                "abab": {
+                  "version": "1.0.4",
+                  "bundled": true
+                },
+                "acorn": {
+                  "version": "4.0.13",
+                  "bundled": true
+                },
+                "acorn-globals": {
+                  "version": "3.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "acorn": "4.0.13"
+                  }
+                },
+                "acorn-jsx": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "acorn": "3.3.0"
+                  },
+                  "dependencies": {}
+                },
+                "ajv": {
+                  "version": "5.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "co": "4.6.0",
+                    "fast-deep-equal": "1.0.0",
+                    "fast-json-stable-stringify": "2.0.0",
+                    "json-schema-traverse": "0.3.1"
+                  }
+                },
+                "ajv-keywords": {
+                  "version": "1.5.1",
+                  "bundled": true
+                },
+                "align-text": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "3.2.2",
+                    "longest": "1.0.1",
+                    "repeat-string": "1.6.1"
+                  }
+                },
+                "alpheios-lexicon-client": {
+                  "version": "0.0.1",
+                  "bundled": true,
+                  "dependencies": {}
+                },
+                "amdefine": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "ansi-escapes": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true
+                },
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "bundled": true
+                },
+                "anymatch": {
+                  "version": "1.3.2",
+                  "bundled": true,
+                  "requires": {
+                    "micromatch": "2.3.11",
+                    "normalize-path": "2.1.1"
+                  }
+                },
+                "append-transform": {
+                  "version": "0.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "default-require-extensions": "1.0.0"
+                  }
+                },
+                "argparse": {
+                  "version": "1.0.9",
+                  "bundled": true,
+                  "requires": {
+                    "sprintf-js": "1.0.3"
+                  }
+                },
+                "arr-diff": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "arr-flatten": "1.1.0"
+                  }
+                },
+                "arr-flatten": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "array-equal": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "array-union": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "array-uniq": "1.0.3"
+                  }
+                },
+                "array-uniq": {
+                  "version": "1.0.3",
+                  "bundled": true
+                },
+                "array-unique": {
+                  "version": "0.2.1",
+                  "bundled": true
+                },
+                "array.prototype.find": {
+                  "version": "2.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "define-properties": "1.1.2",
+                    "es-abstract": "1.9.0"
+                  }
+                },
+                "arrify": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "asn1": {
+                  "version": "0.2.3",
+                  "bundled": true
+                },
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "astral-regex": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "asynckit": {
+                  "version": "0.4.0",
+                  "bundled": true
+                },
+                "aws-sign2": {
+                  "version": "0.7.0",
+                  "bundled": true
+                },
+                "aws4": {
+                  "version": "1.6.0",
+                  "bundled": true
+                },
+                "babel-code-frame": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "chalk": "1.1.3",
+                    "esutils": "2.0.2",
+                    "js-tokens": "3.0.2"
+                  }
+                },
+                "babel-core": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-code-frame": "6.26.0",
+                    "babel-generator": "6.26.0",
+                    "babel-helpers": "6.24.1",
+                    "babel-messages": "6.23.0",
+                    "babel-register": "6.26.0",
+                    "babel-runtime": "6.26.0",
+                    "babel-template": "6.26.0",
+                    "babel-traverse": "6.26.0",
+                    "babel-types": "6.26.0",
+                    "babylon": "6.18.0",
+                    "convert-source-map": "1.5.0",
+                    "debug": "2.6.9",
+                    "json5": "0.5.1",
+                    "lodash": "4.17.4",
+                    "minimatch": "3.0.4",
+                    "path-is-absolute": "1.0.1",
+                    "private": "0.1.8",
+                    "slash": "1.0.0",
+                    "source-map": "0.5.7"
+                  }
+                },
+                "babel-generator": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-messages": "6.23.0",
+                    "babel-runtime": "6.26.0",
+                    "babel-types": "6.26.0",
+                    "detect-indent": "4.0.0",
+                    "jsesc": "1.3.0",
+                    "lodash": "4.17.4",
+                    "source-map": "0.5.7",
+                    "trim-right": "1.0.1"
+                  }
+                },
+                "babel-helper-call-delegate": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-helper-hoist-variables": "6.24.1",
+                    "babel-runtime": "6.26.0",
+                    "babel-traverse": "6.26.0",
+                    "babel-types": "6.26.0"
+                  }
+                },
+                "babel-helper-define-map": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-helper-function-name": "6.24.1",
+                    "babel-runtime": "6.26.0",
+                    "babel-types": "6.26.0",
+                    "lodash": "4.17.4"
+                  }
+                },
+                "babel-helper-function-name": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-helper-get-function-arity": "6.24.1",
+                    "babel-runtime": "6.26.0",
+                    "babel-template": "6.26.0",
+                    "babel-traverse": "6.26.0",
+                    "babel-types": "6.26.0"
+                  }
+                },
+                "babel-helper-get-function-arity": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0",
+                    "babel-types": "6.26.0"
+                  }
+                },
+                "babel-helper-hoist-variables": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0",
+                    "babel-types": "6.26.0"
+                  }
+                },
+                "babel-helper-optimise-call-expression": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0",
+                    "babel-types": "6.26.0"
+                  }
+                },
+                "babel-helper-regex": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0",
+                    "babel-types": "6.26.0",
+                    "lodash": "4.17.4"
+                  }
+                },
+                "babel-helper-replace-supers": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-helper-optimise-call-expression": "6.24.1",
+                    "babel-messages": "6.23.0",
+                    "babel-runtime": "6.26.0",
+                    "babel-template": "6.26.0",
+                    "babel-traverse": "6.26.0",
+                    "babel-types": "6.26.0"
+                  }
+                },
+                "babel-helpers": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0",
+                    "babel-template": "6.26.0"
+                  }
+                },
+                "babel-jest": {
+                  "version": "21.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-plugin-istanbul": "4.1.5",
+                    "babel-preset-jest": "21.2.0"
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.23.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0"
+                  }
+                },
+                "babel-plugin-check-es2015-constants": {
+                  "version": "6.22.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0"
+                  }
+                },
+                "babel-plugin-istanbul": {
+                  "version": "4.1.5",
+                  "bundled": true,
+                  "requires": {
+                    "find-up": "2.1.0",
+                    "istanbul-lib-instrument": "1.9.1",
+                    "test-exclude": "4.1.1"
+                  }
+                },
+                "babel-plugin-jest-hoist": {
+                  "version": "21.2.0",
+                  "bundled": true
+                },
+                "babel-plugin-syntax-object-rest-spread": {
+                  "version": "6.13.0",
+                  "bundled": true
+                },
+                "babel-plugin-transform-es2015-arrow-functions": {
+                  "version": "6.22.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-block-scoped-functions": {
+                  "version": "6.22.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-block-scoping": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0",
+                    "babel-template": "6.26.0",
+                    "babel-traverse": "6.26.0",
+                    "babel-types": "6.26.0",
+                    "lodash": "4.17.4"
+                  }
+                },
+                "babel-plugin-transform-es2015-classes": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-helper-define-map": "6.26.0",
+                    "babel-helper-function-name": "6.24.1",
+                    "babel-helper-optimise-call-expression": "6.24.1",
+                    "babel-helper-replace-supers": "6.24.1",
+                    "babel-messages": "6.23.0",
+                    "babel-runtime": "6.26.0",
+                    "babel-template": "6.26.0",
+                    "babel-traverse": "6.26.0",
+                    "babel-types": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-computed-properties": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0",
+                    "babel-template": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-destructuring": {
+                  "version": "6.23.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-duplicate-keys": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0",
+                    "babel-types": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-for-of": {
+                  "version": "6.23.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-function-name": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-helper-function-name": "6.24.1",
+                    "babel-runtime": "6.26.0",
+                    "babel-types": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-literals": {
+                  "version": "6.22.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-modules-amd": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+                    "babel-runtime": "6.26.0",
+                    "babel-template": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-modules-commonjs": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-plugin-transform-strict-mode": "6.24.1",
+                    "babel-runtime": "6.26.0",
+                    "babel-template": "6.26.0",
+                    "babel-types": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-modules-systemjs": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-helper-hoist-variables": "6.24.1",
+                    "babel-runtime": "6.26.0",
+                    "babel-template": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-modules-umd": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+                    "babel-runtime": "6.26.0",
+                    "babel-template": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-object-super": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-helper-replace-supers": "6.24.1",
+                    "babel-runtime": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-parameters": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-helper-call-delegate": "6.24.1",
+                    "babel-helper-get-function-arity": "6.24.1",
+                    "babel-runtime": "6.26.0",
+                    "babel-template": "6.26.0",
+                    "babel-traverse": "6.26.0",
+                    "babel-types": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-shorthand-properties": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0",
+                    "babel-types": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-spread": {
+                  "version": "6.22.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-sticky-regex": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-helper-regex": "6.26.0",
+                    "babel-runtime": "6.26.0",
+                    "babel-types": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-template-literals": {
+                  "version": "6.22.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-typeof-symbol": {
+                  "version": "6.23.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0"
+                  }
+                },
+                "babel-plugin-transform-es2015-unicode-regex": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-helper-regex": "6.26.0",
+                    "babel-runtime": "6.26.0",
+                    "regexpu-core": "2.0.0"
+                  }
+                },
+                "babel-plugin-transform-regenerator": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "regenerator-transform": "0.10.1"
+                  }
+                },
+                "babel-plugin-transform-strict-mode": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0",
+                    "babel-types": "6.26.0"
+                  }
+                },
+                "babel-preset-es2015": {
+                  "version": "6.24.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-plugin-check-es2015-constants": "6.22.0",
+                    "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+                    "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+                    "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+                    "babel-plugin-transform-es2015-classes": "6.24.1",
+                    "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+                    "babel-plugin-transform-es2015-destructuring": "6.23.0",
+                    "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+                    "babel-plugin-transform-es2015-for-of": "6.23.0",
+                    "babel-plugin-transform-es2015-function-name": "6.24.1",
+                    "babel-plugin-transform-es2015-literals": "6.22.0",
+                    "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+                    "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+                    "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+                    "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+                    "babel-plugin-transform-es2015-object-super": "6.24.1",
+                    "babel-plugin-transform-es2015-parameters": "6.24.1",
+                    "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+                    "babel-plugin-transform-es2015-spread": "6.22.0",
+                    "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+                    "babel-plugin-transform-es2015-template-literals": "6.22.0",
+                    "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+                    "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+                    "babel-plugin-transform-regenerator": "6.26.0"
+                  }
+                },
+                "babel-preset-jest": {
+                  "version": "21.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-plugin-jest-hoist": "21.2.0",
+                    "babel-plugin-syntax-object-rest-spread": "6.13.0"
+                  }
+                },
+                "babel-register": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-core": "6.26.0",
+                    "babel-runtime": "6.26.0",
+                    "core-js": "2.5.1",
+                    "home-or-tmp": "2.0.0",
+                    "lodash": "4.17.4",
+                    "mkdirp": "0.5.1",
+                    "source-map-support": "0.4.18"
+                  }
+                },
+                "babel-runtime": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "core-js": "2.5.1",
+                    "regenerator-runtime": "0.11.0"
+                  }
+                },
+                "babel-template": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0",
+                    "babel-traverse": "6.26.0",
+                    "babel-types": "6.26.0",
+                    "babylon": "6.18.0",
+                    "lodash": "4.17.4"
+                  }
+                },
+                "babel-traverse": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-code-frame": "6.26.0",
+                    "babel-messages": "6.23.0",
+                    "babel-runtime": "6.26.0",
+                    "babel-types": "6.26.0",
+                    "babylon": "6.18.0",
+                    "debug": "2.6.9",
+                    "globals": "9.18.0",
+                    "invariant": "2.2.2",
+                    "lodash": "4.17.4"
+                  }
+                },
+                "babel-types": {
+                  "version": "6.26.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0",
+                    "esutils": "2.0.2",
+                    "lodash": "4.17.4",
+                    "to-fast-properties": "1.0.3"
+                  }
+                },
+                "babylon": {
+                  "version": "6.18.0",
+                  "bundled": true
+                },
+                "balanced-match": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "bcrypt-pbkdf": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "tweetnacl": "0.14.5"
+                  }
+                },
+                "boom": {
+                  "version": "4.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "hoek": "4.2.0"
+                  }
+                },
+                "brace-expansion": {
+                  "version": "1.1.8",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  }
+                },
+                "braces": {
+                  "version": "1.8.5",
+                  "bundled": true,
+                  "requires": {
+                    "expand-range": "1.8.2",
+                    "preserve": "0.2.0",
+                    "repeat-element": "1.1.2"
+                  }
+                },
+                "browser-resolve": {
+                  "version": "1.11.2",
+                  "bundled": true,
+                  "requires": {
+                    "resolve": "1.1.7"
+                  }
+                },
+                "bser": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "node-int64": "0.4.0"
+                  }
+                },
+                "builtin-modules": {
+                  "version": "1.1.1",
+                  "bundled": true
+                },
+                "caller-path": {
+                  "version": "0.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "callsites": "0.2.0"
+                  },
+                  "dependencies": {
+                    "callsites": {
+                      "version": "0.2.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "callsites": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "camelcase": {
+                  "version": "1.2.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "caseless": {
+                  "version": "0.12.0",
+                  "bundled": true
+                },
+                "center-align": {
+                  "version": "0.1.3",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "align-text": "0.1.4",
+                    "lazy-cache": "1.0.4"
+                  }
+                },
+                "chalk": {
+                  "version": "1.1.3",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-styles": "2.2.1",
+                    "escape-string-regexp": "1.0.5",
+                    "has-ansi": "2.0.0",
+                    "strip-ansi": "3.0.1",
+                    "supports-color": "2.0.0"
+                  }
+                },
+                "ci-info": {
+                  "version": "1.1.1",
+                  "bundled": true
+                },
+                "circular-json": {
+                  "version": "0.3.3",
+                  "bundled": true
+                },
+                "cli-cursor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "restore-cursor": "1.0.1"
+                  }
+                },
+                "cli-width": {
+                  "version": "2.2.0",
+                  "bundled": true
+                },
+                "cliui": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "center-align": "0.1.3",
+                    "right-align": "0.1.3",
+                    "wordwrap": "0.0.2"
+                  },
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "bundled": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "co": {
+                  "version": "4.6.0",
+                  "bundled": true
+                },
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "color-convert": {
+                  "version": "1.9.0",
+                  "bundled": true,
+                  "requires": {
+                    "color-name": "1.1.3"
+                  }
+                },
+                "color-name": {
+                  "version": "1.1.3",
+                  "bundled": true
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  }
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "bundled": true
+                },
+                "concat-stream": {
+                  "version": "1.6.0",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.3",
+                    "typedarray": "0.0.6"
+                  }
+                },
+                "contains-path": {
+                  "version": "0.1.0",
+                  "bundled": true
+                },
+                "content-type-parser": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "convert-source-map": {
+                  "version": "1.5.0",
+                  "bundled": true
+                },
+                "core-js": {
+                  "version": "2.5.1",
+                  "bundled": true
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "cross-spawn": {
+                  "version": "5.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "lru-cache": "4.1.1",
+                    "shebang-command": "1.2.0",
+                    "which": "1.3.0"
+                  }
+                },
+                "cryptiles": {
+                  "version": "3.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "boom": "5.2.0"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "5.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "4.2.0"
+                      }
+                    }
+                  }
+                },
+                "cssom": {
+                  "version": "0.3.2",
+                  "bundled": true
+                },
+                "cssstyle": {
+                  "version": "0.2.37",
+                  "bundled": true,
+                  "requires": {
+                    "cssom": "0.3.2"
+                  }
+                },
+                "d": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "es5-ext": "0.10.35"
+                  }
+                },
+                "dashdash": {
+                  "version": "1.14.1",
+                  "bundled": true,
+                  "requires": {
+                    "assert-plus": "1.0.0"
+                  }
+                },
+                "debug": {
+                  "version": "2.6.9",
+                  "bundled": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "debug-log": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "decamelize": {
+                  "version": "1.2.0",
+                  "bundled": true
+                },
+                "deep-is": {
+                  "version": "0.1.3",
+                  "bundled": true
+                },
+                "default-require-extensions": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "strip-bom": "2.0.0"
+                  }
+                },
+                "define-properties": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "foreach": "2.0.5",
+                    "object-keys": "1.0.11"
+                  }
+                },
+                "deglob": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "find-root": "1.1.0",
+                    "glob": "7.1.2",
+                    "ignore": "3.3.7",
+                    "pkg-config": "1.1.1",
+                    "run-parallel": "1.1.6",
+                    "uniq": "1.0.1"
+                  }
+                },
+                "del": {
+                  "version": "2.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "globby": "5.0.0",
+                    "is-path-cwd": "1.0.0",
+                    "is-path-in-cwd": "1.0.0",
+                    "object-assign": "4.1.1",
+                    "pify": "2.3.0",
+                    "pinkie-promise": "2.0.1",
+                    "rimraf": "2.6.2"
+                  }
+                },
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "detect-indent": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "repeating": "2.0.1"
+                  }
+                },
+                "diff": {
+                  "version": "3.4.0",
+                  "bundled": true
+                },
+                "doctrine": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "esutils": "2.0.2",
+                    "isarray": "1.0.0"
+                  }
+                },
+                "domexception": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "jsbn": "0.1.1"
+                  }
+                },
+                "errno": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "requires": {
+                    "prr": "0.0.0"
+                  }
+                },
+                "error-ex": {
+                  "version": "1.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-arrayish": "0.2.1"
+                  }
+                },
+                "es-abstract": {
+                  "version": "1.9.0",
+                  "bundled": true,
+                  "requires": {
+                    "es-to-primitive": "1.1.1",
+                    "function-bind": "1.1.1",
+                    "has": "1.0.1",
+                    "is-callable": "1.1.3",
+                    "is-regex": "1.0.4"
+                  }
+                },
+                "es-to-primitive": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-callable": "1.1.3",
+                    "is-date-object": "1.0.1",
+                    "is-symbol": "1.0.1"
+                  }
+                },
+                "es5-ext": {
+                  "version": "0.10.35",
+                  "bundled": true,
+                  "requires": {
+                    "es6-iterator": "2.0.3",
+                    "es6-symbol": "3.1.1"
+                  }
+                },
+                "es6-iterator": {
+                  "version": "2.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "d": "1.0.0",
+                    "es5-ext": "0.10.35",
+                    "es6-symbol": "3.1.1"
+                  }
+                },
+                "es6-map": {
+                  "version": "0.1.5",
+                  "bundled": true,
+                  "requires": {
+                    "d": "1.0.0",
+                    "es5-ext": "0.10.35",
+                    "es6-iterator": "2.0.3",
+                    "es6-set": "0.1.5",
+                    "es6-symbol": "3.1.1",
+                    "event-emitter": "0.3.5"
+                  }
+                },
+                "es6-set": {
+                  "version": "0.1.5",
+                  "bundled": true,
+                  "requires": {
+                    "d": "1.0.0",
+                    "es5-ext": "0.10.35",
+                    "es6-iterator": "2.0.3",
+                    "es6-symbol": "3.1.1",
+                    "event-emitter": "0.3.5"
+                  }
+                },
+                "es6-symbol": {
+                  "version": "3.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "d": "1.0.0",
+                    "es5-ext": "0.10.35"
+                  }
+                },
+                "es6-weak-map": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "d": "1.0.0",
+                    "es5-ext": "0.10.35",
+                    "es6-iterator": "2.0.3",
+                    "es6-symbol": "3.1.1"
+                  }
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "bundled": true
+                },
+                "escodegen": {
+                  "version": "1.9.0",
+                  "bundled": true,
+                  "requires": {
+                    "esprima": "3.1.3",
+                    "estraverse": "4.2.0",
+                    "esutils": "2.0.2",
+                    "optionator": "0.8.2",
+                    "source-map": "0.5.7"
+                  },
+                  "dependencies": {
+                    "esprima": {
+                      "version": "3.1.3",
+                      "bundled": true
+                    }
+                  }
+                },
+                "escope": {
+                  "version": "3.6.0",
+                  "bundled": true,
+                  "requires": {
+                    "es6-map": "0.1.5",
+                    "es6-weak-map": "2.0.2",
+                    "esrecurse": "4.2.0",
+                    "estraverse": "4.2.0"
+                  }
+                },
+                "eslint": {
+                  "version": "3.19.0",
+                  "bundled": true,
+                  "requires": {
+                    "babel-code-frame": "6.26.0",
+                    "chalk": "1.1.3",
+                    "concat-stream": "1.6.0",
+                    "debug": "2.6.9",
+                    "doctrine": "2.0.0",
+                    "escope": "3.6.0",
+                    "espree": "3.5.1",
+                    "esquery": "1.0.0",
+                    "estraverse": "4.2.0",
+                    "esutils": "2.0.2",
+                    "file-entry-cache": "2.0.0",
+                    "glob": "7.1.2",
+                    "globals": "9.18.0",
+                    "ignore": "3.3.7",
+                    "imurmurhash": "0.1.4",
+                    "inquirer": "0.12.0",
+                    "is-my-json-valid": "2.16.1",
+                    "is-resolvable": "1.0.0",
+                    "js-yaml": "3.10.0",
+                    "json-stable-stringify": "1.0.1",
+                    "levn": "0.3.0",
+                    "lodash": "4.17.4",
+                    "mkdirp": "0.5.1",
+                    "natural-compare": "1.4.0",
+                    "optionator": "0.8.2",
+                    "path-is-inside": "1.0.2",
+                    "pluralize": "1.2.1",
+                    "progress": "1.1.8",
+                    "require-uncached": "1.0.3",
+                    "shelljs": "0.7.8",
+                    "strip-bom": "3.0.0",
+                    "strip-json-comments": "2.0.1",
+                    "table": "3.8.3",
+                    "text-table": "0.2.0",
+                    "user-home": "2.0.0"
+                  },
+                  "dependencies": {
+                    "strip-bom": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "eslint-config-standard": {
+                  "version": "10.2.1",
+                  "bundled": true
+                },
+                "eslint-config-standard-jsx": {
+                  "version": "4.0.2",
+                  "bundled": true
+                },
+                "eslint-import-resolver-node": {
+                  "version": "0.2.3",
+                  "bundled": true,
+                  "requires": {
+                    "debug": "2.6.9",
+                    "object-assign": "4.1.1",
+                    "resolve": "1.1.7"
+                  }
+                },
+                "eslint-module-utils": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "debug": "2.6.9",
+                    "pkg-dir": "1.0.0"
+                  }
+                },
+                "eslint-plugin-import": {
+                  "version": "2.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "builtin-modules": "1.1.1",
+                    "contains-path": "0.1.0",
+                    "debug": "2.6.9",
+                    "doctrine": "1.5.0",
+                    "eslint-import-resolver-node": "0.2.3",
+                    "eslint-module-utils": "2.1.1",
+                    "has": "1.0.1",
+                    "lodash.cond": "4.5.2",
+                    "minimatch": "3.0.4",
+                    "pkg-up": "1.0.0"
+                  },
+                  "dependencies": {
+                    "doctrine": {
+                      "version": "1.5.0",
+                      "bundled": true,
+                      "requires": {
+                        "esutils": "2.0.2",
+                        "isarray": "1.0.0"
+                      }
+                    }
+                  }
+                },
+                "eslint-plugin-node": {
+                  "version": "4.2.3",
+                  "bundled": true,
+                  "requires": {
+                    "ignore": "3.3.7",
+                    "minimatch": "3.0.4",
+                    "object-assign": "4.1.1",
+                    "resolve": "1.1.7",
+                    "semver": "5.3.0"
+                  },
+                  "dependencies": {
+                    "semver": {
+                      "version": "5.3.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "eslint-plugin-promise": {
+                  "version": "3.5.0",
+                  "bundled": true
+                },
+                "eslint-plugin-react": {
+                  "version": "6.10.3",
+                  "bundled": true,
+                  "requires": {
+                    "array.prototype.find": "2.0.4",
+                    "doctrine": "1.5.0",
+                    "has": "1.0.1",
+                    "jsx-ast-utils": "1.4.1",
+                    "object.assign": "4.0.4"
+                  },
+                  "dependencies": {
+                    "doctrine": {
+                      "version": "1.5.0",
+                      "bundled": true,
+                      "requires": {
+                        "esutils": "2.0.2",
+                        "isarray": "1.0.0"
+                      }
+                    }
+                  }
+                },
+                "eslint-plugin-standard": {
+                  "version": "3.0.1",
+                  "bundled": true
+                },
+                "espree": {
+                  "version": "3.5.1",
+                  "bundled": true,
+                  "requires": {
+                    "acorn": "5.2.1",
+                    "acorn-jsx": "3.0.1"
+                  },
+                  "dependencies": {
+                    "acorn": {
+                      "version": "5.2.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "4.0.0",
+                  "bundled": true
+                },
+                "esquery": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "estraverse": "4.2.0"
+                  }
+                },
+                "esrecurse": {
+                  "version": "4.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "estraverse": "4.2.0",
+                    "object-assign": "4.1.1"
+                  }
+                },
+                "estraverse": {
+                  "version": "4.2.0",
+                  "bundled": true
+                },
+                "estree-walker": {
+                  "version": "0.5.0",
+                  "bundled": true
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "bundled": true
+                },
+                "event-emitter": {
+                  "version": "0.3.5",
+                  "bundled": true,
+                  "requires": {
+                    "d": "1.0.0",
+                    "es5-ext": "0.10.35"
+                  }
+                },
+                "exec-sh": {
+                  "version": "0.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "merge": "1.2.0"
+                  }
+                },
+                "execa": {
+                  "version": "0.7.0",
+                  "bundled": true,
+                  "requires": {
+                    "cross-spawn": "5.1.0",
+                    "get-stream": "3.0.0",
+                    "is-stream": "1.1.0",
+                    "npm-run-path": "2.0.2",
+                    "p-finally": "1.0.0",
+                    "signal-exit": "3.0.2",
+                    "strip-eof": "1.0.0"
+                  }
+                },
+                "exit-hook": {
+                  "version": "1.1.1",
+                  "bundled": true
+                },
+                "expand-brackets": {
+                  "version": "0.1.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-posix-bracket": "0.1.1"
+                  }
+                },
+                "expand-range": {
+                  "version": "1.8.2",
+                  "bundled": true,
+                  "requires": {
+                    "fill-range": "2.2.3"
+                  }
+                },
+                "expect": {
+                  "version": "21.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-styles": "3.2.0",
+                    "jest-diff": "21.2.1",
+                    "jest-get-type": "21.2.0",
+                    "jest-matcher-utils": "21.2.1",
+                    "jest-message-util": "21.2.1",
+                    "jest-regex-util": "21.2.0"
+                  },
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "color-convert": "1.9.0"
+                      }
+                    }
+                  }
+                },
+                "extend": {
+                  "version": "3.0.1",
+                  "bundled": true
+                },
+                "extglob": {
+                  "version": "0.3.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-extglob": "1.0.0"
+                  }
+                },
+                "extsprintf": {
+                  "version": "1.3.0",
+                  "bundled": true
+                },
+                "fast-deep-equal": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "fast-json-stable-stringify": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "fast-levenshtein": {
+                  "version": "2.0.6",
+                  "bundled": true
+                },
+                "fb-watchman": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "bser": "2.0.0"
+                  }
+                },
+                "figures": {
+                  "version": "1.7.0",
+                  "bundled": true,
+                  "requires": {
+                    "escape-string-regexp": "1.0.5",
+                    "object-assign": "4.1.1"
+                  }
+                },
+                "file-entry-cache": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "flat-cache": "1.3.0",
+                    "object-assign": "4.1.1"
+                  }
+                },
+                "filename-regex": {
+                  "version": "2.0.1",
+                  "bundled": true
+                },
+                "fileset": {
+                  "version": "2.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "glob": "7.1.2",
+                    "minimatch": "3.0.4"
+                  }
+                },
+                "fill-range": {
+                  "version": "2.2.3",
+                  "bundled": true,
+                  "requires": {
+                    "is-number": "2.1.0",
+                    "isobject": "2.1.0",
+                    "randomatic": "1.1.7",
+                    "repeat-element": "1.1.2",
+                    "repeat-string": "1.6.1"
+                  }
+                },
+                "find-root": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "find-up": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "locate-path": "2.0.0"
+                  }
+                },
+                "flat-cache": {
+                  "version": "1.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "circular-json": "0.3.3",
+                    "del": "2.2.2",
+                    "graceful-fs": "4.1.11",
+                    "write": "0.2.1"
+                  }
+                },
+                "for-in": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "for-own": {
+                  "version": "0.1.5",
+                  "bundled": true,
+                  "requires": {
+                    "for-in": "1.0.2"
+                  }
+                },
+                "foreach": {
+                  "version": "2.0.5",
+                  "bundled": true
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "bundled": true
+                },
+                "form-data": {
+                  "version": "2.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "asynckit": "0.4.0",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.17"
+                  }
+                },
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "function-bind": {
+                  "version": "1.1.1",
+                  "bundled": true
+                },
+                "generate-function": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "generate-object-property": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-property": "1.0.2"
+                  }
+                },
+                "get-caller-file": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "get-stdin": {
+                  "version": "5.0.1",
+                  "bundled": true
+                },
+                "get-stream": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "getpass": {
+                  "version": "0.1.7",
+                  "bundled": true,
+                  "requires": {
+                    "assert-plus": "1.0.0"
+                  }
+                },
+                "glob": {
+                  "version": "7.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "fs.realpath": "1.0.0",
+                    "inflight": "1.0.6",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4",
+                    "once": "1.4.0",
+                    "path-is-absolute": "1.0.1"
+                  }
+                },
+                "glob-base": {
+                  "version": "0.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "glob-parent": "2.0.0",
+                    "is-glob": "2.0.1"
+                  }
+                },
+                "glob-parent": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-glob": "2.0.1"
+                  }
+                },
+                "globals": {
+                  "version": "9.18.0",
+                  "bundled": true
+                },
+                "globby": {
+                  "version": "5.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "array-union": "1.0.2",
+                    "arrify": "1.0.1",
+                    "glob": "7.1.2",
+                    "object-assign": "4.1.1",
+                    "pify": "2.3.0",
+                    "pinkie-promise": "2.0.1"
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.11",
+                  "bundled": true
+                },
+                "growly": {
+                  "version": "1.3.0",
+                  "bundled": true
+                },
+                "handlebars": {
+                  "version": "4.0.11",
+                  "bundled": true,
+                  "requires": {
+                    "async": "1.5.2",
+                    "optimist": "0.6.1",
+                    "source-map": "0.4.4",
+                    "uglify-js": "2.8.29"
+                  },
+                  "dependencies": {
+                    "async": {
+                      "version": "1.5.2",
+                      "bundled": true
+                    },
+                    "source-map": {
+                      "version": "0.4.4",
+                      "bundled": true,
+                      "requires": {
+                        "amdefine": "1.0.1"
+                      }
+                    }
+                  }
+                },
+                "har-schema": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "har-validator": {
+                  "version": "5.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "ajv": "5.3.0",
+                    "har-schema": "2.0.0"
+                  }
+                },
+                "has": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "function-bind": "1.1.1"
+                  }
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  }
+                },
+                "has-flag": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "hawk": {
+                  "version": "6.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "boom": "4.3.1",
+                    "cryptiles": "3.1.2",
+                    "hoek": "4.2.0",
+                    "sntp": "2.1.0"
+                  }
+                },
+                "hoek": {
+                  "version": "4.2.0",
+                  "bundled": true
+                },
+                "home-or-tmp": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "os-homedir": "1.0.2",
+                    "os-tmpdir": "1.0.2"
+                  }
+                },
+                "hosted-git-info": {
+                  "version": "2.5.0",
+                  "bundled": true
+                },
+                "html-encoding-sniffer": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "whatwg-encoding": "1.0.3"
+                  }
+                },
+                "http-signature": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "assert-plus": "1.0.0",
+                    "jsprim": "1.4.1",
+                    "sshpk": "1.13.1"
+                  }
+                },
+                "iconv-lite": {
+                  "version": "0.4.19",
+                  "bundled": true
+                },
+                "ignore": {
+                  "version": "3.3.7",
+                  "bundled": true
+                },
+                "imurmurhash": {
+                  "version": "0.1.4",
+                  "bundled": true
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "bundled": true,
+                  "requires": {
+                    "once": "1.4.0",
+                    "wrappy": "1.0.2"
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "bundled": true
+                },
+                "inquirer": {
+                  "version": "0.12.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-escapes": "1.4.0",
+                    "ansi-regex": "2.1.1",
+                    "chalk": "1.1.3",
+                    "cli-cursor": "1.0.2",
+                    "cli-width": "2.2.0",
+                    "figures": "1.7.0",
+                    "lodash": "4.17.4",
+                    "readline2": "1.0.1",
+                    "run-async": "0.1.0",
+                    "rx-lite": "3.1.2",
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "through": "2.3.8"
+                  },
+                  "dependencies": {
+                    "ansi-escapes": {
+                      "version": "1.4.0",
+                      "bundled": true
+                    },
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      }
+                    }
+                  }
+                },
+                "interpret": {
+                  "version": "1.0.4",
+                  "bundled": true
+                },
+                "intl-messageformat": {
+                  "version": "2.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "intl-messageformat-parser": "1.4.0"
+                  }
+                },
+                "intl-messageformat-parser": {
+                  "version": "1.4.0",
+                  "bundled": true
+                },
+                "invariant": {
+                  "version": "2.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "loose-envify": "1.3.1"
+                  }
+                },
+                "invert-kv": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "is-arrayish": {
+                  "version": "0.2.1",
+                  "bundled": true
+                },
+                "is-buffer": {
+                  "version": "1.1.6",
+                  "bundled": true
+                },
+                "is-builtin-module": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "builtin-modules": "1.1.1"
+                  }
+                },
+                "is-callable": {
+                  "version": "1.1.3",
+                  "bundled": true
+                },
+                "is-ci": {
+                  "version": "1.0.10",
+                  "bundled": true,
+                  "requires": {
+                    "ci-info": "1.1.1"
+                  }
+                },
+                "is-date-object": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "is-dotfile": {
+                  "version": "1.0.3",
+                  "bundled": true
+                },
+                "is-equal-shallow": {
+                  "version": "0.1.3",
+                  "bundled": true,
+                  "requires": {
+                    "is-primitive": "2.0.0"
+                  }
+                },
+                "is-extendable": {
+                  "version": "0.1.1",
+                  "bundled": true
+                },
+                "is-extglob": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "is-finite": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  }
+                },
+                "is-glob": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extglob": "1.0.0"
+                  }
+                },
+                "is-module": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "is-my-json-valid": {
+                  "version": "2.16.1",
+                  "bundled": true,
+                  "requires": {
+                    "generate-function": "2.0.0",
+                    "generate-object-property": "1.2.0",
+                    "jsonpointer": "4.0.1",
+                    "xtend": "4.0.1"
+                  }
+                },
+                "is-number": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  }
+                },
+                "is-path-cwd": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "is-path-in-cwd": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-path-inside": "1.0.0"
+                  }
+                },
+                "is-path-inside": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "path-is-inside": "1.0.2"
+                  }
+                },
+                "is-posix-bracket": {
+                  "version": "0.1.1",
+                  "bundled": true
+                },
+                "is-primitive": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "is-property": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "is-regex": {
+                  "version": "1.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "has": "1.0.1"
+                  }
+                },
+                "is-resolvable": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "tryit": "1.0.3"
+                  }
+                },
+                "is-stream": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "is-symbol": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "is-utf8": {
+                  "version": "0.2.1",
+                  "bundled": true
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "isexe": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "isobject": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "bundled": true
+                },
+                "istanbul-api": {
+                  "version": "1.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "async": "2.5.0",
+                    "fileset": "2.0.3",
+                    "istanbul-lib-coverage": "1.1.1",
+                    "istanbul-lib-hook": "1.1.0",
+                    "istanbul-lib-instrument": "1.9.1",
+                    "istanbul-lib-report": "1.1.2",
+                    "istanbul-lib-source-maps": "1.2.2",
+                    "istanbul-reports": "1.1.3",
+                    "js-yaml": "3.10.0",
+                    "mkdirp": "0.5.1",
+                    "once": "1.4.0"
+                  },
+                  "dependencies": {
+                    "async": {
+                      "version": "2.5.0",
+                      "bundled": true,
+                      "requires": {
+                        "lodash": "4.17.4"
+                      }
+                    }
+                  }
+                },
+                "istanbul-lib-coverage": {
+                  "version": "1.1.1",
+                  "bundled": true
+                },
+                "istanbul-lib-hook": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "append-transform": "0.4.0"
+                  }
+                },
+                "istanbul-lib-instrument": {
+                  "version": "1.9.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-generator": "6.26.0",
+                    "babel-template": "6.26.0",
+                    "babel-traverse": "6.26.0",
+                    "babel-types": "6.26.0",
+                    "babylon": "6.18.0",
+                    "istanbul-lib-coverage": "1.1.1",
+                    "semver": "5.4.1"
+                  }
+                },
+                "istanbul-lib-report": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "istanbul-lib-coverage": "1.1.1",
+                    "mkdirp": "0.5.1",
+                    "path-parse": "1.0.5",
+                    "supports-color": "3.2.3"
+                  },
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "supports-color": {
+                      "version": "3.2.3",
+                      "bundled": true,
+                      "requires": {
+                        "has-flag": "1.0.0"
+                      }
+                    }
+                  }
+                },
+                "istanbul-lib-source-maps": {
+                  "version": "1.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "debug": "3.1.0",
+                    "istanbul-lib-coverage": "1.1.1",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.6.2",
+                    "source-map": "0.5.7"
+                  },
+                  "dependencies": {
+                    "debug": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      }
+                    }
+                  }
+                },
+                "istanbul-reports": {
+                  "version": "1.1.3",
+                  "bundled": true,
+                  "requires": {
+                    "handlebars": "4.0.11"
+                  }
+                },
+                "jest": {
+                  "version": "21.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "jest-cli": "21.2.1"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    },
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "color-convert": "1.9.0"
+                      }
+                    },
+                    "chalk": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "4.5.0"
+                      }
+                    },
+                    "jest-cli": {
+                      "version": "21.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-escapes": "3.0.0",
+                        "chalk": "2.3.0",
+                        "glob": "7.1.2",
+                        "graceful-fs": "4.1.11",
+                        "is-ci": "1.0.10",
+                        "istanbul-api": "1.2.1",
+                        "istanbul-lib-coverage": "1.1.1",
+                        "istanbul-lib-instrument": "1.9.1",
+                        "istanbul-lib-source-maps": "1.2.2",
+                        "jest-changed-files": "21.2.0",
+                        "jest-config": "21.2.1",
+                        "jest-environment-jsdom": "21.2.1",
+                        "jest-haste-map": "21.2.0",
+                        "jest-message-util": "21.2.1",
+                        "jest-regex-util": "21.2.0",
+                        "jest-resolve-dependencies": "21.2.0",
+                        "jest-runner": "21.2.1",
+                        "jest-runtime": "21.2.1",
+                        "jest-snapshot": "21.2.1",
+                        "jest-util": "21.2.1",
+                        "micromatch": "2.3.11",
+                        "node-notifier": "5.1.2",
+                        "pify": "3.0.0",
+                        "slash": "1.0.0",
+                        "string-length": "2.0.0",
+                        "strip-ansi": "4.0.0",
+                        "which": "1.3.0",
+                        "worker-farm": "1.5.1",
+                        "yargs": "9.0.1"
+                      }
+                    },
+                    "pify": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    },
+                    "strip-ansi": {
+                      "version": "4.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-regex": "3.0.0"
+                      }
+                    },
+                    "supports-color": {
+                      "version": "4.5.0",
+                      "bundled": true,
+                      "requires": {
+                        "has-flag": "2.0.0"
+                      }
+                    }
+                  }
+                },
+                "jest-changed-files": {
+                  "version": "21.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "throat": "4.1.0"
+                  }
+                },
+                "jest-config": {
+                  "version": "21.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "chalk": "2.3.0",
+                    "glob": "7.1.2",
+                    "jest-environment-jsdom": "21.2.1",
+                    "jest-environment-node": "21.2.1",
+                    "jest-get-type": "21.2.0",
+                    "jest-jasmine2": "21.2.1",
+                    "jest-regex-util": "21.2.0",
+                    "jest-resolve": "21.2.0",
+                    "jest-util": "21.2.1",
+                    "jest-validate": "21.2.1",
+                    "pretty-format": "21.2.1"
+                  },
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "color-convert": "1.9.0"
+                      }
+                    },
+                    "chalk": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "4.5.0"
+                      }
+                    },
+                    "supports-color": {
+                      "version": "4.5.0",
+                      "bundled": true,
+                      "requires": {
+                        "has-flag": "2.0.0"
+                      }
+                    }
+                  }
+                },
+                "jest-diff": {
+                  "version": "21.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "chalk": "2.3.0",
+                    "diff": "3.4.0",
+                    "jest-get-type": "21.2.0",
+                    "pretty-format": "21.2.1"
+                  },
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "color-convert": "1.9.0"
+                      }
+                    },
+                    "chalk": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "4.5.0"
+                      }
+                    },
+                    "supports-color": {
+                      "version": "4.5.0",
+                      "bundled": true,
+                      "requires": {
+                        "has-flag": "2.0.0"
+                      }
+                    }
+                  }
+                },
+                "jest-docblock": {
+                  "version": "21.2.0",
+                  "bundled": true
+                },
+                "jest-environment-jsdom": {
+                  "version": "21.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "jest-mock": "21.2.0",
+                    "jest-util": "21.2.1",
+                    "jsdom": "9.12.0"
+                  }
+                },
+                "jest-environment-jsdom-11.0.0": {
+                  "version": "20.0.9",
+                  "bundled": true,
+                  "requires": {
+                    "jest-mock": "20.0.3",
+                    "jest-util": "20.0.3",
+                    "jsdom": "11.3.0"
+                  },
+                  "dependencies": {
+                    "acorn": {
+                      "version": "5.2.1",
+                      "bundled": true
+                    },
+                    "acorn-globals": {
+                      "version": "4.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "acorn": "5.2.1"
+                      }
+                    },
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "color-convert": "1.9.0"
+                      }
+                    },
+                    "jest-matcher-utils": {
+                      "version": "20.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "chalk": "1.1.3",
+                        "pretty-format": "20.0.3"
+                      }
+                    },
+                    "jest-message-util": {
+                      "version": "20.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "chalk": "1.1.3",
+                        "micromatch": "2.3.11",
+                        "slash": "1.0.0"
+                      }
+                    },
+                    "jest-mock": {
+                      "version": "20.0.3",
+                      "bundled": true
+                    },
+                    "jest-util": {
+                      "version": "20.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "chalk": "1.1.3",
+                        "graceful-fs": "4.1.11",
+                        "jest-message-util": "20.0.3",
+                        "jest-mock": "20.0.3",
+                        "jest-validate": "20.0.3",
+                        "leven": "2.1.0",
+                        "mkdirp": "0.5.1"
+                      }
+                    },
+                    "jest-validate": {
+                      "version": "20.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "chalk": "1.1.3",
+                        "jest-matcher-utils": "20.0.3",
+                        "leven": "2.1.0",
+                        "pretty-format": "20.0.3"
+                      }
+                    },
+                    "jsdom": {
+                      "version": "11.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "abab": "1.0.4",
+                        "acorn": "5.2.1",
+                        "acorn-globals": "4.1.0",
+                        "array-equal": "1.0.0",
+                        "content-type-parser": "1.0.2",
+                        "cssom": "0.3.2",
+                        "cssstyle": "0.2.37",
+                        "domexception": "1.0.0",
+                        "escodegen": "1.9.0",
+                        "html-encoding-sniffer": "1.0.2",
+                        "nwmatcher": "1.4.3",
+                        "parse5": "3.0.2",
+                        "pn": "1.0.0",
+                        "request": "2.83.0",
+                        "request-promise-native": "1.0.5",
+                        "sax": "1.2.4",
+                        "symbol-tree": "3.2.2",
+                        "tough-cookie": "2.3.3",
+                        "webidl-conversions": "4.0.2",
+                        "whatwg-encoding": "1.0.3",
+                        "whatwg-url": "6.3.0",
+                        "xml-name-validator": "2.0.1"
+                      }
+                    },
+                    "parse5": {
+                      "version": "3.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "@types/node": "6.0.90"
+                      }
+                    },
+                    "pretty-format": {
+                      "version": "20.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-regex": "2.1.1",
+                        "ansi-styles": "3.2.0"
+                      }
+                    },
+                    "punycode": {
+                      "version": "2.1.0",
+                      "bundled": true
+                    },
+                    "tr46": {
+                      "version": "1.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "punycode": "2.1.0"
+                      }
+                    },
+                    "whatwg-url": {
+                      "version": "6.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "lodash.sortby": "4.7.0",
+                        "tr46": "1.0.1",
+                        "webidl-conversions": "4.0.2"
+                      }
+                    }
+                  }
+                },
+                "jest-environment-node": {
+                  "version": "21.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "jest-mock": "21.2.0",
+                    "jest-util": "21.2.1"
+                  }
+                },
+                "jest-get-type": {
+                  "version": "21.2.0",
+                  "bundled": true
+                },
+                "jest-haste-map": {
+                  "version": "21.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "fb-watchman": "2.0.0",
+                    "graceful-fs": "4.1.11",
+                    "jest-docblock": "21.2.0",
+                    "micromatch": "2.3.11",
+                    "sane": "2.2.0",
+                    "worker-farm": "1.5.1"
+                  }
+                },
+                "jest-jasmine2": {
+                  "version": "21.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "chalk": "2.3.0",
+                    "expect": "21.2.1",
+                    "graceful-fs": "4.1.11",
+                    "jest-diff": "21.2.1",
+                    "jest-matcher-utils": "21.2.1",
+                    "jest-message-util": "21.2.1",
+                    "jest-snapshot": "21.2.1",
+                    "p-cancelable": "0.3.0"
+                  },
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "color-convert": "1.9.0"
+                      }
+                    },
+                    "chalk": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "4.5.0"
+                      }
+                    },
+                    "supports-color": {
+                      "version": "4.5.0",
+                      "bundled": true,
+                      "requires": {
+                        "has-flag": "2.0.0"
+                      }
+                    }
+                  }
+                },
+                "jest-matcher-utils": {
+                  "version": "21.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "chalk": "2.3.0",
+                    "jest-get-type": "21.2.0",
+                    "pretty-format": "21.2.1"
+                  },
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "color-convert": "1.9.0"
+                      }
+                    },
+                    "chalk": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "4.5.0"
+                      }
+                    },
+                    "supports-color": {
+                      "version": "4.5.0",
+                      "bundled": true,
+                      "requires": {
+                        "has-flag": "2.0.0"
+                      }
+                    }
+                  }
+                },
+                "jest-message-util": {
+                  "version": "21.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "chalk": "2.3.0",
+                    "micromatch": "2.3.11",
+                    "slash": "1.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "color-convert": "1.9.0"
+                      }
+                    },
+                    "chalk": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "4.5.0"
+                      }
+                    },
+                    "supports-color": {
+                      "version": "4.5.0",
+                      "bundled": true,
+                      "requires": {
+                        "has-flag": "2.0.0"
+                      }
+                    }
+                  }
+                },
+                "jest-mock": {
+                  "version": "21.2.0",
+                  "bundled": true
+                },
+                "jest-regex-util": {
+                  "version": "21.2.0",
+                  "bundled": true
+                },
+                "jest-resolve": {
+                  "version": "21.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "browser-resolve": "1.11.2",
+                    "chalk": "2.3.0",
+                    "is-builtin-module": "1.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "color-convert": "1.9.0"
+                      }
+                    },
+                    "chalk": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "4.5.0"
+                      }
+                    },
+                    "supports-color": {
+                      "version": "4.5.0",
+                      "bundled": true,
+                      "requires": {
+                        "has-flag": "2.0.0"
+                      }
+                    }
+                  }
+                },
+                "jest-resolve-dependencies": {
+                  "version": "21.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "jest-regex-util": "21.2.0"
+                  }
+                },
+                "jest-runner": {
+                  "version": "21.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "jest-config": "21.2.1",
+                    "jest-docblock": "21.2.0",
+                    "jest-haste-map": "21.2.0",
+                    "jest-jasmine2": "21.2.1",
+                    "jest-message-util": "21.2.1",
+                    "jest-runtime": "21.2.1",
+                    "jest-util": "21.2.1",
+                    "pify": "3.0.0",
+                    "throat": "4.1.0",
+                    "worker-farm": "1.5.1"
+                  },
+                  "dependencies": {
+                    "pify": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "jest-runtime": {
+                  "version": "21.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-core": "6.26.0",
+                    "babel-jest": "21.2.0",
+                    "babel-plugin-istanbul": "4.1.5",
+                    "chalk": "2.3.0",
+                    "convert-source-map": "1.5.0",
+                    "graceful-fs": "4.1.11",
+                    "jest-config": "21.2.1",
+                    "jest-haste-map": "21.2.0",
+                    "jest-regex-util": "21.2.0",
+                    "jest-resolve": "21.2.0",
+                    "jest-util": "21.2.1",
+                    "json-stable-stringify": "1.0.1",
+                    "micromatch": "2.3.11",
+                    "slash": "1.0.0",
+                    "strip-bom": "3.0.0",
+                    "write-file-atomic": "2.3.0",
+                    "yargs": "9.0.1"
+                  },
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "color-convert": "1.9.0"
+                      }
+                    },
+                    "chalk": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "4.5.0"
+                      }
+                    },
+                    "strip-bom": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    },
+                    "supports-color": {
+                      "version": "4.5.0",
+                      "bundled": true,
+                      "requires": {
+                        "has-flag": "2.0.0"
+                      }
+                    }
+                  }
+                },
+                "jest-snapshot": {
+                  "version": "21.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "chalk": "2.3.0",
+                    "jest-diff": "21.2.1",
+                    "jest-matcher-utils": "21.2.1",
+                    "mkdirp": "0.5.1",
+                    "natural-compare": "1.4.0",
+                    "pretty-format": "21.2.1"
+                  },
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "color-convert": "1.9.0"
+                      }
+                    },
+                    "chalk": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "4.5.0"
+                      }
+                    },
+                    "supports-color": {
+                      "version": "4.5.0",
+                      "bundled": true,
+                      "requires": {
+                        "has-flag": "2.0.0"
+                      }
+                    }
+                  }
+                },
+                "jest-util": {
+                  "version": "21.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "callsites": "2.0.0",
+                    "chalk": "2.3.0",
+                    "graceful-fs": "4.1.11",
+                    "jest-message-util": "21.2.1",
+                    "jest-mock": "21.2.0",
+                    "jest-validate": "21.2.1",
+                    "mkdirp": "0.5.1"
+                  },
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "color-convert": "1.9.0"
+                      }
+                    },
+                    "chalk": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "4.5.0"
+                      }
+                    },
+                    "supports-color": {
+                      "version": "4.5.0",
+                      "bundled": true,
+                      "requires": {
+                        "has-flag": "2.0.0"
+                      }
+                    }
+                  }
+                },
+                "jest-validate": {
+                  "version": "21.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "chalk": "2.3.0",
+                    "jest-get-type": "21.2.0",
+                    "leven": "2.1.0",
+                    "pretty-format": "21.2.1"
+                  },
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "color-convert": "1.9.0"
+                      }
+                    },
+                    "chalk": {
+                      "version": "2.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "4.5.0"
+                      }
+                    },
+                    "supports-color": {
+                      "version": "4.5.0",
+                      "bundled": true,
+                      "requires": {
+                        "has-flag": "2.0.0"
+                      }
+                    }
+                  }
+                },
+                "js-tokens": {
+                  "version": "3.0.2",
+                  "bundled": true
+                },
+                "js-yaml": {
+                  "version": "3.10.0",
+                  "bundled": true,
+                  "requires": {
+                    "argparse": "1.0.9",
+                    "esprima": "4.0.0"
+                  }
+                },
+                "jsbn": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "jsdom": {
+                  "version": "9.12.0",
+                  "bundled": true,
+                  "requires": {
+                    "abab": "1.0.4",
+                    "acorn": "4.0.13",
+                    "acorn-globals": "3.1.0",
+                    "array-equal": "1.0.0",
+                    "content-type-parser": "1.0.2",
+                    "cssom": "0.3.2",
+                    "cssstyle": "0.2.37",
+                    "escodegen": "1.9.0",
+                    "html-encoding-sniffer": "1.0.2",
+                    "nwmatcher": "1.4.3",
+                    "parse5": "1.5.1",
+                    "request": "2.83.0",
+                    "sax": "1.2.4",
+                    "symbol-tree": "3.2.2",
+                    "tough-cookie": "2.3.3",
+                    "webidl-conversions": "4.0.2",
+                    "whatwg-encoding": "1.0.3",
+                    "whatwg-url": "4.8.0",
+                    "xml-name-validator": "2.0.1"
+                  }
+                },
+                "jsesc": {
+                  "version": "1.3.0",
+                  "bundled": true
+                },
+                "json-schema": {
+                  "version": "0.2.3",
+                  "bundled": true
+                },
+                "json-schema-traverse": {
+                  "version": "0.3.1",
+                  "bundled": true
+                },
+                "json-stable-stringify": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "jsonify": "0.0.0"
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "bundled": true
+                },
+                "json5": {
+                  "version": "0.5.1",
+                  "bundled": true
+                },
+                "jsonify": {
+                  "version": "0.0.0",
+                  "bundled": true
+                },
+                "jsonpointer": {
+                  "version": "4.0.1",
+                  "bundled": true
+                },
+                "jsprim": {
+                  "version": "1.4.1",
+                  "bundled": true,
+                  "requires": {
+                    "assert-plus": "1.0.0",
+                    "extsprintf": "1.3.0",
+                    "json-schema": "0.2.3",
+                    "verror": "1.10.0"
+                  }
+                },
+                "jsx-ast-utils": {
+                  "version": "1.4.1",
+                  "bundled": true
+                },
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                },
+                "lazy-cache": {
+                  "version": "1.0.4",
+                  "bundled": true,
+                  "optional": true
+                },
+                "lcid": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "invert-kv": "1.0.0"
+                  }
+                },
+                "leven": {
+                  "version": "2.1.0",
+                  "bundled": true
+                },
+                "levn": {
+                  "version": "0.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "prelude-ls": "1.1.2",
+                    "type-check": "0.3.2"
+                  }
+                },
+                "load-json-file": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "parse-json": "2.2.0",
+                    "pify": "2.3.0",
+                    "pinkie-promise": "2.0.1",
+                    "strip-bom": "2.0.0"
+                  }
+                },
+                "locate-path": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "p-locate": "2.0.0",
+                    "path-exists": "3.0.0"
+                  }
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "bundled": true
+                },
+                "lodash.cond": {
+                  "version": "4.5.2",
+                  "bundled": true
+                },
+                "lodash.sortby": {
+                  "version": "4.7.0",
+                  "bundled": true
+                },
+                "longest": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "loose-envify": {
+                  "version": "1.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "js-tokens": "3.0.2"
+                  }
+                },
+                "lru-cache": {
+                  "version": "4.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "pseudomap": "1.0.2",
+                    "yallist": "2.1.2"
+                  }
+                },
+                "magic-string": {
+                  "version": "0.22.4",
+                  "bundled": true,
+                  "requires": {
+                    "vlq": "0.2.3"
+                  }
+                },
+                "makeerror": {
+                  "version": "1.0.11",
+                  "bundled": true,
+                  "requires": {
+                    "tmpl": "1.0.4"
+                  }
+                },
+                "mem": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "mimic-fn": "1.1.0"
+                  }
+                },
+                "merge": {
+                  "version": "1.2.0",
+                  "bundled": true
+                },
+                "micromatch": {
+                  "version": "2.3.11",
+                  "bundled": true,
+                  "requires": {
+                    "arr-diff": "2.0.0",
+                    "array-unique": "0.2.1",
+                    "braces": "1.8.5",
+                    "expand-brackets": "0.1.5",
+                    "extglob": "0.3.2",
+                    "filename-regex": "2.0.1",
+                    "is-extglob": "1.0.0",
+                    "is-glob": "2.0.1",
+                    "kind-of": "3.2.2",
+                    "normalize-path": "2.1.1",
+                    "object.omit": "2.0.1",
+                    "parse-glob": "3.0.4",
+                    "regex-cache": "0.4.4"
+                  }
+                },
+                "mime-db": {
+                  "version": "1.30.0",
+                  "bundled": true
+                },
+                "mime-types": {
+                  "version": "2.1.17",
+                  "bundled": true,
+                  "requires": {
+                    "mime-db": "1.30.0"
+                  }
+                },
+                "mimic-fn": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.8"
+                  }
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "bundled": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "bundled": true
+                    }
+                  }
+                },
+                "ms": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "mute-stream": {
+                  "version": "0.0.5",
+                  "bundled": true
+                },
+                "natural-compare": {
+                  "version": "1.4.0",
+                  "bundled": true
+                },
+                "node-int64": {
+                  "version": "0.4.0",
+                  "bundled": true
+                },
+                "node-notifier": {
+                  "version": "5.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "growly": "1.3.0",
+                    "semver": "5.4.1",
+                    "shellwords": "0.1.1",
+                    "which": "1.3.0"
+                  }
+                },
+                "normalize-package-data": {
+                  "version": "2.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "hosted-git-info": "2.5.0",
+                    "is-builtin-module": "1.0.0",
+                    "semver": "5.4.1",
+                    "validate-npm-package-license": "3.0.1"
+                  }
+                },
+                "normalize-path": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "remove-trailing-separator": "1.1.0"
+                  }
+                },
+                "npm-run-path": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "path-key": "2.0.1"
+                  }
+                },
+                "number-is-nan": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "nwmatcher": {
+                  "version": "1.4.3",
+                  "bundled": true
+                },
+                "oauth-sign": {
+                  "version": "0.8.2",
+                  "bundled": true
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true
+                },
+                "object-keys": {
+                  "version": "1.0.11",
+                  "bundled": true
+                },
+                "object.assign": {
+                  "version": "4.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "define-properties": "1.1.2",
+                    "function-bind": "1.1.1",
+                    "object-keys": "1.0.11"
+                  }
+                },
+                "object.omit": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "for-own": "0.1.5",
+                    "is-extendable": "0.1.1"
+                  }
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  }
+                },
+                "onetime": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "bundled": true,
+                  "requires": {
+                    "minimist": "0.0.10",
+                    "wordwrap": "0.0.3"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "bundled": true
+                    }
+                  }
+                },
+                "optionator": {
+                  "version": "0.8.2",
+                  "bundled": true,
+                  "requires": {
+                    "deep-is": "0.1.3",
+                    "fast-levenshtein": "2.0.6",
+                    "levn": "0.3.0",
+                    "prelude-ls": "1.1.2",
+                    "type-check": "0.3.2",
+                    "wordwrap": "1.0.0"
+                  },
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "os-locale": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "execa": "0.7.0",
+                    "lcid": "1.0.0",
+                    "mem": "1.1.0"
+                  }
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "p-cancelable": {
+                  "version": "0.3.0",
+                  "bundled": true
+                },
+                "p-finally": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "p-limit": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "p-locate": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "p-limit": "1.1.0"
+                  }
+                },
+                "parse-glob": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "glob-base": "0.3.0",
+                    "is-dotfile": "1.0.3",
+                    "is-extglob": "1.0.0",
+                    "is-glob": "2.0.1"
+                  }
+                },
+                "parse-json": {
+                  "version": "2.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "error-ex": "1.3.1"
+                  }
+                },
+                "parse5": {
+                  "version": "1.5.1",
+                  "bundled": true
+                },
+                "path-exists": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "path-is-inside": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "path-key": {
+                  "version": "2.0.1",
+                  "bundled": true
+                },
+                "path-parse": {
+                  "version": "1.0.5",
+                  "bundled": true
+                },
+                "path-type": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "pify": "2.3.0",
+                    "pinkie-promise": "2.0.1"
+                  }
+                },
+                "performance-now": {
+                  "version": "2.1.0",
+                  "bundled": true
+                },
+                "pify": {
+                  "version": "2.3.0",
+                  "bundled": true
+                },
+                "pinkie": {
+                  "version": "2.0.4",
+                  "bundled": true
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "pinkie": "2.0.4"
+                  }
+                },
+                "pkg-conf": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "find-up": "2.1.0",
+                    "load-json-file": "2.0.0"
+                  },
+                  "dependencies": {
+                    "load-json-file": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "strip-bom": "3.0.0"
+                      }
+                    },
+                    "strip-bom": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "pkg-config": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "debug-log": "1.0.1",
+                    "find-root": "1.1.0",
+                    "xtend": "4.0.1"
+                  }
+                },
+                "pkg-dir": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "find-up": "1.1.2"
+                  },
+                  "dependencies": {
+                    "find-up": {
+                      "version": "1.1.2",
+                      "bundled": true,
+                      "requires": {
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.1"
+                      }
+                    },
+                    "path-exists": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "pinkie-promise": "2.0.1"
+                      }
+                    }
+                  }
+                },
+                "pkg-up": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "find-up": "1.1.2"
+                  },
+                  "dependencies": {
+                    "find-up": {
+                      "version": "1.1.2",
+                      "bundled": true,
+                      "requires": {
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.1"
+                      }
+                    },
+                    "path-exists": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "pinkie-promise": "2.0.1"
+                      }
+                    }
+                  }
+                },
+                "pluralize": {
+                  "version": "1.2.1",
+                  "bundled": true
+                },
+                "pn": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "prelude-ls": {
+                  "version": "1.1.2",
+                  "bundled": true
+                },
+                "preserve": {
+                  "version": "0.2.0",
+                  "bundled": true
+                },
+                "pretty-format": {
+                  "version": "21.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "3.0.0",
+                    "ansi-styles": "3.2.0"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    },
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "color-convert": "1.9.0"
+                      }
+                    }
+                  }
+                },
+                "private": {
+                  "version": "0.1.8",
+                  "bundled": true
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "bundled": true
+                },
+                "progress": {
+                  "version": "1.1.8",
+                  "bundled": true
+                },
+                "prr": {
+                  "version": "0.0.0",
+                  "bundled": true
+                },
+                "pseudomap": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "punycode": {
+                  "version": "1.4.1",
+                  "bundled": true
+                },
+                "randomatic": {
+                  "version": "1.1.7",
+                  "bundled": true,
+                  "requires": {
+                    "is-number": "3.0.0",
+                    "kind-of": "4.0.0"
+                  },
+                  "dependencies": {
+                    "is-number": {
+                      "version": "3.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "kind-of": "3.2.2"
+                      },
+                      "dependencies": {
+                        "kind-of": {
+                          "version": "3.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "is-buffer": "1.1.6"
+                          }
+                        }
+                      }
+                    },
+                    "kind-of": {
+                      "version": "4.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "read-pkg": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "load-json-file": "1.1.0",
+                    "normalize-package-data": "2.4.0",
+                    "path-type": "1.1.0"
+                  }
+                },
+                "read-pkg-up": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "find-up": "1.1.2",
+                    "read-pkg": "1.1.0"
+                  },
+                  "dependencies": {
+                    "find-up": {
+                      "version": "1.1.2",
+                      "bundled": true,
+                      "requires": {
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.1"
+                      }
+                    },
+                    "path-exists": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "pinkie-promise": "2.0.1"
+                      }
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.3.3",
+                  "bundled": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "safe-buffer": "5.1.1",
+                    "string_decoder": "1.0.3",
+                    "util-deprecate": "1.0.2"
+                  }
+                },
+                "readline2": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "mute-stream": "0.0.5"
+                  }
+                },
+                "rechoir": {
+                  "version": "0.6.2",
+                  "bundled": true,
+                  "requires": {
+                    "resolve": "1.1.7"
+                  }
+                },
+                "regenerate": {
+                  "version": "1.3.3",
+                  "bundled": true
+                },
+                "regenerator-runtime": {
+                  "version": "0.11.0",
+                  "bundled": true
+                },
+                "regenerator-transform": {
+                  "version": "0.10.1",
+                  "bundled": true,
+                  "requires": {
+                    "babel-runtime": "6.26.0",
+                    "babel-types": "6.26.0",
+                    "private": "0.1.8"
+                  }
+                },
+                "regex-cache": {
+                  "version": "0.4.4",
+                  "bundled": true,
+                  "requires": {
+                    "is-equal-shallow": "0.1.3"
+                  }
+                },
+                "regexpu-core": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "regenerate": "1.3.3",
+                    "regjsgen": "0.2.0",
+                    "regjsparser": "0.1.5"
+                  }
+                },
+                "regjsgen": {
+                  "version": "0.2.0",
+                  "bundled": true
+                },
+                "regjsparser": {
+                  "version": "0.1.5",
+                  "bundled": true,
+                  "requires": {
+                    "jsesc": "0.5.0"
+                  },
+                  "dependencies": {
+                    "jsesc": {
+                      "version": "0.5.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "remove-trailing-separator": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "repeat-element": {
+                  "version": "1.1.2",
+                  "bundled": true
+                },
+                "repeat-string": {
+                  "version": "1.6.1",
+                  "bundled": true
+                },
+                "repeating": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-finite": "1.0.2"
+                  }
+                },
+                "request": {
+                  "version": "2.83.0",
+                  "bundled": true,
+                  "requires": {
+                    "aws-sign2": "0.7.0",
+                    "aws4": "1.6.0",
+                    "caseless": "0.12.0",
+                    "combined-stream": "1.0.5",
+                    "extend": "3.0.1",
+                    "forever-agent": "0.6.1",
+                    "form-data": "2.3.1",
+                    "har-validator": "5.0.3",
+                    "hawk": "6.0.2",
+                    "http-signature": "1.2.0",
+                    "is-typedarray": "1.0.0",
+                    "isstream": "0.1.2",
+                    "json-stringify-safe": "5.0.1",
+                    "mime-types": "2.1.17",
+                    "oauth-sign": "0.8.2",
+                    "performance-now": "2.1.0",
+                    "qs": "6.5.1",
+                    "safe-buffer": "5.1.1",
+                    "stringstream": "0.0.5",
+                    "tough-cookie": "2.3.3",
+                    "tunnel-agent": "0.6.0",
+                    "uuid": "3.1.0"
+                  },
+                  "dependencies": {
+                    "qs": {
+                      "version": "6.5.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "request-promise-core": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "lodash": "4.17.4"
+                  }
+                },
+                "request-promise-native": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "requires": {
+                    "request-promise-core": "1.1.1",
+                    "stealthy-require": "1.1.1",
+                    "tough-cookie": "2.3.3"
+                  }
+                },
+                "require-directory": {
+                  "version": "2.1.1",
+                  "bundled": true
+                },
+                "require-main-filename": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "require-uncached": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "caller-path": "0.1.0",
+                    "resolve-from": "1.0.1"
+                  }
+                },
+                "resolve": {
+                  "version": "1.1.7",
+                  "bundled": true
+                },
+                "resolve-from": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "restore-cursor": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "exit-hook": "1.1.1",
+                    "onetime": "1.1.0"
+                  }
+                },
+                "right-align": {
+                  "version": "0.1.3",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "align-text": "0.1.4"
+                  }
+                },
+                "rimraf": {
+                  "version": "2.6.2",
+                  "bundled": true,
+                  "requires": {
+                    "glob": "7.1.2"
+                  }
+                },
+                "rollup": {
+                  "version": "0.47.6",
+                  "bundled": true
+                },
+                "rollup-plugin-commonjs": {
+                  "version": "8.2.6",
+                  "bundled": true,
+                  "requires": {
+                    "acorn": "5.2.1",
+                    "estree-walker": "0.5.0",
+                    "magic-string": "0.22.4",
+                    "resolve": "1.5.0",
+                    "rollup-pluginutils": "2.0.1"
+                  },
+                  "dependencies": {
+                    "acorn": {
+                      "version": "5.2.1",
+                      "bundled": true
+                    },
+                    "resolve": {
+                      "version": "1.5.0",
+                      "bundled": true,
+                      "requires": {
+                        "path-parse": "1.0.5"
+                      }
+                    }
+                  }
+                },
+                "rollup-plugin-node-resolve": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "browser-resolve": "1.11.2",
+                    "builtin-modules": "1.1.1",
+                    "is-module": "1.0.0",
+                    "resolve": "1.1.7"
+                  }
+                },
+                "rollup-plugin-replace": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "magic-string": "0.22.4",
+                    "minimatch": "3.0.4",
+                    "rollup-pluginutils": "2.0.1"
+                  }
+                },
+                "rollup-plugin-string": {
+                  "version": "2.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "rollup-pluginutils": "1.5.2"
+                  },
+                  "dependencies": {
+                    "estree-walker": {
+                      "version": "0.2.1",
+                      "bundled": true
+                    },
+                    "rollup-pluginutils": {
+                      "version": "1.5.2",
+                      "bundled": true,
+                      "requires": {
+                        "estree-walker": "0.2.1",
+                        "minimatch": "3.0.4"
+                      }
+                    }
+                  }
+                },
+                "rollup-pluginutils": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "estree-walker": "0.3.1",
+                    "micromatch": "2.3.11"
+                  },
+                  "dependencies": {
+                    "estree-walker": {
+                      "version": "0.3.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "run-async": {
+                  "version": "0.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "once": "1.4.0"
+                  }
+                },
+                "run-parallel": {
+                  "version": "1.1.6",
+                  "bundled": true
+                },
+                "rx-lite": {
+                  "version": "3.1.2",
+                  "bundled": true
+                },
+                "safe-buffer": {
+                  "version": "5.1.1",
+                  "bundled": true
+                },
+                "sane": {
+                  "version": "2.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "anymatch": "1.3.2",
+                    "exec-sh": "0.2.1",
+                    "fb-watchman": "2.0.0",
+                    "minimatch": "3.0.4",
+                    "minimist": "1.2.0",
+                    "walker": "1.0.7",
+                    "watch": "0.18.0"
+                  }
+                },
+                "sax": {
+                  "version": "1.2.4",
+                  "bundled": true
+                },
+                "semver": {
+                  "version": "5.4.1",
+                  "bundled": true
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "shebang-command": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "shebang-regex": "1.0.0"
+                  }
+                },
+                "shebang-regex": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "shelljs": {
+                  "version": "0.7.8",
+                  "bundled": true,
+                  "requires": {
+                    "glob": "7.1.2",
+                    "interpret": "1.0.4",
+                    "rechoir": "0.6.2"
+                  }
+                },
+                "shellwords": {
+                  "version": "0.1.1",
+                  "bundled": true
+                },
+                "signal-exit": {
+                  "version": "3.0.2",
+                  "bundled": true
+                },
+                "slash": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "slice-ansi": {
+                  "version": "0.0.4",
+                  "bundled": true
+                },
+                "sntp": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "hoek": "4.2.0"
+                  }
+                },
+                "source-map": {
+                  "version": "0.5.7",
+                  "bundled": true
+                },
+                "source-map-support": {
+                  "version": "0.4.18",
+                  "bundled": true,
+                  "requires": {
+                    "source-map": "0.5.7"
+                  }
+                },
+                "spdx-correct": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "spdx-license-ids": "1.2.2"
+                  }
+                },
+                "spdx-expression-parse": {
+                  "version": "1.0.4",
+                  "bundled": true
+                },
+                "spdx-license-ids": {
+                  "version": "1.2.2",
+                  "bundled": true
+                },
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "bundled": true
+                },
+                "sshpk": {
+                  "version": "1.13.1",
+                  "bundled": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.1",
+                    "dashdash": "1.14.1",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.7",
+                    "jsbn": "0.1.1",
+                    "tweetnacl": "0.14.5"
+                  }
+                },
+                "standard": {
+                  "version": "10.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "eslint": "3.19.0",
+                    "eslint-config-standard": "10.2.1",
+                    "eslint-config-standard-jsx": "4.0.2",
+                    "eslint-plugin-import": "2.2.0",
+                    "eslint-plugin-node": "4.2.3",
+                    "eslint-plugin-promise": "3.5.0",
+                    "eslint-plugin-react": "6.10.3",
+                    "eslint-plugin-standard": "3.0.1",
+                    "standard-engine": "7.0.0"
+                  }
+                },
+                "standard-engine": {
+                  "version": "7.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "deglob": "2.1.0",
+                    "get-stdin": "5.0.1",
+                    "minimist": "1.2.0",
+                    "pkg-conf": "2.0.0"
+                  }
+                },
+                "stealthy-require": {
+                  "version": "1.1.1",
+                  "bundled": true
+                },
+                "string-length": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "astral-regex": "1.0.0",
+                    "strip-ansi": "4.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    },
+                    "strip-ansi": {
+                      "version": "4.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-regex": "3.0.0"
+                      }
+                    }
+                  }
+                },
+                "string-width": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "4.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    },
+                    "strip-ansi": {
+                      "version": "4.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-regex": "3.0.0"
+                      }
+                    }
+                  }
+                },
+                "string_decoder": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "5.1.1"
+                  }
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "bundled": true
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  }
+                },
+                "strip-bom": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-utf8": "0.2.1"
+                  }
+                },
+                "strip-eof": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "strip-json-comments": {
+                  "version": "2.0.1",
+                  "bundled": true
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "symbol-tree": {
+                  "version": "3.2.2",
+                  "bundled": true
+                },
+                "table": {
+                  "version": "3.8.3",
+                  "bundled": true,
+                  "requires": {
+                    "ajv": "4.11.8",
+                    "ajv-keywords": "1.5.1",
+                    "chalk": "1.1.3",
+                    "lodash": "4.17.4",
+                    "slice-ansi": "0.0.4",
+                    "string-width": "2.1.1"
+                  },
+                  "dependencies": {
+                    "ajv": {
+                      "version": "4.11.8",
+                      "bundled": true,
+                      "requires": {
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
+                      }
+                    }
+                  }
+                },
+                "test-exclude": {
+                  "version": "4.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "arrify": "1.0.1",
+                    "micromatch": "2.3.11",
+                    "object-assign": "4.1.1",
+                    "read-pkg-up": "1.0.1",
+                    "require-main-filename": "1.0.1"
+                  }
+                },
+                "text-table": {
+                  "version": "0.2.0",
+                  "bundled": true
+                },
+                "throat": {
+                  "version": "4.1.0",
+                  "bundled": true
+                },
+                "through": {
+                  "version": "2.3.8",
+                  "bundled": true
+                },
+                "tmpl": {
+                  "version": "1.0.4",
+                  "bundled": true
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "bundled": true
+                },
+                "tough-cookie": {
+                  "version": "2.3.3",
+                  "bundled": true,
+                  "requires": {
+                    "punycode": "1.4.1"
+                  }
+                },
+                "tr46": {
+                  "version": "0.0.3",
+                  "bundled": true
+                },
+                "trim-right": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "tryit": {
+                  "version": "1.0.3",
+                  "bundled": true
+                },
+                "tunnel-agent": {
+                  "version": "0.6.0",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "5.1.1"
+                  }
+                },
+                "tweetnacl": {
+                  "version": "0.14.5",
+                  "bundled": true,
+                  "optional": true
+                },
+                "type-check": {
+                  "version": "0.3.2",
+                  "bundled": true,
+                  "requires": {
+                    "prelude-ls": "1.1.2"
+                  }
+                },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "bundled": true
+                },
+                "uglify-js": {
+                  "version": "2.8.29",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "source-map": "0.5.7",
+                    "uglify-to-browserify": "1.0.2",
+                    "yargs": "3.10.0"
+                  },
+                  "dependencies": {
+                    "yargs": {
+                      "version": "3.10.0",
+                      "bundled": true,
+                      "optional": true,
+                      "requires": {
+                        "camelcase": "1.2.1",
+                        "cliui": "2.1.0",
+                        "decamelize": "1.2.0",
+                        "window-size": "0.1.0"
+                      }
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "uniq": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "user-home": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "os-homedir": "1.0.2"
+                  }
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "uuid": {
+                  "version": "3.1.0",
+                  "bundled": true
+                },
+                "validate-npm-package-license": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "spdx-correct": "1.0.2",
+                    "spdx-expression-parse": "1.0.4"
+                  }
+                },
+                "verror": {
+                  "version": "1.10.0",
+                  "bundled": true,
+                  "requires": {
+                    "assert-plus": "1.0.0",
+                    "core-util-is": "1.0.2",
+                    "extsprintf": "1.3.0"
+                  }
+                },
+                "vlq": {
+                  "version": "0.2.3",
+                  "bundled": true
+                },
+                "walker": {
+                  "version": "1.0.7",
+                  "bundled": true,
+                  "requires": {
+                    "makeerror": "1.0.11"
+                  }
+                },
+                "watch": {
+                  "version": "0.18.0",
+                  "bundled": true,
+                  "requires": {
+                    "exec-sh": "0.2.1",
+                    "minimist": "1.2.0"
+                  }
+                },
+                "webidl-conversions": {
+                  "version": "4.0.2",
+                  "bundled": true
+                },
+                "whatwg-encoding": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "iconv-lite": "0.4.19"
+                  }
+                },
+                "whatwg-url": {
+                  "version": "4.8.0",
+                  "bundled": true,
+                  "requires": {
+                    "tr46": "0.0.3",
+                    "webidl-conversions": "3.0.1"
+                  },
+                  "dependencies": {
+                    "webidl-conversions": {
+                      "version": "3.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "which": {
+                  "version": "1.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "isexe": "2.0.0"
+                  }
+                },
+                "which-module": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "window-size": {
+                  "version": "0.1.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "bundled": true
+                },
+                "worker-farm": {
+                  "version": "1.5.1",
+                  "bundled": true,
+                  "requires": {
+                    "errno": "0.1.4",
+                    "xtend": "4.0.1"
+                  }
+                },
+                "wrap-ansi": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1"
+                  },
+                  "dependencies": {
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      }
+                    }
+                  }
+                },
+                "wrappy": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "write": {
+                  "version": "0.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "mkdirp": "0.5.1"
+                  }
+                },
+                "write-file-atomic": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "imurmurhash": "0.1.4",
+                    "signal-exit": "3.0.2"
+                  }
+                },
+                "xml-name-validator": {
+                  "version": "2.0.1",
+                  "bundled": true
+                },
+                "xmldom": {
+                  "version": "0.1.27",
+                  "bundled": true
+                },
+                "xmltojson": {
+                  "version": "1.3.5",
+                  "bundled": true
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "bundled": true
+                },
+                "y18n": {
+                  "version": "3.2.1",
+                  "bundled": true
+                },
+                "yallist": {
+                  "version": "2.1.2",
+                  "bundled": true
+                },
+                "yargs": {
+                  "version": "9.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "camelcase": "4.1.0",
+                    "cliui": "3.2.0",
+                    "decamelize": "1.2.0",
+                    "get-caller-file": "1.0.2",
+                    "os-locale": "2.1.0",
+                    "read-pkg-up": "2.0.0",
+                    "require-directory": "2.1.1",
+                    "require-main-filename": "1.0.1",
+                    "set-blocking": "2.0.0",
+                    "string-width": "2.1.1",
+                    "which-module": "2.0.0",
+                    "y18n": "3.2.1",
+                    "yargs-parser": "7.0.0"
+                  },
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "4.1.0",
+                      "bundled": true
+                    },
+                    "cliui": {
+                      "version": "3.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wrap-ansi": "2.1.0"
+                      },
+                      "dependencies": {
+                        "string-width": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "code-point-at": "1.1.0",
+                            "is-fullwidth-code-point": "1.0.0",
+                            "strip-ansi": "3.0.1"
+                          }
+                        }
+                      }
+                    },
+                    "load-json-file": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "strip-bom": "3.0.0"
+                      }
+                    },
+                    "path-type": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "pify": "2.3.0"
+                      }
+                    },
+                    "read-pkg": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "load-json-file": "2.0.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "2.0.0"
+                      }
+                    },
+                    "read-pkg-up": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "find-up": "2.1.0",
+                        "read-pkg": "2.0.0"
+                      }
+                    },
+                    "strip-bom": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "yargs-parser": {
+                  "version": "7.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "camelcase": "4.1.0"
+                  },
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "4.1.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "amdefine": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "ansi-escapes": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "anymatch": {
+              "version": "1.3.2",
+              "bundled": true,
+              "requires": {
+                "micromatch": "2.3.11",
+                "normalize-path": "2.1.1"
+              }
+            },
+            "append-transform": {
+              "version": "0.4.0",
+              "bundled": true,
+              "requires": {
+                "default-require-extensions": "1.0.0"
+              }
+            },
+            "argparse": {
+              "version": "1.0.9",
+              "bundled": true,
+              "requires": {
+                "sprintf-js": "1.0.3"
+              }
+            },
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "1.1.0"
+              }
+            },
+            "arr-flatten": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "array-equal": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "array-union": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "array-uniq": "1.0.3"
+              }
+            },
+            "array-uniq": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "array.prototype.find": {
+              "version": "2.0.4",
+              "bundled": true,
+              "requires": {
+                "define-properties": "1.1.2",
+                "es-abstract": "1.9.0"
+              }
+            },
+            "arrify": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "astral-regex": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "async": {
+              "version": "2.6.0",
+              "bundled": true,
+              "requires": {
+                "lodash": "4.17.4"
+              }
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "bundled": true
+            },
+            "aws-sign2": {
+              "version": "0.7.0",
+              "bundled": true
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "bundled": true
+            },
+            "babel-code-frame": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
+              }
+            },
+            "babel-core": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-code-frame": "6.26.0",
+                "babel-generator": "6.26.0",
+                "babel-helpers": "6.24.1",
+                "babel-messages": "6.23.0",
+                "babel-register": "6.26.0",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "convert-source-map": "1.5.0",
+                "debug": "2.6.9",
+                "json5": "0.5.1",
+                "lodash": "4.17.4",
+                "minimatch": "3.0.4",
+                "path-is-absolute": "1.0.1",
+                "private": "0.1.8",
+                "slash": "1.0.0",
+                "source-map": "0.5.7"
+              }
+            },
+            "babel-generator": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "detect-indent": "4.0.0",
+                "jsesc": "1.3.0",
+                "lodash": "4.17.4",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
+              }
+            },
+            "babel-helper-call-delegate": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-helper-hoist-variables": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
+              }
+            },
+            "babel-helper-define-map": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-helper-function-name": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "lodash": "4.17.4"
+              }
+            },
+            "babel-helper-function-name": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-helper-get-function-arity": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
+              }
+            },
+            "babel-helper-get-function-arity": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
+              }
+            },
+            "babel-helper-hoist-variables": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
+              }
+            },
+            "babel-helper-optimise-call-expression": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
+              }
+            },
+            "babel-helper-regex": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "lodash": "4.17.4"
+              }
+            },
+            "babel-helper-replace-supers": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-helper-optimise-call-expression": "6.24.1",
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
+              }
+            },
+            "babel-helpers": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
+              }
+            },
+            "babel-jest": {
+              "version": "21.2.0",
+              "bundled": true,
+              "requires": {
+                "babel-plugin-istanbul": "4.1.5",
+                "babel-preset-jest": "21.2.0"
+              }
+            },
+            "babel-messages": {
+              "version": "6.23.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0"
+              }
+            },
+            "babel-plugin-check-es2015-constants": {
+              "version": "6.22.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0"
+              }
+            },
+            "babel-plugin-istanbul": {
+              "version": "4.1.5",
+              "bundled": true,
+              "requires": {
+                "find-up": "2.1.0",
+                "istanbul-lib-instrument": "1.9.1",
+                "test-exclude": "4.1.1"
+              }
+            },
+            "babel-plugin-jest-hoist": {
+              "version": "21.2.0",
+              "bundled": true
+            },
+            "babel-plugin-syntax-object-rest-spread": {
+              "version": "6.13.0",
+              "bundled": true
+            },
+            "babel-plugin-transform-es2015-arrow-functions": {
+              "version": "6.22.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-block-scoped-functions": {
+              "version": "6.22.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-block-scoping": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "lodash": "4.17.4"
+              }
+            },
+            "babel-plugin-transform-es2015-classes": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-helper-define-map": "6.26.0",
+                "babel-helper-function-name": "6.24.1",
+                "babel-helper-optimise-call-expression": "6.24.1",
+                "babel-helper-replace-supers": "6.24.1",
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-computed-properties": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-destructuring": {
+              "version": "6.23.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-duplicate-keys": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-for-of": {
+              "version": "6.23.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-function-name": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-helper-function-name": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-literals": {
+              "version": "6.22.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-modules-amd": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-modules-commonjs": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-plugin-transform-strict-mode": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-types": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-modules-systemjs": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-helper-hoist-variables": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-modules-umd": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-object-super": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-helper-replace-supers": "6.24.1",
+                "babel-runtime": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-parameters": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-helper-call-delegate": "6.24.1",
+                "babel-helper-get-function-arity": "6.24.1",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-shorthand-properties": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-spread": {
+              "version": "6.22.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-sticky-regex": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-helper-regex": "6.26.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-template-literals": {
+              "version": "6.22.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-typeof-symbol": {
+              "version": "6.23.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0"
+              }
+            },
+            "babel-plugin-transform-es2015-unicode-regex": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-helper-regex": "6.26.0",
+                "babel-runtime": "6.26.0",
+                "regexpu-core": "2.0.0"
+              }
+            },
+            "babel-plugin-transform-regenerator": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "regenerator-transform": "0.10.1"
+              }
+            },
+            "babel-plugin-transform-strict-mode": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0"
+              }
+            },
+            "babel-preset-es2015": {
+              "version": "6.24.1",
+              "bundled": true,
+              "requires": {
+                "babel-plugin-check-es2015-constants": "6.22.0",
+                "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+                "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+                "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+                "babel-plugin-transform-es2015-classes": "6.24.1",
+                "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+                "babel-plugin-transform-es2015-destructuring": "6.23.0",
+                "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+                "babel-plugin-transform-es2015-for-of": "6.23.0",
+                "babel-plugin-transform-es2015-function-name": "6.24.1",
+                "babel-plugin-transform-es2015-literals": "6.22.0",
+                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+                "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+                "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+                "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+                "babel-plugin-transform-es2015-object-super": "6.24.1",
+                "babel-plugin-transform-es2015-parameters": "6.24.1",
+                "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+                "babel-plugin-transform-es2015-spread": "6.22.0",
+                "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+                "babel-plugin-transform-es2015-template-literals": "6.22.0",
+                "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+                "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+                "babel-plugin-transform-regenerator": "6.26.0"
+              }
+            },
+            "babel-preset-jest": {
+              "version": "21.2.0",
+              "bundled": true,
+              "requires": {
+                "babel-plugin-jest-hoist": "21.2.0",
+                "babel-plugin-syntax-object-rest-spread": "6.13.0"
+              }
+            },
+            "babel-register": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-core": "6.26.0",
+                "babel-runtime": "6.26.0",
+                "core-js": "2.5.1",
+                "home-or-tmp": "2.0.0",
+                "lodash": "4.17.4",
+                "mkdirp": "0.5.1",
+                "source-map-support": "0.4.18"
+              }
+            },
+            "babel-runtime": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "core-js": "2.5.1",
+                "regenerator-runtime": "0.11.0"
+              }
+            },
+            "babel-template": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "lodash": "4.17.4"
+              }
+            },
+            "babel-traverse": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-code-frame": "6.26.0",
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "debug": "2.6.9",
+                "globals": "9.18.0",
+                "invariant": "2.2.2",
+                "lodash": "4.17.4"
+              }
+            },
+            "babel-types": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0",
+                "esutils": "2.0.2",
+                "lodash": "4.17.4",
+                "to-fast-properties": "1.0.3"
+              }
+            },
+            "babylon": {
+              "version": "6.18.0",
+              "bundled": true
+            },
+            "babyparse": {
+              "version": "0.4.6",
+              "bundled": true
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "boom": {
+              "version": "4.3.1",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            },
+            "brace-expansion": {
+              "version": "1.1.8",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+              }
+            },
+            "browser-resolve": {
+              "version": "1.11.2",
+              "bundled": true,
+              "requires": {
+                "resolve": "1.1.7"
+              }
+            },
+            "bser": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "node-int64": "0.4.0"
+              }
+            },
+            "builtin-modules": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "caller-path": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "callsites": "0.2.0"
+              },
+              "dependencies": {
+                "callsites": {
+                  "version": "0.2.0",
+                  "bundled": true
+                }
+              }
+            },
+            "callsites": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "camelcase": {
+              "version": "1.2.1",
+              "bundled": true,
+              "optional": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true
+            },
+            "center-align": {
+              "version": "0.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
+              }
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              }
+            },
+            "ci-info": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "circular-json": {
+              "version": "0.3.3",
+              "bundled": true
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "restore-cursor": "1.0.1"
+              }
+            },
+            "cli-width": {
+              "version": "2.2.0",
+              "bundled": true
+            },
+            "cliui": {
+              "version": "2.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "center-align": "0.1.3",
+                "right-align": "0.1.3",
+                "wordwrap": "0.0.2"
+              },
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "co": {
+              "version": "4.6.0",
+              "bundled": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "color-convert": {
+              "version": "1.9.0",
+              "bundled": true,
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "bundled": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "concat-stream": {
+              "version": "1.6.0",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "typedarray": "0.0.6"
+              }
+            },
+            "contains-path": {
+              "version": "0.1.0",
+              "bundled": true
+            },
+            "content-type-parser": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "convert-source-map": {
+              "version": "1.5.0",
+              "bundled": true
+            },
+            "core-js": {
+              "version": "2.5.1",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "cross-spawn": {
+              "version": "5.1.0",
+              "bundled": true,
+              "requires": {
+                "lru-cache": "4.1.1",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
+              }
+            },
+            "cryptiles": {
+              "version": "3.1.2",
+              "bundled": true,
+              "requires": {
+                "boom": "5.2.0"
+              },
+              "dependencies": {
+                "boom": {
+                  "version": "5.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "hoek": "4.2.0"
+                  }
+                }
+              }
+            },
+            "cssom": {
+              "version": "0.3.2",
+              "bundled": true
+            },
+            "cssstyle": {
+              "version": "0.2.37",
+              "bundled": true,
+              "requires": {
+                "cssom": "0.3.2"
+              }
+            },
+            "d": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "es5-ext": "0.10.35"
+              }
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              }
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "debug-log": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "decamelize": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "deep-is": {
+              "version": "0.1.3",
+              "bundled": true
+            },
+            "default-require-extensions": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "strip-bom": "2.0.0"
+              }
+            },
+            "define-properties": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "foreach": "2.0.5",
+                "object-keys": "1.0.11"
+              }
+            },
+            "deglob": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "find-root": "1.1.0",
+                "glob": "7.1.2",
+                "ignore": "3.3.7",
+                "pkg-config": "1.1.1",
+                "run-parallel": "1.1.6",
+                "uniq": "1.0.1"
+              }
+            },
+            "del": {
+              "version": "2.2.2",
+              "bundled": true,
+              "requires": {
+                "globby": "5.0.0",
+                "is-path-cwd": "1.0.0",
+                "is-path-in-cwd": "1.0.0",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "rimraf": "2.6.2"
+              }
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "detect-indent": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "repeating": "2.0.1"
+              }
+            },
+            "diff": {
+              "version": "3.4.0",
+              "bundled": true
+            },
+            "doctrine": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "esutils": "2.0.2",
+                "isarray": "1.0.0"
+              }
+            },
+            "domexception": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "encoding": {
+              "version": "0.1.12",
+              "bundled": true,
+              "requires": {
+                "iconv-lite": "0.4.19"
+              }
+            },
+            "errno": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "prr": "0.0.0"
+              }
+            },
+            "error-ex": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "is-arrayish": "0.2.1"
+              }
+            },
+            "es-abstract": {
+              "version": "1.9.0",
+              "bundled": true,
+              "requires": {
+                "es-to-primitive": "1.1.1",
+                "function-bind": "1.1.1",
+                "has": "1.0.1",
+                "is-callable": "1.1.3",
+                "is-regex": "1.0.4"
+              }
+            },
+            "es-to-primitive": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "is-callable": "1.1.3",
+                "is-date-object": "1.0.1",
+                "is-symbol": "1.0.1"
+              }
+            },
+            "es5-ext": {
+              "version": "0.10.35",
+              "bundled": true,
+              "requires": {
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1"
+              }
+            },
+            "es6-iterator": {
+              "version": "2.0.3",
+              "bundled": true,
+              "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.35",
+                "es6-symbol": "3.1.1"
+              }
+            },
+            "es6-map": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.35",
+                "es6-iterator": "2.0.3",
+                "es6-set": "0.1.5",
+                "es6-symbol": "3.1.1",
+                "event-emitter": "0.3.5"
+              }
+            },
+            "es6-set": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.35",
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1",
+                "event-emitter": "0.3.5"
+              }
+            },
+            "es6-symbol": {
+              "version": "3.1.1",
+              "bundled": true,
+              "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.35"
+              }
+            },
+            "es6-weak-map": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.35",
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1"
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "escodegen": {
+              "version": "1.9.0",
+              "bundled": true,
+              "requires": {
+                "esprima": "3.1.3",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.5.7"
+              },
+              "dependencies": {
+                "esprima": {
+                  "version": "3.1.3",
+                  "bundled": true
+                }
+              }
+            },
+            "escope": {
+              "version": "3.6.0",
+              "bundled": true,
+              "requires": {
+                "es6-map": "0.1.5",
+                "es6-weak-map": "2.0.2",
+                "esrecurse": "4.2.0",
+                "estraverse": "4.2.0"
+              }
+            },
+            "eslint": {
+              "version": "3.19.0",
+              "bundled": true,
+              "requires": {
+                "babel-code-frame": "6.26.0",
+                "chalk": "1.1.3",
+                "concat-stream": "1.6.0",
+                "debug": "2.6.9",
+                "doctrine": "2.0.0",
+                "escope": "3.6.0",
+                "espree": "3.5.1",
+                "esquery": "1.0.0",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "file-entry-cache": "2.0.0",
+                "glob": "7.1.2",
+                "globals": "9.18.0",
+                "ignore": "3.3.7",
+                "imurmurhash": "0.1.4",
+                "inquirer": "0.12.0",
+                "is-my-json-valid": "2.16.1",
+                "is-resolvable": "1.0.0",
+                "js-yaml": "3.10.0",
+                "json-stable-stringify": "1.0.1",
+                "levn": "0.3.0",
+                "lodash": "4.17.4",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "optionator": "0.8.2",
+                "path-is-inside": "1.0.2",
+                "pluralize": "1.2.1",
+                "progress": "1.1.8",
+                "require-uncached": "1.0.3",
+                "shelljs": "0.7.8",
+                "strip-bom": "3.0.0",
+                "strip-json-comments": "2.0.1",
+                "table": "3.8.3",
+                "text-table": "0.2.0",
+                "user-home": "2.0.0"
+              },
+              "dependencies": {
+                "strip-bom": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "eslint-config-standard": {
+              "version": "10.2.1",
+              "bundled": true
+            },
+            "eslint-config-standard-jsx": {
+              "version": "4.0.2",
+              "bundled": true
+            },
+            "eslint-import-resolver-node": {
+              "version": "0.2.3",
+              "bundled": true,
+              "requires": {
+                "debug": "2.6.9",
+                "object-assign": "4.1.1",
+                "resolve": "1.1.7"
+              }
+            },
+            "eslint-module-utils": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "debug": "2.6.9",
+                "pkg-dir": "1.0.0"
+              }
+            },
+            "eslint-plugin-import": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "builtin-modules": "1.1.1",
+                "contains-path": "0.1.0",
+                "debug": "2.6.9",
+                "doctrine": "1.5.0",
+                "eslint-import-resolver-node": "0.2.3",
+                "eslint-module-utils": "2.1.1",
+                "has": "1.0.1",
+                "lodash.cond": "4.5.2",
+                "minimatch": "3.0.4",
+                "pkg-up": "1.0.0"
+              },
+              "dependencies": {
+                "doctrine": {
+                  "version": "1.5.0",
+                  "bundled": true,
+                  "requires": {
+                    "esutils": "2.0.2",
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "eslint-plugin-node": {
+              "version": "4.2.3",
+              "bundled": true,
+              "requires": {
+                "ignore": "3.3.7",
+                "minimatch": "3.0.4",
+                "object-assign": "4.1.1",
+                "resolve": "1.1.7",
+                "semver": "5.3.0"
+              },
+              "dependencies": {
+                "semver": {
+                  "version": "5.3.0",
+                  "bundled": true
+                }
+              }
+            },
+            "eslint-plugin-promise": {
+              "version": "3.5.0",
+              "bundled": true
+            },
+            "eslint-plugin-react": {
+              "version": "6.10.3",
+              "bundled": true,
+              "requires": {
+                "array.prototype.find": "2.0.4",
+                "doctrine": "1.5.0",
+                "has": "1.0.1",
+                "jsx-ast-utils": "1.4.1",
+                "object.assign": "4.0.4"
+              },
+              "dependencies": {
+                "doctrine": {
+                  "version": "1.5.0",
+                  "bundled": true,
+                  "requires": {
+                    "esutils": "2.0.2",
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "eslint-plugin-standard": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "espree": {
+              "version": "3.5.1",
+              "bundled": true,
+              "requires": {
+                "acorn": "5.2.1",
+                "acorn-jsx": "3.0.1"
+              },
+              "dependencies": {
+                "acorn": {
+                  "version": "5.2.1",
+                  "bundled": true
+                }
+              }
+            },
+            "esprima": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "esquery": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "estraverse": "4.2.0"
+              }
+            },
+            "esrecurse": {
+              "version": "4.2.0",
+              "bundled": true,
+              "requires": {
+                "estraverse": "4.2.0",
+                "object-assign": "4.1.1"
+              }
+            },
+            "estraverse": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "estree-walker": {
+              "version": "0.5.0",
+              "bundled": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "bundled": true
+            },
+            "event-emitter": {
+              "version": "0.3.5",
+              "bundled": true,
+              "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.35"
+              }
+            },
+            "exec-sh": {
+              "version": "0.2.1",
+              "bundled": true,
+              "requires": {
+                "merge": "1.2.0"
+              }
+            },
+            "execa": {
+              "version": "0.7.0",
+              "bundled": true,
+              "requires": {
+                "cross-spawn": "5.1.0",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+              }
+            },
+            "exit-hook": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "0.1.1"
+              }
+            },
+            "expand-range": {
+              "version": "1.8.2",
+              "bundled": true,
+              "requires": {
+                "fill-range": "2.2.3"
+              }
+            },
+            "expect": {
+              "version": "21.2.1",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "3.2.0",
+                "jest-diff": "21.2.1",
+                "jest-get-type": "21.2.0",
+                "jest-matcher-utils": "21.2.1",
+                "jest-message-util": "21.2.1",
+                "jest-regex-util": "21.2.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.0"
+                  }
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
+            },
+            "extsprintf": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "fast-deep-equal": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "fast-json-stable-stringify": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "fast-levenshtein": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "fb-watchman": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "bser": "2.0.0"
+              }
+            },
+            "figures": {
+              "version": "1.7.0",
+              "bundled": true,
+              "requires": {
+                "escape-string-regexp": "1.0.5",
+                "object-assign": "4.1.1"
+              }
+            },
+            "file-entry-cache": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "flat-cache": "1.3.0",
+                "object-assign": "4.1.1"
+              }
+            },
+            "filename-regex": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "fileset": {
+              "version": "2.0.3",
+              "bundled": true,
+              "requires": {
+                "glob": "7.1.2",
+                "minimatch": "3.0.4"
+              }
+            },
+            "fill-range": {
+              "version": "2.2.3",
+              "bundled": true,
+              "requires": {
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "1.1.7",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
+              }
+            },
+            "find-root": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "2.0.0"
+              }
+            },
+            "flat-cache": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "circular-json": "0.3.3",
+                "del": "2.2.2",
+                "graceful-fs": "4.1.11",
+                "write": "0.2.1"
+              }
+            },
+            "for-in": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "for-own": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "for-in": "1.0.2"
+              }
+            },
+            "foreach": {
+              "version": "2.0.5",
+              "bundled": true
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "form-data": {
+              "version": "2.3.1",
+              "bundled": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "function-bind": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "generate-function": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "generate-object-property": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "is-property": "1.0.2"
+              }
+            },
+            "get-caller-file": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "get-stdin": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
+            },
+            "glob-base": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
+              }
+            },
+            "glob-parent": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-glob": "2.0.1"
+              }
+            },
+            "globals": {
+              "version": "9.18.0",
+              "bundled": true
+            },
+            "globby": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "glob": "7.1.2",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "bundled": true
+            },
+            "growly": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "handlebars": {
+              "version": "4.0.11",
+              "bundled": true,
+              "requires": {
+                "async": "1.5.2",
+                "optimist": "0.6.1",
+                "source-map": "0.4.4",
+                "uglify-js": "2.8.29"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "1.5.2",
+                  "bundled": true
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "bundled": true,
+                  "requires": {
+                    "amdefine": "1.0.1"
+                  }
+                }
+              }
+            },
+            "har-schema": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "har-validator": {
+              "version": "5.0.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "5.3.0",
+                "har-schema": "2.0.0"
+              }
+            },
+            "has": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "function-bind": "1.1.1"
+              }
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "has-flag": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "hawk": {
+              "version": "6.0.2",
+              "bundled": true,
+              "requires": {
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.0",
+                "sntp": "2.1.0"
+              }
+            },
+            "hoek": {
+              "version": "4.2.0",
+              "bundled": true
+            },
+            "home-or-tmp": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
+              }
+            },
+            "hosted-git-info": {
+              "version": "2.5.0",
+              "bundled": true
+            },
+            "html-encoding-sniffer": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "whatwg-encoding": "1.0.3"
+              }
+            },
+            "http-signature": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
+              }
+            },
+            "iconv-lite": {
+              "version": "0.4.19",
+              "bundled": true
+            },
+            "ignore": {
+              "version": "3.3.7",
+              "bundled": true
+            },
+            "imurmurhash": {
+              "version": "0.1.4",
+              "bundled": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "inquirer": {
+              "version": "0.12.0",
+              "bundled": true,
+              "requires": {
+                "ansi-escapes": "1.4.0",
+                "ansi-regex": "2.1.1",
+                "chalk": "1.1.3",
+                "cli-cursor": "1.0.2",
+                "cli-width": "2.2.0",
+                "figures": "1.7.0",
+                "lodash": "4.17.4",
+                "readline2": "1.0.1",
+                "run-async": "0.1.0",
+                "rx-lite": "3.1.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "through": "2.3.8"
+              },
+              "dependencies": {
+                "ansi-escapes": {
+                  "version": "1.4.0",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
+                }
+              }
+            },
+            "interpret": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "invariant": {
+              "version": "2.2.2",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "1.3.1"
+              }
+            },
+            "invert-kv": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-arrayish": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "is-buffer": {
+              "version": "1.1.6",
+              "bundled": true
+            },
+            "is-builtin-module": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "builtin-modules": "1.1.1"
+              }
+            },
+            "is-callable": {
+              "version": "1.1.3",
+              "bundled": true
+            },
+            "is-ci": {
+              "version": "1.0.10",
+              "bundled": true,
+              "requires": {
+                "ci-info": "1.1.1"
+              }
+            },
+            "is-date-object": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "is-dotfile": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "is-equal-shallow": {
+              "version": "0.1.3",
+              "bundled": true,
+              "requires": {
+                "is-primitive": "2.0.0"
+              }
+            },
+            "is-extendable": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-finite": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
+            },
+            "is-module": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-my-json-valid": {
+              "version": "2.16.1",
+              "bundled": true,
+              "requires": {
+                "generate-function": "2.0.0",
+                "generate-object-property": "1.2.0",
+                "jsonpointer": "4.0.1",
+                "xtend": "4.0.1"
+              }
+            },
+            "is-number": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            },
+            "is-path-cwd": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-path-in-cwd": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-path-inside": "1.0.0"
+              }
+            },
+            "is-path-inside": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "path-is-inside": "1.0.2"
+              }
+            },
+            "is-posix-bracket": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "is-primitive": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "is-property": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "is-regex": {
+              "version": "1.0.4",
+              "bundled": true,
+              "requires": {
+                "has": "1.0.1"
+              }
+            },
+            "is-resolvable": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "tryit": "1.0.3"
+              }
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-symbol": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-utf8": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "isobject": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            },
+            "isomorphic-fetch": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "node-fetch": "1.7.3",
+                "whatwg-fetch": "2.0.3"
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "istanbul-api": {
+              "version": "1.2.1",
+              "bundled": true,
+              "requires": {
+                "async": "2.6.0",
+                "fileset": "2.0.3",
+                "istanbul-lib-coverage": "1.1.1",
+                "istanbul-lib-hook": "1.1.0",
+                "istanbul-lib-instrument": "1.9.1",
+                "istanbul-lib-report": "1.1.2",
+                "istanbul-lib-source-maps": "1.2.2",
+                "istanbul-reports": "1.1.3",
+                "js-yaml": "3.10.0",
+                "mkdirp": "0.5.1",
+                "once": "1.4.0"
+              }
+            },
+            "istanbul-lib-coverage": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "istanbul-lib-hook": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "append-transform": "0.4.0"
+              }
+            },
+            "istanbul-lib-instrument": {
+              "version": "1.9.1",
+              "bundled": true,
+              "requires": {
+                "babel-generator": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "istanbul-lib-coverage": "1.1.1",
+                "semver": "5.4.1"
+              }
+            },
+            "istanbul-lib-report": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "istanbul-lib-coverage": "1.1.1",
+                "mkdirp": "0.5.1",
+                "path-parse": "1.0.5",
+                "supports-color": "3.2.3"
+              },
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "supports-color": {
+                  "version": "3.2.3",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "1.0.0"
+                  }
+                }
+              }
+            },
+            "istanbul-lib-source-maps": {
+              "version": "1.2.2",
+              "bundled": true,
+              "requires": {
+                "debug": "3.1.0",
+                "istanbul-lib-coverage": "1.1.1",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "source-map": "0.5.7"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "3.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                }
+              }
+            },
+            "istanbul-reports": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "handlebars": "4.0.11"
+              }
+            },
+            "jest": {
+              "version": "21.2.1",
+              "bundled": true,
+              "requires": {
+                "jest-cli": "21.2.1"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "ansi-styles": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.0"
+                  }
+                },
+                "chalk": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-styles": "3.2.0",
+                    "escape-string-regexp": "1.0.5",
+                    "supports-color": "4.5.0"
+                  }
+                },
+                "jest-cli": {
+                  "version": "21.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-escapes": "3.0.0",
+                    "chalk": "2.3.0",
+                    "glob": "7.1.2",
+                    "graceful-fs": "4.1.11",
+                    "is-ci": "1.0.10",
+                    "istanbul-api": "1.2.1",
+                    "istanbul-lib-coverage": "1.1.1",
+                    "istanbul-lib-instrument": "1.9.1",
+                    "istanbul-lib-source-maps": "1.2.2",
+                    "jest-changed-files": "21.2.0",
+                    "jest-config": "21.2.1",
+                    "jest-environment-jsdom": "21.2.1",
+                    "jest-haste-map": "21.2.0",
+                    "jest-message-util": "21.2.1",
+                    "jest-regex-util": "21.2.0",
+                    "jest-resolve-dependencies": "21.2.0",
+                    "jest-runner": "21.2.1",
+                    "jest-runtime": "21.2.1",
+                    "jest-snapshot": "21.2.1",
+                    "jest-util": "21.2.1",
+                    "micromatch": "2.3.11",
+                    "node-notifier": "5.1.2",
+                    "pify": "3.0.0",
+                    "slash": "1.0.0",
+                    "string-length": "2.0.0",
+                    "strip-ansi": "4.0.0",
+                    "which": "1.3.0",
+                    "worker-farm": "1.5.1",
+                    "yargs": "9.0.1"
+                  }
+                },
+                "pify": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "strip-ansi": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "3.0.0"
+                  }
+                },
+                "supports-color": {
+                  "version": "4.5.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "2.0.0"
+                  }
+                }
+              }
+            },
+            "jest-changed-files": {
+              "version": "21.2.0",
+              "bundled": true,
+              "requires": {
+                "throat": "4.1.0"
+              }
+            },
+            "jest-config": {
+              "version": "21.2.1",
+              "bundled": true,
+              "requires": {
+                "chalk": "2.3.0",
+                "glob": "7.1.2",
+                "jest-environment-jsdom": "21.2.1",
+                "jest-environment-node": "21.2.1",
+                "jest-get-type": "21.2.0",
+                "jest-jasmine2": "21.2.1",
+                "jest-regex-util": "21.2.0",
+                "jest-resolve": "21.2.0",
+                "jest-util": "21.2.1",
+                "jest-validate": "21.2.1",
+                "pretty-format": "21.2.1"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.0"
+                  }
+                },
+                "chalk": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-styles": "3.2.0",
+                    "escape-string-regexp": "1.0.5",
+                    "supports-color": "4.5.0"
+                  }
+                },
+                "supports-color": {
+                  "version": "4.5.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "2.0.0"
+                  }
+                }
+              }
+            },
+            "jest-diff": {
+              "version": "21.2.1",
+              "bundled": true,
+              "requires": {
+                "chalk": "2.3.0",
+                "diff": "3.4.0",
+                "jest-get-type": "21.2.0",
+                "pretty-format": "21.2.1"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.0"
+                  }
+                },
+                "chalk": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-styles": "3.2.0",
+                    "escape-string-regexp": "1.0.5",
+                    "supports-color": "4.5.0"
+                  }
+                },
+                "supports-color": {
+                  "version": "4.5.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "2.0.0"
+                  }
+                }
+              }
+            },
+            "jest-docblock": {
+              "version": "21.2.0",
+              "bundled": true
+            },
+            "jest-environment-jsdom": {
+              "version": "21.2.1",
+              "bundled": true,
+              "requires": {
+                "jest-mock": "21.2.0",
+                "jest-util": "21.2.1",
+                "jsdom": "9.12.0"
+              }
+            },
+            "jest-environment-jsdom-11.0.0": {
+              "version": "20.0.9",
+              "bundled": true,
+              "requires": {
+                "jest-mock": "20.0.3",
+                "jest-util": "20.0.3",
+                "jsdom": "11.3.0"
+              },
+              "dependencies": {
+                "acorn": {
+                  "version": "5.2.1",
+                  "bundled": true
+                },
+                "acorn-globals": {
+                  "version": "4.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "acorn": "5.2.1"
+                  }
+                },
+                "ansi-styles": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.0"
+                  }
+                },
+                "jest-matcher-utils": {
+                  "version": "20.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "chalk": "1.1.3",
+                    "pretty-format": "20.0.3"
+                  }
+                },
+                "jest-message-util": {
+                  "version": "20.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "chalk": "1.1.3",
+                    "micromatch": "2.3.11",
+                    "slash": "1.0.0"
+                  }
+                },
+                "jest-mock": {
+                  "version": "20.0.3",
+                  "bundled": true
+                },
+                "jest-util": {
+                  "version": "20.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "chalk": "1.1.3",
+                    "graceful-fs": "4.1.11",
+                    "jest-message-util": "20.0.3",
+                    "jest-mock": "20.0.3",
+                    "jest-validate": "20.0.3",
+                    "leven": "2.1.0",
+                    "mkdirp": "0.5.1"
+                  }
+                },
+                "jest-validate": {
+                  "version": "20.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "chalk": "1.1.3",
+                    "jest-matcher-utils": "20.0.3",
+                    "leven": "2.1.0",
+                    "pretty-format": "20.0.3"
+                  }
+                },
+                "jsdom": {
+                  "version": "11.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "abab": "1.0.4",
+                    "acorn": "5.2.1",
+                    "acorn-globals": "4.1.0",
+                    "array-equal": "1.0.0",
+                    "content-type-parser": "1.0.2",
+                    "cssom": "0.3.2",
+                    "cssstyle": "0.2.37",
+                    "domexception": "1.0.0",
+                    "escodegen": "1.9.0",
+                    "html-encoding-sniffer": "1.0.2",
+                    "nwmatcher": "1.4.3",
+                    "parse5": "3.0.3",
+                    "pn": "1.0.0",
+                    "request": "2.83.0",
+                    "request-promise-native": "1.0.5",
+                    "sax": "1.2.4",
+                    "symbol-tree": "3.2.2",
+                    "tough-cookie": "2.3.3",
+                    "webidl-conversions": "4.0.2",
+                    "whatwg-encoding": "1.0.3",
+                    "whatwg-url": "6.3.0",
+                    "xml-name-validator": "2.0.1"
+                  }
+                },
+                "parse5": {
+                  "version": "3.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "@types/node": "8.0.50"
+                  }
+                },
+                "pretty-format": {
+                  "version": "20.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1",
+                    "ansi-styles": "3.2.0"
+                  }
+                },
+                "punycode": {
+                  "version": "2.1.0",
+                  "bundled": true
+                },
+                "tr46": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "punycode": "2.1.0"
+                  }
+                },
+                "whatwg-url": {
+                  "version": "6.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "lodash.sortby": "4.7.0",
+                    "tr46": "1.0.1",
+                    "webidl-conversions": "4.0.2"
+                  }
+                }
+              }
+            },
+            "jest-environment-node": {
+              "version": "21.2.1",
+              "bundled": true,
+              "requires": {
+                "jest-mock": "21.2.0",
+                "jest-util": "21.2.1"
+              }
+            },
+            "jest-fetch-mock": {
+              "version": "1.3.3",
+              "bundled": true,
+              "requires": {
+                "isomorphic-fetch": "2.2.1"
+              }
+            },
+            "jest-get-type": {
+              "version": "21.2.0",
+              "bundled": true
+            },
+            "jest-haste-map": {
+              "version": "21.2.0",
+              "bundled": true,
+              "requires": {
+                "fb-watchman": "2.0.0",
+                "graceful-fs": "4.1.11",
+                "jest-docblock": "21.2.0",
+                "micromatch": "2.3.11",
+                "sane": "2.2.0",
+                "worker-farm": "1.5.1"
+              }
+            },
+            "jest-jasmine2": {
+              "version": "21.2.1",
+              "bundled": true,
+              "requires": {
+                "chalk": "2.3.0",
+                "expect": "21.2.1",
+                "graceful-fs": "4.1.11",
+                "jest-diff": "21.2.1",
+                "jest-matcher-utils": "21.2.1",
+                "jest-message-util": "21.2.1",
+                "jest-snapshot": "21.2.1",
+                "p-cancelable": "0.3.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.0"
+                  }
+                },
+                "chalk": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-styles": "3.2.0",
+                    "escape-string-regexp": "1.0.5",
+                    "supports-color": "4.5.0"
+                  }
+                },
+                "supports-color": {
+                  "version": "4.5.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "2.0.0"
+                  }
+                }
+              }
+            },
+            "jest-matcher-utils": {
+              "version": "21.2.1",
+              "bundled": true,
+              "requires": {
+                "chalk": "2.3.0",
+                "jest-get-type": "21.2.0",
+                "pretty-format": "21.2.1"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.0"
+                  }
+                },
+                "chalk": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-styles": "3.2.0",
+                    "escape-string-regexp": "1.0.5",
+                    "supports-color": "4.5.0"
+                  }
+                },
+                "supports-color": {
+                  "version": "4.5.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "2.0.0"
+                  }
+                }
+              }
+            },
+            "jest-message-util": {
+              "version": "21.2.1",
+              "bundled": true,
+              "requires": {
+                "chalk": "2.3.0",
+                "micromatch": "2.3.11",
+                "slash": "1.0.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.0"
+                  }
+                },
+                "chalk": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-styles": "3.2.0",
+                    "escape-string-regexp": "1.0.5",
+                    "supports-color": "4.5.0"
+                  }
+                },
+                "supports-color": {
+                  "version": "4.5.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "2.0.0"
+                  }
+                }
+              }
+            },
+            "jest-mock": {
+              "version": "21.2.0",
+              "bundled": true
+            },
+            "jest-regex-util": {
+              "version": "21.2.0",
+              "bundled": true
+            },
+            "jest-resolve": {
+              "version": "21.2.0",
+              "bundled": true,
+              "requires": {
+                "browser-resolve": "1.11.2",
+                "chalk": "2.3.0",
+                "is-builtin-module": "1.0.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.0"
+                  }
+                },
+                "chalk": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-styles": "3.2.0",
+                    "escape-string-regexp": "1.0.5",
+                    "supports-color": "4.5.0"
+                  }
+                },
+                "supports-color": {
+                  "version": "4.5.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "2.0.0"
+                  }
+                }
+              }
+            },
+            "jest-resolve-dependencies": {
+              "version": "21.2.0",
+              "bundled": true,
+              "requires": {
+                "jest-regex-util": "21.2.0"
+              }
+            },
+            "jest-runner": {
+              "version": "21.2.1",
+              "bundled": true,
+              "requires": {
+                "jest-config": "21.2.1",
+                "jest-docblock": "21.2.0",
+                "jest-haste-map": "21.2.0",
+                "jest-jasmine2": "21.2.1",
+                "jest-message-util": "21.2.1",
+                "jest-runtime": "21.2.1",
+                "jest-util": "21.2.1",
+                "pify": "3.0.0",
+                "throat": "4.1.0",
+                "worker-farm": "1.5.1"
+              },
+              "dependencies": {
+                "pify": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "jest-runtime": {
+              "version": "21.2.1",
+              "bundled": true,
+              "requires": {
+                "babel-core": "6.26.0",
+                "babel-jest": "21.2.0",
+                "babel-plugin-istanbul": "4.1.5",
+                "chalk": "2.3.0",
+                "convert-source-map": "1.5.0",
+                "graceful-fs": "4.1.11",
+                "jest-config": "21.2.1",
+                "jest-haste-map": "21.2.0",
+                "jest-regex-util": "21.2.0",
+                "jest-resolve": "21.2.0",
+                "jest-util": "21.2.1",
+                "json-stable-stringify": "1.0.1",
+                "micromatch": "2.3.11",
+                "slash": "1.0.0",
+                "strip-bom": "3.0.0",
+                "write-file-atomic": "2.3.0",
+                "yargs": "9.0.1"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.0"
+                  }
+                },
+                "chalk": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-styles": "3.2.0",
+                    "escape-string-regexp": "1.0.5",
+                    "supports-color": "4.5.0"
+                  }
+                },
+                "strip-bom": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "supports-color": {
+                  "version": "4.5.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "2.0.0"
+                  }
+                }
+              }
+            },
+            "jest-snapshot": {
+              "version": "21.2.1",
+              "bundled": true,
+              "requires": {
+                "chalk": "2.3.0",
+                "jest-diff": "21.2.1",
+                "jest-matcher-utils": "21.2.1",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "pretty-format": "21.2.1"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.0"
+                  }
+                },
+                "chalk": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-styles": "3.2.0",
+                    "escape-string-regexp": "1.0.5",
+                    "supports-color": "4.5.0"
+                  }
+                },
+                "supports-color": {
+                  "version": "4.5.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "2.0.0"
+                  }
+                }
+              }
+            },
+            "jest-util": {
+              "version": "21.2.1",
+              "bundled": true,
+              "requires": {
+                "callsites": "2.0.0",
+                "chalk": "2.3.0",
+                "graceful-fs": "4.1.11",
+                "jest-message-util": "21.2.1",
+                "jest-mock": "21.2.0",
+                "jest-validate": "21.2.1",
+                "mkdirp": "0.5.1"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.0"
+                  }
+                },
+                "chalk": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-styles": "3.2.0",
+                    "escape-string-regexp": "1.0.5",
+                    "supports-color": "4.5.0"
+                  }
+                },
+                "supports-color": {
+                  "version": "4.5.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "2.0.0"
+                  }
+                }
+              }
+            },
+            "jest-validate": {
+              "version": "21.2.1",
+              "bundled": true,
+              "requires": {
+                "chalk": "2.3.0",
+                "jest-get-type": "21.2.0",
+                "leven": "2.1.0",
+                "pretty-format": "21.2.1"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.0"
+                  }
+                },
+                "chalk": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-styles": "3.2.0",
+                    "escape-string-regexp": "1.0.5",
+                    "supports-color": "4.5.0"
+                  }
+                },
+                "supports-color": {
+                  "version": "4.5.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "2.0.0"
+                  }
+                }
+              }
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "js-yaml": {
+              "version": "3.10.0",
+              "bundled": true,
+              "requires": {
+                "argparse": "1.0.9",
+                "esprima": "4.0.0"
+              }
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "jsdom": {
+              "version": "9.12.0",
+              "bundled": true,
+              "requires": {
+                "abab": "1.0.4",
+                "acorn": "4.0.13",
+                "acorn-globals": "3.1.0",
+                "array-equal": "1.0.0",
+                "content-type-parser": "1.0.2",
+                "cssom": "0.3.2",
+                "cssstyle": "0.2.37",
+                "escodegen": "1.9.0",
+                "html-encoding-sniffer": "1.0.2",
+                "nwmatcher": "1.4.3",
+                "parse5": "1.5.1",
+                "request": "2.83.0",
+                "sax": "1.2.4",
+                "symbol-tree": "3.2.2",
+                "tough-cookie": "2.3.3",
+                "webidl-conversions": "4.0.2",
+                "whatwg-encoding": "1.0.3",
+                "whatwg-url": "4.8.0",
+                "xml-name-validator": "2.0.1"
+              }
+            },
+            "jsesc": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "json-schema-traverse": {
+              "version": "0.3.1",
+              "bundled": true
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "jsonify": "0.0.0"
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "json5": {
+              "version": "0.5.1",
+              "bundled": true
+            },
+            "jsonify": {
+              "version": "0.0.0",
+              "bundled": true
+            },
+            "jsonpointer": {
+              "version": "4.0.1",
+              "bundled": true
+            },
+            "jsprim": {
+              "version": "1.4.1",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+              }
+            },
+            "jsx-ast-utils": {
+              "version": "1.4.1",
+              "bundled": true
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            },
+            "lazy-cache": {
+              "version": "1.0.4",
+              "bundled": true,
+              "optional": true
+            },
+            "lcid": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "invert-kv": "1.0.0"
+              }
+            },
+            "leven": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "levn": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+              }
+            },
+            "load-json-file": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
+              }
+            },
+            "lodash": {
+              "version": "4.17.4",
+              "bundled": true
+            },
+            "lodash.cond": {
+              "version": "4.5.2",
+              "bundled": true
+            },
+            "lodash.sortby": {
+              "version": "4.7.0",
+              "bundled": true
+            },
+            "longest": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "loose-envify": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "3.0.2"
+              }
+            },
+            "lru-cache": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
+              }
+            },
+            "magic-string": {
+              "version": "0.22.4",
+              "bundled": true,
+              "requires": {
+                "vlq": "0.2.3"
+              }
+            },
+            "makeerror": {
+              "version": "1.0.11",
+              "bundled": true,
+              "requires": {
+                "tmpl": "1.0.4"
+              }
+            },
+            "mem": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "mimic-fn": "1.1.0"
+              }
+            },
+            "merge": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
+              }
+            },
+            "mime-db": {
+              "version": "1.30.0",
+              "bundled": true
+            },
+            "mime-types": {
+              "version": "2.1.17",
+              "bundled": true,
+              "requires": {
+                "mime-db": "1.30.0"
+              }
+            },
+            "mimic-fn": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.8"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "mute-stream": {
+              "version": "0.0.5",
+              "bundled": true
+            },
+            "natural-compare": {
+              "version": "1.4.0",
+              "bundled": true
+            },
+            "node-fetch": {
+              "version": "1.7.3",
+              "bundled": true,
+              "requires": {
+                "encoding": "0.1.12",
+                "is-stream": "1.1.0"
+              }
+            },
+            "node-int64": {
+              "version": "0.4.0",
+              "bundled": true
+            },
+            "node-notifier": {
+              "version": "5.1.2",
+              "bundled": true,
+              "requires": {
+                "growly": "1.3.0",
+                "semver": "5.4.1",
+                "shellwords": "0.1.1",
+                "which": "1.3.0"
+              }
+            },
+            "normalize-package-data": {
+              "version": "2.4.0",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "2.5.0",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.4.1",
+                "validate-npm-package-license": "3.0.1"
+              }
+            },
+            "normalize-path": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "remove-trailing-separator": "1.1.0"
+              }
+            },
+            "npm-run-path": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "path-key": "2.0.1"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "nwmatcher": {
+              "version": "1.4.3",
+              "bundled": true
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "object-keys": {
+              "version": "1.0.11",
+              "bundled": true
+            },
+            "object.assign": {
+              "version": "4.0.4",
+              "bundled": true,
+              "requires": {
+                "define-properties": "1.1.2",
+                "function-bind": "1.1.1",
+                "object-keys": "1.0.11"
+              }
+            },
+            "object.omit": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              }
+            },
+            "onetime": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8",
+                "wordwrap": "0.0.3"
+              }
+            },
+            "optionator": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
+              },
+              "dependencies": {
+                "wordwrap": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "os-locale": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "execa": "0.7.0",
+                "lcid": "1.0.0",
+                "mem": "1.1.0"
+              }
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "p-cancelable": {
+              "version": "0.3.0",
+              "bundled": true
+            },
+            "p-finally": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "p-limit": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "1.1.0"
+              }
+            },
+            "papaparse": {
+              "version": "4.3.6",
+              "bundled": true
+            },
+            "parse-glob": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+              }
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "1.3.1"
+              }
+            },
+            "parse5": {
+              "version": "1.5.1",
+              "bundled": true
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "path-is-inside": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "path-key": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "path-parse": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "path-type": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+              }
+            },
+            "performance-now": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "pinkie": {
+              "version": "2.0.4",
+              "bundled": true
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "pinkie": "2.0.4"
+              }
+            },
+            "pkg-conf": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "2.1.0",
+                "load-json-file": "2.0.0"
+              },
+              "dependencies": {
+                "load-json-file": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "parse-json": "2.2.0",
+                    "pify": "2.3.0",
+                    "strip-bom": "3.0.0"
+                  }
+                },
+                "strip-bom": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "pkg-config": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "debug-log": "1.0.1",
+                "find-root": "1.1.0",
+                "xtend": "4.0.1"
+              }
+            },
+            "pkg-dir": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "1.1.2"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "path-exists": "2.1.0",
+                    "pinkie-promise": "2.0.1"
+                  }
+                },
+                "path-exists": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "pinkie-promise": "2.0.1"
+                  }
+                }
+              }
+            },
+            "pkg-up": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "1.1.2"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "path-exists": "2.1.0",
+                    "pinkie-promise": "2.0.1"
+                  }
+                },
+                "path-exists": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "pinkie-promise": "2.0.1"
+                  }
+                }
+              }
+            },
+            "pluralize": {
+              "version": "1.2.1",
+              "bundled": true
+            },
+            "pn": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "preserve": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "pretty-format": {
+              "version": "21.2.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "3.0.0",
+                "ansi-styles": "3.2.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "ansi-styles": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "color-convert": "1.9.0"
+                  }
+                }
+              }
+            },
+            "private": {
+              "version": "0.1.8",
+              "bundled": true
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "bundled": true
+            },
+            "progress": {
+              "version": "1.1.8",
+              "bundled": true
+            },
+            "prr": {
+              "version": "0.0.0",
+              "bundled": true
+            },
+            "pseudomap": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "bundled": true
+            },
+            "qs": {
+              "version": "6.5.1",
+              "bundled": true
+            },
+            "randomatic": {
+              "version": "1.1.7",
+              "bundled": true,
+              "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+              },
+              "dependencies": {
+                "is-number": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "kind-of": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "read-pkg": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "1.1.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "1.1.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "path-exists": "2.1.0",
+                    "pinkie-promise": "2.0.1"
+                  }
+                },
+                "path-exists": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "pinkie-promise": "2.0.1"
+                  }
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.3",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
+              }
+            },
+            "readline2": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "mute-stream": "0.0.5"
+              }
+            },
+            "rechoir": {
+              "version": "0.6.2",
+              "bundled": true,
+              "requires": {
+                "resolve": "1.1.7"
+              }
+            },
+            "regenerate": {
+              "version": "1.3.3",
+              "bundled": true
+            },
+            "regenerator-runtime": {
+              "version": "0.11.0",
+              "bundled": true
+            },
+            "regenerator-transform": {
+              "version": "0.10.1",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "private": "0.1.8"
+              }
+            },
+            "regex-cache": {
+              "version": "0.4.4",
+              "bundled": true,
+              "requires": {
+                "is-equal-shallow": "0.1.3"
+              }
+            },
+            "regexpu-core": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "regenerate": "1.3.3",
+                "regjsgen": "0.2.0",
+                "regjsparser": "0.1.5"
+              }
+            },
+            "regjsgen": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "regjsparser": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "jsesc": "0.5.0"
+              },
+              "dependencies": {
+                "jsesc": {
+                  "version": "0.5.0",
+                  "bundled": true
+                }
+              }
+            },
+            "remove-trailing-separator": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "repeat-element": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "repeat-string": {
+              "version": "1.6.1",
+              "bundled": true
+            },
+            "repeating": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-finite": "1.0.2"
+              }
+            },
+            "request": {
+              "version": "2.83.0",
+              "bundled": true,
+              "requires": {
+                "aws-sign2": "0.7.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.1",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.17",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.1.0"
+              }
+            },
+            "request-promise-core": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "lodash": "4.17.4"
+              }
+            },
+            "request-promise-native": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "request-promise-core": "1.1.1",
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.3.3"
+              }
+            },
+            "require-directory": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "require-main-filename": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "require-uncached": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "caller-path": "0.1.0",
+                "resolve-from": "1.0.1"
+              }
+            },
+            "resolve": {
+              "version": "1.1.7",
+              "bundled": true
+            },
+            "resolve-from": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "restore-cursor": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "exit-hook": "1.1.1",
+                "onetime": "1.1.0"
+              }
+            },
+            "right-align": {
+              "version": "0.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "align-text": "0.1.4"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "requires": {
+                "glob": "7.1.2"
+              }
+            },
+            "rollup": {
+              "version": "0.47.6",
+              "bundled": true
+            },
+            "rollup-plugin-commonjs": {
+              "version": "8.2.6",
+              "bundled": true,
+              "requires": {
+                "acorn": "5.2.1",
+                "estree-walker": "0.5.0",
+                "magic-string": "0.22.4",
+                "resolve": "1.5.0",
+                "rollup-pluginutils": "2.0.1"
+              },
+              "dependencies": {
+                "acorn": {
+                  "version": "5.2.1",
+                  "bundled": true
+                },
+                "resolve": {
+                  "version": "1.5.0",
+                  "bundled": true,
+                  "requires": {
+                    "path-parse": "1.0.5"
+                  }
+                }
+              }
+            },
+            "rollup-plugin-node-resolve": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "browser-resolve": "1.11.2",
+                "builtin-modules": "1.1.1",
+                "is-module": "1.0.0",
+                "resolve": "1.1.7"
+              }
+            },
+            "rollup-plugin-replace": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "magic-string": "0.22.4",
+                "minimatch": "3.0.4",
+                "rollup-pluginutils": "2.0.1"
+              }
+            },
+            "rollup-plugin-string": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "rollup-pluginutils": "1.5.2"
+              },
+              "dependencies": {
+                "estree-walker": {
+                  "version": "0.2.1",
+                  "bundled": true
+                },
+                "rollup-pluginutils": {
+                  "version": "1.5.2",
+                  "bundled": true,
+                  "requires": {
+                    "estree-walker": "0.2.1",
+                    "minimatch": "3.0.4"
+                  }
+                }
+              }
+            },
+            "rollup-pluginutils": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "estree-walker": "0.3.1",
+                "micromatch": "2.3.11"
+              },
+              "dependencies": {
+                "estree-walker": {
+                  "version": "0.3.1",
+                  "bundled": true
+                }
+              }
+            },
+            "run-async": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "once": "1.4.0"
+              }
+            },
+            "run-parallel": {
+              "version": "1.1.6",
+              "bundled": true
+            },
+            "rx-lite": {
+              "version": "3.1.2",
+              "bundled": true
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true
+            },
+            "sane": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "anymatch": "1.3.2",
+                "exec-sh": "0.2.1",
+                "fb-watchman": "2.0.0",
+                "minimatch": "3.0.4",
+                "minimist": "1.2.0",
+                "walker": "1.0.7",
+                "watch": "0.18.0"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true
+                }
+              }
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true
+            },
+            "semver": {
+              "version": "5.4.1",
+              "bundled": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "shebang-command": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "shebang-regex": "1.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "shelljs": {
+              "version": "0.7.8",
+              "bundled": true,
+              "requires": {
+                "glob": "7.1.2",
+                "interpret": "1.0.4",
+                "rechoir": "0.6.2"
+              }
+            },
+            "shellwords": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "slash": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "slice-ansi": {
+              "version": "0.0.4",
+              "bundled": true
+            },
+            "sntp": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "source-map-support": {
+              "version": "0.4.18",
+              "bundled": true,
+              "requires": {
+                "source-map": "0.5.7"
+              }
+            },
+            "spdx-correct": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "spdx-license-ids": "1.2.2"
+              }
+            },
+            "spdx-expression-parse": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "spdx-license-ids": {
+              "version": "1.2.2",
+              "bundled": true
+            },
+            "sprintf-js": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "sshpk": {
+              "version": "1.13.1",
+              "bundled": true,
+              "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "standard": {
+              "version": "10.0.3",
+              "bundled": true,
+              "requires": {
+                "eslint": "3.19.0",
+                "eslint-config-standard": "10.2.1",
+                "eslint-config-standard-jsx": "4.0.2",
+                "eslint-plugin-import": "2.2.0",
+                "eslint-plugin-node": "4.2.3",
+                "eslint-plugin-promise": "3.5.0",
+                "eslint-plugin-react": "6.10.3",
+                "eslint-plugin-standard": "3.0.1",
+                "standard-engine": "7.0.0"
+              }
+            },
+            "standard-engine": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "deglob": "2.1.0",
+                "get-stdin": "5.0.1",
+                "minimist": "1.2.0",
+                "pkg-conf": "2.0.0"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true
+                }
+              }
+            },
+            "stealthy-require": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "string-length": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "astral-regex": "1.0.0",
+                "strip-ansi": "4.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "strip-ansi": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "3.0.0"
+                  }
+                }
+              }
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "strip-ansi": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "3.0.0"
+                  }
+                }
+              }
+            },
+            "string_decoder": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-utf8": "0.2.1"
+              }
+            },
+            "strip-eof": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "symbol-tree": {
+              "version": "3.2.2",
+              "bundled": true
+            },
+            "table": {
+              "version": "3.8.3",
+              "bundled": true,
+              "requires": {
+                "ajv": "4.11.8",
+                "ajv-keywords": "1.5.1",
+                "chalk": "1.1.3",
+                "lodash": "4.17.4",
+                "slice-ansi": "0.0.4",
+                "string-width": "2.1.1"
+              },
+              "dependencies": {
+                "ajv": {
+                  "version": "4.11.8",
+                  "bundled": true,
+                  "requires": {
+                    "co": "4.6.0",
+                    "json-stable-stringify": "1.0.1"
+                  }
+                }
+              }
+            },
+            "test-exclude": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "arrify": "1.0.1",
+                "micromatch": "2.3.11",
+                "object-assign": "4.1.1",
+                "read-pkg-up": "1.0.1",
+                "require-main-filename": "1.0.1"
+              }
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "throat": {
+              "version": "4.1.0",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
+            },
+            "tmpl": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "to-fast-properties": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "tough-cookie": {
+              "version": "2.3.3",
+              "bundled": true,
+              "requires": {
+                "punycode": "1.4.1"
+              }
+            },
+            "tr46": {
+              "version": "0.0.3",
+              "bundled": true
+            },
+            "trim-right": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "tryit": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "bundled": true,
+              "optional": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "prelude-ls": "1.1.2"
+              }
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "bundled": true
+            },
+            "uglify-js": {
+              "version": "2.8.29",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "source-map": "0.5.7",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+              },
+              "dependencies": {
+                "yargs": {
+                  "version": "3.10.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "camelcase": "1.2.1",
+                    "cliui": "2.1.0",
+                    "decamelize": "1.2.0",
+                    "window-size": "0.1.0"
+                  }
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "uniq": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "user-home": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "os-homedir": "1.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "uuid": {
+              "version": "3.1.0",
+              "bundled": true
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "spdx-correct": "1.0.2",
+                "spdx-expression-parse": "1.0.4"
+              }
+            },
+            "verror": {
+              "version": "1.10.0",
+              "bundled": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+              }
+            },
+            "vlq": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "walker": {
+              "version": "1.0.7",
+              "bundled": true,
+              "requires": {
+                "makeerror": "1.0.11"
+              }
+            },
+            "watch": {
+              "version": "0.18.0",
+              "bundled": true,
+              "requires": {
+                "exec-sh": "0.2.1",
+                "minimist": "1.2.0"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true
+                }
+              }
+            },
+            "webidl-conversions": {
+              "version": "4.0.2",
+              "bundled": true
+            },
+            "whatwg-encoding": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "iconv-lite": "0.4.19"
+              }
+            },
+            "whatwg-fetch": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "whatwg-url": {
+              "version": "4.8.0",
+              "bundled": true,
+              "requires": {
+                "tr46": "0.0.3",
+                "webidl-conversions": "3.0.1"
+              },
+              "dependencies": {
+                "webidl-conversions": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "which": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "isexe": "2.0.0"
+              }
+            },
+            "which-module": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "window-size": {
+              "version": "0.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "bundled": true
+            },
+            "worker-farm": {
+              "version": "1.5.1",
+              "bundled": true,
+              "requires": {
+                "errno": "0.1.4",
+                "xtend": "4.0.1"
+              }
+            },
+            "wrap-ansi": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
+              },
+              "dependencies": {
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
+                }
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "write": {
+              "version": "0.2.1",
+              "bundled": true,
+              "requires": {
+                "mkdirp": "0.5.1"
+              }
+            },
+            "write-file-atomic": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "imurmurhash": "0.1.4",
+                "signal-exit": "3.0.2"
+              }
+            },
+            "xml-name-validator": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "bundled": true
+            },
+            "y18n": {
+              "version": "3.2.1",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "9.0.1",
+              "bundled": true,
+              "requires": {
+                "camelcase": "4.1.0",
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "read-pkg-up": "2.0.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "7.0.0"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                },
+                "cliui": {
+                  "version": "3.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wrap-ansi": "2.1.0"
+                  },
+                  "dependencies": {
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      }
+                    }
+                  }
+                },
+                "load-json-file": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "parse-json": "2.2.0",
+                    "pify": "2.3.0",
+                    "strip-bom": "3.0.0"
+                  }
+                },
+                "path-type": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "pify": "2.3.0"
+                  }
+                },
+                "read-pkg": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "load-json-file": "2.0.0",
+                    "normalize-package-data": "2.4.0",
+                    "path-type": "2.0.0"
+                  }
+                },
+                "read-pkg-up": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "find-up": "2.1.0",
+                    "read-pkg": "2.0.0"
+                  }
+                },
+                "strip-bom": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "yargs-parser": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "camelcase": "4.1.0"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "ansi-escapes": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true
+        },
+        "anymatch": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "micromatch": "2.3.11",
+            "normalize-path": "2.1.1"
+          }
+        },
+        "append-transform": {
+          "version": "0.4.0",
+          "bundled": true,
+          "requires": {
+            "default-require-extensions": "1.0.0"
+          }
+        },
+        "argparse": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "sprintf-js": "1.0.3"
+          }
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "array-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "array-uniq": "1.0.3"
+          }
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "array.prototype.find": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "define-properties": "1.1.2",
+            "es-abstract": "1.9.0"
+          }
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "astral-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babel-core": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.0",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.5.0",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.4",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.4",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
+          }
+        },
+        "babel-helper-call-delegate": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-hoist-variables": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-define-map": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-helper-function-name": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-get-function-arity": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-get-function-arity": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-hoist-variables": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-optimise-call-expression": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helper-regex": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-helper-replace-supers": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-optimise-call-expression": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-helpers": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
+          }
+        },
+        "babel-jest": {
+          "version": "21.2.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-istanbul": "4.1.5",
+            "babel-preset-jest": "21.2.0"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-check-es2015-constants": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-istanbul": {
+          "version": "4.1.5",
+          "bundled": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "istanbul-lib-instrument": "1.9.1",
+            "test-exclude": "4.1.1"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "21.2.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-object-rest-spread": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-arrow-functions": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoped-functions": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-plugin-transform-es2015-classes": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-define-map": "6.26.0",
+            "babel-helper-function-name": "6.24.1",
+            "babel-helper-optimise-call-expression": "6.24.1",
+            "babel-helper-replace-supers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-computed-properties": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-duplicate-keys": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-for-of": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-function-name": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-literals": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-amd": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-strict-mode": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-systemjs": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-hoist-variables": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-umd": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-object-super": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-replace-supers": "6.24.1",
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-call-delegate": "6.24.1",
+            "babel-helper-get-function-arity": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-spread": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-template-literals": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "regexpu-core": "2.0.0"
+          }
+        },
+        "babel-plugin-transform-regenerator": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "regenerator-transform": "0.10.1"
+          }
+        },
+        "babel-plugin-transform-strict-mode": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-preset-es2015": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-check-es2015-constants": "6.22.0",
+            "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+            "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+            "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+            "babel-plugin-transform-es2015-classes": "6.24.1",
+            "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+            "babel-plugin-transform-es2015-destructuring": "6.23.0",
+            "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+            "babel-plugin-transform-es2015-for-of": "6.23.0",
+            "babel-plugin-transform-es2015-function-name": "6.24.1",
+            "babel-plugin-transform-es2015-literals": "6.22.0",
+            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+            "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+            "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+            "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+            "babel-plugin-transform-es2015-object-super": "6.24.1",
+            "babel-plugin-transform-es2015-parameters": "6.24.1",
+            "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+            "babel-plugin-transform-es2015-spread": "6.22.0",
+            "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+            "babel-plugin-transform-es2015-template-literals": "6.22.0",
+            "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+            "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+            "babel-plugin-transform-regenerator": "6.26.0"
+          }
+        },
+        "babel-preset-jest": {
+          "version": "21.2.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-jest-hoist": "21.2.0",
+            "babel-plugin-syntax-object-rest-spread": "6.13.0"
+          }
+        },
+        "babel-register": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-core": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "core-js": "2.5.1",
+            "home-or-tmp": "2.0.0",
+            "lodash": "4.17.4",
+            "mkdirp": "0.5.1",
+            "source-map-support": "0.4.18"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "2.5.1",
+            "regenerator-runtime": "0.11.0"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "boom": {
+          "version": "4.3.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "1.8.5",
+          "bundled": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "browser-resolve": {
+          "version": "1.11.2",
+          "bundled": true,
+          "requires": {
+            "resolve": "1.1.7"
+          }
+        },
+        "bser": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "node-int64": "0.4.0"
+          }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "caller-path": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "callsites": "0.2.0"
+          },
+          "dependencies": {}
+        },
+        "callsites": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "ci-info": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "circular-json": {
+          "version": "0.3.3",
+          "bundled": true
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "restore-cursor": "1.0.1"
+          }
+        },
+        "cli-width": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {}
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "color-convert": {
+          "version": "1.9.0",
+          "bundled": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "concat-stream": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.3",
+            "typedarray": "0.0.6"
+          }
+        },
+        "contains-path": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "content-type-parser": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "convert-source-map": {
+          "version": "1.5.0",
+          "bundled": true
+        },
+        "core-js": {
+          "version": "2.5.1",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "boom": "5.2.0"
+          },
+          "dependencies": {}
+        },
+        "cssom": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "cssstyle": {
+          "version": "0.2.37",
+          "bundled": true,
+          "requires": {
+            "cssom": "0.3.2"
+          }
+        },
+        "d": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "es5-ext": "0.10.35"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "strip-bom": "2.0.0"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "foreach": "2.0.5",
+            "object-keys": "1.0.11"
+          }
+        },
+        "deglob": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "find-root": "1.1.0",
+            "glob": "7.1.2",
+            "ignore": "3.3.7",
+            "pkg-config": "1.1.1",
+            "run-parallel": "1.1.6",
+            "uniq": "1.0.1"
+          }
+        },
+        "del": {
+          "version": "2.2.2",
+          "bundled": true,
+          "requires": {
+            "globby": "5.0.0",
+            "is-path-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.0",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "rimraf": "2.6.2"
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "repeating": "2.0.1"
+          }
+        },
+        "diff": {
+          "version": "3.4.0",
+          "bundled": true
+        },
+        "doctrine": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
+        },
+        "domexception": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "errno": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "prr": "0.0.0"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.9.0",
+          "bundled": true,
+          "requires": {
+            "es-to-primitive": "1.1.1",
+            "function-bind": "1.1.1",
+            "has": "1.0.1",
+            "is-callable": "1.1.3",
+            "is-regex": "1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "is-callable": "1.1.3",
+            "is-date-object": "1.0.1",
+            "is-symbol": "1.0.1"
+          }
+        },
+        "es5-ext": {
+          "version": "0.10.35",
+          "bundled": true,
+          "requires": {
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.1"
+          }
+        },
+        "es6-iterator": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.35",
+            "es6-symbol": "3.1.1"
+          }
+        },
+        "es6-map": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.35",
+            "es6-iterator": "2.0.3",
+            "es6-set": "0.1.5",
+            "es6-symbol": "3.1.1",
+            "event-emitter": "0.3.5"
+          }
+        },
+        "es6-set": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.35",
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.1",
+            "event-emitter": "0.3.5"
+          }
+        },
+        "es6-symbol": {
+          "version": "3.1.1",
+          "bundled": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.35"
+          }
+        },
+        "es6-weak-map": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.35",
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "escodegen": {
+          "version": "1.9.0",
+          "bundled": true,
+          "requires": {
+            "esprima": "3.1.3",
+            "estraverse": "4.2.0",
+            "esutils": "2.0.2",
+            "optionator": "0.8.2",
+            "source-map": "0.5.7"
+          },
+          "dependencies": {}
+        },
+        "escope": {
+          "version": "3.6.0",
+          "bundled": true,
+          "requires": {
+            "es6-map": "0.1.5",
+            "es6-weak-map": "2.0.2",
+            "esrecurse": "4.2.0",
+            "estraverse": "4.2.0"
+          }
+        },
+        "eslint": {
+          "version": "3.19.0",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "chalk": "1.1.3",
+            "concat-stream": "1.6.0",
+            "debug": "2.6.9",
+            "doctrine": "2.0.0",
+            "escope": "3.6.0",
+            "espree": "3.5.1",
+            "esquery": "1.0.0",
+            "estraverse": "4.2.0",
+            "esutils": "2.0.2",
+            "file-entry-cache": "2.0.0",
+            "glob": "7.1.2",
+            "globals": "9.18.0",
+            "ignore": "3.3.7",
+            "imurmurhash": "0.1.4",
+            "inquirer": "0.12.0",
+            "is-my-json-valid": "2.16.1",
+            "is-resolvable": "1.0.0",
+            "js-yaml": "3.10.0",
+            "json-stable-stringify": "1.0.1",
+            "levn": "0.3.0",
+            "lodash": "4.17.4",
+            "mkdirp": "0.5.1",
+            "natural-compare": "1.4.0",
+            "optionator": "0.8.2",
+            "path-is-inside": "1.0.2",
+            "pluralize": "1.2.1",
+            "progress": "1.1.8",
+            "require-uncached": "1.0.3",
+            "shelljs": "0.7.8",
+            "strip-bom": "3.0.0",
+            "strip-json-comments": "2.0.1",
+            "table": "3.8.3",
+            "text-table": "0.2.0",
+            "user-home": "2.0.0"
+          },
+          "dependencies": {}
+        },
+        "eslint-config-standard": {
+          "version": "10.2.1",
+          "bundled": true
+        },
+        "eslint-config-standard-jsx": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "eslint-import-resolver-node": {
+          "version": "0.2.3",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "object-assign": "4.1.1",
+            "resolve": "1.1.7"
+          }
+        },
+        "eslint-module-utils": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "pkg-dir": "1.0.0"
+          }
+        },
+        "eslint-plugin-import": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "1.1.1",
+            "contains-path": "0.1.0",
+            "debug": "2.6.9",
+            "doctrine": "1.5.0",
+            "eslint-import-resolver-node": "0.2.3",
+            "eslint-module-utils": "2.1.1",
+            "has": "1.0.1",
+            "lodash.cond": "4.5.2",
+            "minimatch": "3.0.4",
+            "pkg-up": "1.0.0"
+          },
+          "dependencies": {}
+        },
+        "eslint-plugin-node": {
+          "version": "4.2.3",
+          "bundled": true,
+          "requires": {
+            "ignore": "3.3.7",
+            "minimatch": "3.0.4",
+            "object-assign": "4.1.1",
+            "resolve": "1.1.7",
+            "semver": "5.3.0"
+          },
+          "dependencies": {}
+        },
+        "eslint-plugin-promise": {
+          "version": "3.5.0",
+          "bundled": true
+        },
+        "eslint-plugin-react": {
+          "version": "6.10.3",
+          "bundled": true,
+          "requires": {
+            "array.prototype.find": "2.0.4",
+            "doctrine": "1.5.0",
+            "has": "1.0.1",
+            "jsx-ast-utils": "1.4.1",
+            "object.assign": "4.0.4"
+          },
+          "dependencies": {}
+        },
+        "eslint-plugin-standard": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "espree": {
+          "version": "3.5.1",
+          "bundled": true,
+          "requires": {
+            "acorn": "5.2.1",
+            "acorn-jsx": "3.0.1"
+          },
+          "dependencies": {}
+        },
+        "esprima": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "esquery": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "estraverse": "4.2.0"
+          }
+        },
+        "esrecurse": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "estraverse": "4.2.0",
+            "object-assign": "4.1.1"
+          }
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "estree-walker": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "event-emitter": {
+          "version": "0.3.5",
+          "bundled": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.35"
+          }
+        },
+        "exec-sh": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "merge": "1.2.0"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "exit-hook": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "bundled": true,
+          "requires": {
+            "fill-range": "2.2.3"
+          }
+        },
+        "expect": {
+          "version": "21.2.1",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "jest-diff": "21.2.1",
+            "jest-get-type": "21.2.0",
+            "jest-matcher-utils": "21.2.1",
+            "jest-message-util": "21.2.1",
+            "jest-regex-util": "21.2.0"
+          },
+          "dependencies": {}
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "fb-watchman": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "bser": "2.0.0"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "flat-cache": "1.3.0",
+            "object-assign": "4.1.1"
+          }
+        },
+        "filename-regex": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "fileset": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2",
+            "minimatch": "3.0.4"
+          }
+        },
+        "fill-range": {
+          "version": "2.2.3",
+          "bundled": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.7",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "find-root": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "flat-cache": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "circular-json": "0.3.3",
+            "del": "2.2.2",
+            "graceful-fs": "4.1.11",
+            "write": "0.2.1"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "for-own": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        },
+        "foreach": {
+          "version": "2.0.5",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.3.1",
+          "bundled": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "generate-function": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "generate-object-property": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "is-property": "1.0.2"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "get-stdin": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "glob-parent": "2.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "bundled": true
+        },
+        "globby": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "growly": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "bundled": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.29"
+          },
+          "dependencies": {}
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "5.3.0",
+            "har-schema": "2.0.0"
+          }
+        },
+        "has": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "function-bind": "1.1.1"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "bundled": true,
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.0",
+            "sntp": "2.1.0"
+          }
+        },
+        "hoek": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "home-or-tmp": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.5.0",
+          "bundled": true
+        },
+        "html-encoding-sniffer": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "whatwg-encoding": "1.0.3"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "bundled": true
+        },
+        "ignore": {
+          "version": "3.3.7",
+          "bundled": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "inquirer": {
+          "version": "0.12.0",
+          "bundled": true,
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "ansi-regex": "2.1.1",
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-width": "2.2.0",
+            "figures": "1.7.0",
+            "lodash": "4.17.4",
+            "readline2": "1.0.1",
+            "run-async": "0.1.0",
+            "rx-lite": "3.1.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {}
+        },
+        "interpret": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "intl-messageformat": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "intl-messageformat-parser": "1.4.0"
+          }
+        },
+        "intl-messageformat-parser": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "is-ci": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "ci-info": "1.1.1"
+          }
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-dotfile": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "bundled": true,
+          "requires": {
+            "is-primitive": "2.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "is-module": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-my-json-valid": {
+          "version": "2.16.1",
+          "bundled": true,
+          "requires": {
+            "generate-function": "2.0.0",
+            "generate-object-property": "1.2.0",
+            "jsonpointer": "4.0.1",
+            "xtend": "4.0.1"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-path-cwd": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-path-in-cwd": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-path-inside": "1.0.0"
+          }
+        },
+        "is-path-inside": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "path-is-inside": "1.0.2"
+          }
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-property": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "has": "1.0.1"
+          }
+        },
+        "is-resolvable": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "tryit": "1.0.3"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "istanbul-api": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "async": "2.5.0",
+            "fileset": "2.0.3",
+            "istanbul-lib-coverage": "1.1.1",
+            "istanbul-lib-hook": "1.1.0",
+            "istanbul-lib-instrument": "1.9.1",
+            "istanbul-lib-report": "1.1.2",
+            "istanbul-lib-source-maps": "1.2.2",
+            "istanbul-reports": "1.1.3",
+            "js-yaml": "3.10.0",
+            "mkdirp": "0.5.1",
+            "once": "1.4.0"
+          },
+          "dependencies": {}
+        },
+        "istanbul-lib-coverage": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "istanbul-lib-hook": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "append-transform": "0.4.0"
+          }
+        },
+        "istanbul-lib-instrument": {
+          "version": "1.9.1",
+          "bundled": true,
+          "requires": {
+            "babel-generator": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "istanbul-lib-coverage": "1.1.1",
+            "semver": "5.4.1"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "istanbul-lib-coverage": "1.1.1",
+            "mkdirp": "0.5.1",
+            "path-parse": "1.0.5",
+            "supports-color": "3.2.3"
+          },
+          "dependencies": {}
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "debug": "3.1.0",
+            "istanbul-lib-coverage": "1.1.1",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "source-map": "0.5.7"
+          },
+          "dependencies": {}
+        },
+        "istanbul-reports": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "handlebars": "4.0.11"
+          }
+        },
+        "jest": {
+          "version": "21.2.1",
+          "bundled": true,
+          "requires": {
+            "jest-cli": "21.2.1"
+          },
+          "dependencies": {}
+        },
+        "jest-changed-files": {
+          "version": "21.2.0",
+          "bundled": true,
+          "requires": {
+            "throat": "4.1.0"
+          }
+        },
+        "jest-config": {
+          "version": "21.2.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "glob": "7.1.2",
+            "jest-environment-jsdom": "21.2.1",
+            "jest-environment-node": "21.2.1",
+            "jest-get-type": "21.2.0",
+            "jest-jasmine2": "21.2.1",
+            "jest-regex-util": "21.2.0",
+            "jest-resolve": "21.2.0",
+            "jest-util": "21.2.1",
+            "jest-validate": "21.2.1",
+            "pretty-format": "21.2.1"
+          },
+          "dependencies": {}
+        },
+        "jest-diff": {
+          "version": "21.2.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "diff": "3.4.0",
+            "jest-get-type": "21.2.0",
+            "pretty-format": "21.2.1"
+          },
+          "dependencies": {}
+        },
+        "jest-docblock": {
+          "version": "21.2.0",
+          "bundled": true
+        },
+        "jest-environment-jsdom": {
+          "version": "21.2.1",
+          "bundled": true,
+          "requires": {
+            "jest-mock": "21.2.0",
+            "jest-util": "21.2.1",
+            "jsdom": "9.12.0"
+          }
+        },
+        "jest-environment-jsdom-11.0.0": {
+          "version": "20.0.9",
+          "bundled": true,
+          "requires": {
+            "jest-mock": "20.0.3",
+            "jest-util": "20.0.3",
+            "jsdom": "11.3.0"
+          },
+          "dependencies": {}
+        },
+        "jest-environment-node": {
+          "version": "21.2.1",
+          "bundled": true,
+          "requires": {
+            "jest-mock": "21.2.0",
+            "jest-util": "21.2.1"
+          }
+        },
+        "jest-get-type": {
+          "version": "21.2.0",
+          "bundled": true
+        },
+        "jest-haste-map": {
+          "version": "21.2.0",
+          "bundled": true,
+          "requires": {
+            "fb-watchman": "2.0.0",
+            "graceful-fs": "4.1.11",
+            "jest-docblock": "21.2.0",
+            "micromatch": "2.3.11",
+            "sane": "2.2.0",
+            "worker-farm": "1.5.1"
+          }
+        },
+        "jest-jasmine2": {
+          "version": "21.2.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "expect": "21.2.1",
+            "graceful-fs": "4.1.11",
+            "jest-diff": "21.2.1",
+            "jest-matcher-utils": "21.2.1",
+            "jest-message-util": "21.2.1",
+            "jest-snapshot": "21.2.1",
+            "p-cancelable": "0.3.0"
+          },
+          "dependencies": {}
+        },
+        "jest-matcher-utils": {
+          "version": "21.2.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "jest-get-type": "21.2.0",
+            "pretty-format": "21.2.1"
+          },
+          "dependencies": {}
+        },
+        "jest-message-util": {
+          "version": "21.2.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "micromatch": "2.3.11",
+            "slash": "1.0.0"
+          },
+          "dependencies": {}
+        },
+        "jest-mock": {
+          "version": "21.2.0",
+          "bundled": true
+        },
+        "jest-regex-util": {
+          "version": "21.2.0",
+          "bundled": true
+        },
+        "jest-resolve": {
+          "version": "21.2.0",
+          "bundled": true,
+          "requires": {
+            "browser-resolve": "1.11.2",
+            "chalk": "2.3.0",
+            "is-builtin-module": "1.0.0"
+          },
+          "dependencies": {}
+        },
+        "jest-resolve-dependencies": {
+          "version": "21.2.0",
+          "bundled": true,
+          "requires": {
+            "jest-regex-util": "21.2.0"
+          }
+        },
+        "jest-runner": {
+          "version": "21.2.1",
+          "bundled": true,
+          "requires": {
+            "jest-config": "21.2.1",
+            "jest-docblock": "21.2.0",
+            "jest-haste-map": "21.2.0",
+            "jest-jasmine2": "21.2.1",
+            "jest-message-util": "21.2.1",
+            "jest-runtime": "21.2.1",
+            "jest-util": "21.2.1",
+            "pify": "3.0.0",
+            "throat": "4.1.0",
+            "worker-farm": "1.5.1"
+          },
+          "dependencies": {}
+        },
+        "jest-runtime": {
+          "version": "21.2.1",
+          "bundled": true,
+          "requires": {
+            "babel-core": "6.26.0",
+            "babel-jest": "21.2.0",
+            "babel-plugin-istanbul": "4.1.5",
+            "chalk": "2.3.0",
+            "convert-source-map": "1.5.0",
+            "graceful-fs": "4.1.11",
+            "jest-config": "21.2.1",
+            "jest-haste-map": "21.2.0",
+            "jest-regex-util": "21.2.0",
+            "jest-resolve": "21.2.0",
+            "jest-util": "21.2.1",
+            "json-stable-stringify": "1.0.1",
+            "micromatch": "2.3.11",
+            "slash": "1.0.0",
+            "strip-bom": "3.0.0",
+            "write-file-atomic": "2.3.0",
+            "yargs": "9.0.1"
+          },
+          "dependencies": {}
+        },
+        "jest-snapshot": {
+          "version": "21.2.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "jest-diff": "21.2.1",
+            "jest-matcher-utils": "21.2.1",
+            "mkdirp": "0.5.1",
+            "natural-compare": "1.4.0",
+            "pretty-format": "21.2.1"
+          },
+          "dependencies": {}
+        },
+        "jest-util": {
+          "version": "21.2.1",
+          "bundled": true,
+          "requires": {
+            "callsites": "2.0.0",
+            "chalk": "2.3.0",
+            "graceful-fs": "4.1.11",
+            "jest-message-util": "21.2.1",
+            "jest-mock": "21.2.0",
+            "jest-validate": "21.2.1",
+            "mkdirp": "0.5.1"
+          },
+          "dependencies": {}
+        },
+        "jest-validate": {
+          "version": "21.2.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "jest-get-type": "21.2.0",
+            "leven": "2.1.0",
+            "pretty-format": "21.2.1"
+          },
+          "dependencies": {}
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "bundled": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsdom": {
+          "version": "9.12.0",
+          "bundled": true,
+          "requires": {
+            "abab": "1.0.4",
+            "acorn": "4.0.13",
+            "acorn-globals": "3.1.0",
+            "array-equal": "1.0.0",
+            "content-type-parser": "1.0.2",
+            "cssom": "0.3.2",
+            "cssstyle": "0.2.37",
+            "escodegen": "1.9.0",
+            "html-encoding-sniffer": "1.0.2",
+            "nwmatcher": "1.4.3",
+            "parse5": "1.5.1",
+            "request": "2.83.0",
+            "sax": "1.2.4",
+            "symbol-tree": "3.2.2",
+            "tough-cookie": "2.3.3",
+            "webidl-conversions": "4.0.2",
+            "whatwg-encoding": "1.0.3",
+            "whatwg-url": "4.8.0",
+            "xml-name-validator": "2.0.1"
+          }
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "json5": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "jsonpointer": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "jsx-ast-utils": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "bundled": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
+        "leven": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "bundled": true
+        },
+        "lodash.cond": {
+          "version": "4.5.2",
+          "bundled": true
+        },
+        "lodash.sortby": {
+          "version": "4.7.0",
+          "bundled": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.1",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "magic-string": {
+          "version": "0.22.4",
+          "bundled": true,
+          "requires": {
+            "vlq": "0.2.3"
+          }
+        },
+        "makeerror": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "tmpl": "1.0.4"
+          }
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "1.1.0"
+          }
+        },
+        "merge": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        },
+        "mime-db": {
+          "version": "1.30.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.30.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {}
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "mute-stream": {
+          "version": "0.0.5",
+          "bundled": true
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "node-int64": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "node-notifier": {
+          "version": "5.1.2",
+          "bundled": true,
+          "requires": {
+            "growly": "1.3.0",
+            "semver": "5.4.1",
+            "shellwords": "0.1.1",
+            "which": "1.3.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.4.1",
+            "validate-npm-package-license": "3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "remove-trailing-separator": "1.1.0"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "nwmatcher": {
+          "version": "1.4.3",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "object-keys": {
+          "version": "1.0.11",
+          "bundled": true
+        },
+        "object.assign": {
+          "version": "4.0.4",
+          "bundled": true,
+          "requires": {
+            "define-properties": "1.1.2",
+            "function-bind": "1.1.1",
+            "object-keys": "1.0.11"
+          }
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "for-own": "0.1.5",
+            "is-extendable": "0.1.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.10",
+            "wordwrap": "0.0.3"
+          },
+          "dependencies": {}
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "2.0.6",
+            "levn": "0.3.0",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "1.0.0"
+          },
+          "dependencies": {}
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "p-cancelable": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-limit": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "1.1.0"
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "glob-base": "0.3.0",
+            "is-dotfile": "1.0.3",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "parse5": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
+        "pkg-conf": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "load-json-file": "2.0.0"
+          },
+          "dependencies": {}
+        },
+        "pkg-config": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "debug-log": "1.0.1",
+            "find-root": "1.1.0",
+            "xtend": "4.0.1"
+          }
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "1.1.2"
+          },
+          "dependencies": {}
+        },
+        "pkg-up": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "1.1.2"
+          },
+          "dependencies": {}
+        },
+        "pluralize": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "pn": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "pretty-format": {
+          "version": "21.2.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "3.0.0",
+            "ansi-styles": "3.2.0"
+          },
+          "dependencies": {}
+        },
+        "private": {
+          "version": "0.1.8",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "progress": {
+          "version": "1.1.8",
+          "bundled": true
+        },
+        "prr": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "randomatic": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
+          },
+          "dependencies": {}
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          },
+          "dependencies": {}
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "readline2": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "mute-stream": "0.0.5"
+          }
+        },
+        "rechoir": {
+          "version": "0.6.2",
+          "bundled": true,
+          "requires": {
+            "resolve": "1.1.7"
+          }
+        },
+        "regenerate": {
+          "version": "1.3.3",
+          "bundled": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.0",
+          "bundled": true
+        },
+        "regenerator-transform": {
+          "version": "0.10.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "private": "0.1.8"
+          }
+        },
+        "regex-cache": {
+          "version": "0.4.4",
+          "bundled": true,
+          "requires": {
+            "is-equal-shallow": "0.1.3"
+          }
+        },
+        "regexpu-core": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "regenerate": "1.3.3",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
+          }
+        },
+        "regjsgen": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "regjsparser": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "jsesc": "0.5.0"
+          },
+          "dependencies": {}
+        },
+        "remove-trailing-separator": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.83.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.1",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          },
+          "dependencies": {}
+        },
+        "request-promise-core": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "request-promise-native": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "request-promise-core": "1.1.1",
+            "stealthy-require": "1.1.1",
+            "tough-cookie": "2.3.3"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "require-uncached": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "caller-path": "0.1.0",
+            "resolve-from": "1.0.1"
+          }
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "bundled": true
+        },
+        "resolve-from": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
+          }
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "rollup": {
+          "version": "0.47.6",
+          "bundled": true
+        },
+        "rollup-plugin-commonjs": {
+          "version": "8.2.6",
+          "bundled": true,
+          "requires": {
+            "acorn": "5.2.1",
+            "estree-walker": "0.5.0",
+            "magic-string": "0.22.4",
+            "resolve": "1.5.0",
+            "rollup-pluginutils": "2.0.1"
+          },
+          "dependencies": {}
+        },
+        "rollup-plugin-node-resolve": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "browser-resolve": "1.11.2",
+            "builtin-modules": "1.1.1",
+            "is-module": "1.0.0",
+            "resolve": "1.1.7"
+          }
+        },
+        "rollup-plugin-replace": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "magic-string": "0.22.4",
+            "minimatch": "3.0.4",
+            "rollup-pluginutils": "2.0.1"
+          }
+        },
+        "rollup-plugin-string": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "rollup-pluginutils": "1.5.2"
+          },
+          "dependencies": {}
+        },
+        "rollup-pluginutils": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "estree-walker": "0.3.1",
+            "micromatch": "2.3.11"
+          },
+          "dependencies": {}
+        },
+        "run-async": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0"
+          }
+        },
+        "run-parallel": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "rx-lite": {
+          "version": "3.1.2",
+          "bundled": true
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "sane": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "anymatch": "1.3.2",
+            "exec-sh": "0.2.1",
+            "fb-watchman": "2.0.0",
+            "minimatch": "3.0.4",
+            "minimist": "1.2.0",
+            "walker": "1.0.7",
+            "watch": "0.18.0"
+          }
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.4.1",
+          "bundled": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "shelljs": {
+          "version": "0.7.8",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2",
+            "interpret": "1.0.4",
+            "rechoir": "0.6.2"
+          }
+        },
+        "shellwords": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "slice-ansi": {
+          "version": "0.0.4",
+          "bundled": true
+        },
+        "sntp": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true
+        },
+        "source-map-support": {
+          "version": "0.4.18",
+          "bundled": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "spdx-license-ids": "1.2.2"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "spdx-license-ids": {
+          "version": "1.2.2",
+          "bundled": true
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "sshpk": {
+          "version": "1.13.1",
+          "bundled": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "standard": {
+          "version": "10.0.3",
+          "bundled": true,
+          "requires": {
+            "eslint": "3.19.0",
+            "eslint-config-standard": "10.2.1",
+            "eslint-config-standard-jsx": "4.0.2",
+            "eslint-plugin-import": "2.2.0",
+            "eslint-plugin-node": "4.2.3",
+            "eslint-plugin-promise": "3.5.0",
+            "eslint-plugin-react": "6.10.3",
+            "eslint-plugin-standard": "3.0.1",
+            "standard-engine": "7.0.0"
+          }
+        },
+        "standard-engine": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "deglob": "2.1.0",
+            "get-stdin": "5.0.1",
+            "minimist": "1.2.0",
+            "pkg-conf": "2.0.0"
+          }
+        },
+        "stealthy-require": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "string-length": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "astral-regex": "1.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {}
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {}
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "symbol-tree": {
+          "version": "3.2.2",
+          "bundled": true
+        },
+        "table": {
+          "version": "3.8.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "ajv-keywords": "1.5.1",
+            "chalk": "1.1.3",
+            "lodash": "4.17.4",
+            "slice-ansi": "0.0.4",
+            "string-width": "2.1.1"
+          },
+          "dependencies": {}
+        },
+        "test-exclude": {
+          "version": "4.1.1",
+          "bundled": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "micromatch": "2.3.11",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "throat": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "tmpl": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "tough-cookie": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "bundled": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "tryit": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "1.1.2"
+          }
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {}
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "uniq": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
+          }
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "1.3.0"
+          }
+        },
+        "vlq": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "walker": {
+          "version": "1.0.7",
+          "bundled": true,
+          "requires": {
+            "makeerror": "1.0.11"
+          }
+        },
+        "watch": {
+          "version": "0.18.0",
+          "bundled": true,
+          "requires": {
+            "exec-sh": "0.2.1",
+            "minimist": "1.2.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "whatwg-encoding": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "0.4.19"
+          }
+        },
+        "whatwg-url": {
+          "version": "4.8.0",
+          "bundled": true,
+          "requires": {
+            "tr46": "0.0.3",
+            "webidl-conversions": "3.0.1"
+          },
+          "dependencies": {}
+        },
+        "which": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true
+        },
+        "worker-farm": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "errno": "0.1.4",
+            "xtend": "4.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          },
+          "dependencies": {}
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "0.5.1"
+          }
+        },
+        "write-file-atomic": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "xml-name-validator": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "xmldom": {
+          "version": "0.1.27",
+          "bundled": true
+        },
+        "xmltojson": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "yargs": {
+          "version": "9.0.1",
+          "bundled": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
+          },
+          "dependencies": {}
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          },
+          "dependencies": {}
+        }
+      }
     },
     "alpheios-morph-client": {
       "version": "git://github.com/alpheios-project/morph-client.git#8ffb5dfd7b7c4cb0d8fa3584c870b9d2ef1cd178",
@@ -101,8 +12198,13 @@
     "alpheios-tufts-adapter": {
       "version": "git://github.com/alpheios-project/tufts-adapter.git#0a55da62f41e9e0aae9452f5f6794069ee11a844",
       "requires": {
-        "alpheios-data-models": "git://github.com/alpheios-project/data-models.git#8a9ee931ac931c7f13e243ee8898dadb4e9b856a",
+        "alpheios-data-models": "git://github.com/alpheios-project/data-models.git#bc0bf2fafdb5004ff957b3905196340888298493",
         "alpheios-morph-client": "git://github.com/alpheios-project/morph-client.git#8ffb5dfd7b7c4cb0d8fa3584c870b9d2ef1cd178"
+      },
+      "dependencies": {
+        "alpheios-data-models": {
+          "version": "git://github.com/alpheios-project/data-models.git#bc0bf2fafdb5004ff957b3905196340888298493"
+        }
       }
     },
     "amdefine": {

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "alpheios-inflection-tables",
   "version": "0.1.0",
   "description": "Inflection library for an Alpheios project",
-  "main": "dist/inflection-tables.js",
+  "main": "dist/inflection-tables.standalone.js",
+  "moduleExternal": "dist/inflection-tables.module-external.js",
   "directories": {
     "doc": "doc"
   },
   "scripts": {
     "test": "standard --fix && jest --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
-    "build": "standard --fix && node ./support/rollup/build.js",
+    "build": "standard --fix && node ./build/rollup/build.js",
     "convert": "node ./tools/inflections-xml2csv/converter.js"
   },
   "repository": {

--- a/presenter/lib/view.js
+++ b/presenter/lib/view.js
@@ -1567,7 +1567,7 @@ class View {
      * Converts a WordData, returned from inflection tables library, into an HTML representation of an inflection table
      * and inserts that HTML into a `container` HTML element. `messages` provides a translation for view's texts.
      * @param {HTMLElement} container - An HTML element where this view will be inserted.
-     * @param {WordData} wordData - A result set from inflection tables library.
+     * @param {LexicalData} wordData - A result set from inflection tables library.
      * @param {MessageBundle} messages - A message bundle with message translations.
      */
   render (container, wordData, messages) {

--- a/tests/controller.js
+++ b/tests/controller.js
@@ -21,7 +21,7 @@ exports.LanguageDataset = Lib.LanguageDataset
 exports.LanguageData = Lib.LanguageData
 exports.MatchData = Lib.MatchData
 exports.Footnote = Lib.Footnote
-exports.ResultSet = Lib.WordData
+exports.ResultSet = Lib.LexicalData
 
 // L10n
 exports.LatinLanguageModel = Models.LatinLanguageModel


### PR DESCRIPTION
Introduced two types of build: standalone (all dependencies included) and module-external (dependencies are external and need to be provided by the host package). Added a DefinitionSet object. Added support to pull short and full definitions in web extension